### PR TITLE
Add operational AI systems roadmap

### DIFF
--- a/docs/roadmaps/operational-ai-systems-roadmap.md
+++ b/docs/roadmaps/operational-ai-systems-roadmap.md
@@ -1,0 +1,637 @@
+# Operational AI Systems Roadmap
+
+## Purpose
+
+This roadmap defines a directional build plan for operational AI systems that support spectrum studies, spectrum coordination, and spectrum policy workflows.
+
+The systems described here range from narrow artifact-transformation engines to an ecosystem-scale intelligence layer. The roadmap is intended to guide architectural decisions, repo creation, and sequencing across the Spectrum Systems ecosystem.
+
+This document is strategic guidance only. It does not create binding requirements unless a future standard, contract, or repository specification explicitly adopts part of it.
+
+---
+
+## Design Principle
+
+The core shift this roadmap describes is from isolated AI tools to governed operational systems.
+
+In isolated tool use, AI generates text that is consumed by a person and then discarded or stored informally. No structured artifact is produced. No pipeline is defined. No provenance is recorded. Institutional knowledge is lost.
+
+Governed operational systems work differently:
+
+- Documents, models, comments, and transcripts become structured artifacts with defined schemas
+- Artifacts move through deterministic, auditable pipelines rather than ad hoc prompts
+- Systems are modular and can be composed across repositories
+- Outputs are reusable inputs to downstream systems
+- Institutional knowledge accumulates in a persistent, queryable form rather than being scattered across email threads and slide decks
+
+This shift requires defining artifact contracts before building automation, and treating every system output as a potential input to another system.
+
+---
+
+## System Layers
+
+The roadmap organizes systems into three layers based on scope and complexity.
+
+**Layer 1 — Operational Engines**
+Narrow systems that transform specific input artifacts into structured outputs. Each engine addresses one well-defined artifact type or workflow step.
+
+**Layer 2 — Study-Scale Intelligence Systems**
+Systems that combine outputs from multiple operational engines to support the full lifecycle of a spectrum study. These systems operate at the scale of a study program, not a single artifact.
+
+**Layer 3 — Ecosystem-Scale Intelligence Layer**
+A single apex system, the Spectrum Intelligence Map, that integrates engineering, regulatory, and operational information across the entire spectrum ecosystem into a unified reasoning surface.
+
+---
+
+# Layer 1 — Operational Engines
+
+Operational engines are narrow systems that transform specific artifacts into structured outputs. Each engine is designed to be independently deployable, testable, and composable with other engines.
+
+---
+
+## Band Study – Study Plan Generator
+
+### Purpose
+
+Generates structured study plans for a new spectrum band. Given a set of band inputs, the engine produces a defined artifact that organizes the study before modeling or coordination work begins.
+
+### Typical Inputs
+
+- Band identifier and frequency range
+- Statutory or regulatory requirements for the band
+- Known incumbent systems and protection criteria
+- Prior study patterns or templates from related bands
+- Initial scoping decisions from program leadership
+
+### Typical Outputs
+
+- Structured Band Study Plan artifact
+- Study objectives with success criteria
+- List of required modeling tasks and dependencies
+- Analysis milestones and expected deliverables
+- Proposed working group structure
+
+### Why It Matters
+
+Band studies frequently begin without a structured plan, causing scope drift, duplicated analysis, and late-stage gaps. A structured study plan artifact allows the program to validate scope early, assign tasks explicitly, and track progress against a defined baseline.
+
+### Likely Repo / Ecosystem Placement
+
+`band-study-plan-engine` or equivalent operational engine repo. Outputs align with the study plan artifact schema defined in `spectrum-systems`.
+
+---
+
+## Agency Question Radar
+
+### Purpose
+
+Extracts, clusters, and tracks recurring agency questions and concerns from meeting transcripts, comment matrices, and review cycles. Surfaces patterns that are otherwise invisible across a long study program.
+
+### Typical Inputs
+
+- Meeting transcripts
+- Comment matrices from working papers
+- Review cycle records
+- Prior question logs from related studies
+
+### Typical Outputs
+
+- Clustered question register with frequency and agency attribution
+- Trending concern report per review cycle
+- Unresolved question tracker
+- Input seed for the Working Paper Stress Test
+
+### Why It Matters
+
+Agencies repeat concerns across review cycles when those concerns are not resolved or tracked. The Agency Question Radar converts an informal pattern into a structured, auditable record that can be used to improve working paper quality before submission.
+
+### Likely Repo / Ecosystem Placement
+
+`agency-question-radar` engine repo. Outputs feed the Comment Resolution Engine and Working Paper Stress Test.
+
+---
+
+## Interference Analysis Assistant
+
+### Purpose
+
+Converts modeling outputs — MATLAB results, propagation summaries, simulation outputs — into structured engineering summaries and policy-ready language. Bridges the gap between technical analysis and regulatory documentation.
+
+### Typical Inputs
+
+- MATLAB or propagation tool outputs
+- Simulation summary files
+- Scenario definitions and protection criteria
+- Prior interference analysis reports from related bands
+
+### Typical Outputs
+
+- Structured interference analysis summary
+- Policy-ready narrative with technical backing
+- Structured table of scenario results with metadata
+- Identified gaps requiring additional modeling
+
+### Why It Matters
+
+Engineering outputs frequently require significant manual effort to convert into working paper language. This engine standardizes that conversion and produces structured artifacts that downstream systems can reason about.
+
+### Likely Repo / Ecosystem Placement
+
+`interference-analysis-assistant` engine repo. Outputs feed the Working Paper Stress Test and the Spectrum Study Operating System.
+
+---
+
+## Comment Resolution Engine
+
+### Purpose
+
+Ingests comment matrices and working paper revisions to support adjudication, response drafting, duplicate detection, and resolution tracking across review cycles.
+
+### Typical Inputs
+
+- Comment matrices in structured or semi-structured form
+- Draft working paper revisions
+- Prior resolution records from earlier review cycles
+- Canonical position statements from participating agencies
+
+### Typical Outputs
+
+- Deduplicated comment register
+- Draft response language organized by comment cluster
+- Resolution status tracker
+- Unresolved comment report for next cycle
+
+### Why It Matters
+
+Comment resolution is one of the most labor-intensive tasks in a spectrum study. Duplicate comments, inconsistent response language, and lost resolution history are recurring problems. This engine structures the process and produces a persistent record.
+
+### Likely Repo / Ecosystem Placement
+
+`comment-resolution-engine` repo. Outputs feed the Institutional Memory Engine and the Spectrum Study Operating System.
+
+---
+
+## Meeting Intelligence System
+
+### Purpose
+
+Converts meeting transcripts into structured artifacts including meeting minutes, decision logs, action registers, and agenda seeds for follow-on meetings.
+
+### Typical Inputs
+
+- Raw or lightly edited meeting transcripts
+- Prior meeting minutes and action registers
+- Standing agenda templates
+
+### Typical Outputs
+
+- Structured meeting minutes
+- Decision log entries
+- Action register with owner and due date fields
+- Agenda seed for next meeting based on open actions
+
+### Why It Matters
+
+Meeting outputs are currently produced manually from notes and transcripts, a slow and error-prone process. Structured artifacts produced by this engine can feed the Knowledge Capture Engine and the Agency Question Radar.
+
+### Likely Repo / Ecosystem Placement
+
+`meeting-intelligence-engine` repo. Outputs feed the Knowledge Capture Engine, Agency Question Radar, and Spectrum Study Operating System.
+
+---
+
+## Working Paper Stress Test
+
+### Purpose
+
+Analyzes a working paper draft and predicts weaknesses, missing evidence, and likely reviewer objections before formal review. Designed to reduce late-stage surprises in the review cycle.
+
+### Typical Inputs
+
+- Working paper draft
+- Comment history from prior review cycles
+- Agency question register from the Agency Question Radar
+- Prior interference analysis summaries
+
+### Typical Outputs
+
+- Weakness report organized by section
+- List of predicted reviewer objections with evidence basis
+- Missing evidence checklist
+- Priority revision recommendations
+
+### Why It Matters
+
+Working papers are often reviewed by agencies before internal stress testing has been completed. This engine formalizes the stress testing process and produces a documented record of pre-review analysis.
+
+### Likely Repo / Ecosystem Placement
+
+`working-paper-stress-test` engine repo. Depends on outputs from the Agency Question Radar and Interference Analysis Assistant.
+
+---
+
+## Allocation Intelligence Engine
+
+### Purpose
+
+Analyzes allocation tables, service definitions, and regulatory footnotes to detect conflicts and evaluate candidate allocation changes against existing rules and precedent.
+
+### Typical Inputs
+
+- Allocation table excerpts
+- Service definition documents
+- Regulatory footnotes and associated notes
+- Candidate allocation change proposals
+
+### Typical Outputs
+
+- Conflict detection report
+- Precedent summary for candidate changes
+- Structured allocation analysis artifact
+- Regulatory risk assessment
+
+### Why It Matters
+
+Allocation decisions interact with a large number of existing rules, footnotes, and service definitions. Manual review of these interactions is time-consuming and prone to gaps. This engine structures the analysis.
+
+### Likely Repo / Ecosystem Placement
+
+`allocation-intelligence-engine` repo. Outputs feed the Regulatory Impact Simulator and the Spectrum Intelligence Map.
+
+---
+
+## Spectrum Study Program Advisor
+
+### Purpose
+
+Monitors study progress, open risks, artifact maturity, and coordination gaps to help leadership manage the study program. Acts as a program-level status aggregator and risk surface.
+
+### Typical Inputs
+
+- Study plan artifact from the Band Study Plan Generator
+- Open action registers
+- Artifact status records from the Spectrum Study Operating System
+- Risk logs
+
+### Typical Outputs
+
+- Program status report
+- Risk heat map
+- Sequencing recommendations
+- Escalation candidates for leadership review
+
+### Why It Matters
+
+Study programs accumulate complexity over time. Without a structured monitoring system, program-level risks are identified late. This engine produces a structured view of program health that supports leadership decision-making.
+
+### Likely Repo / Ecosystem Placement
+
+`spectrum-program-advisor` repo. This is a dedicated intelligence layer for program management, separate from the operational engines.
+
+---
+
+## Knowledge Capture Engine
+
+### Purpose
+
+Captures decisions, assumptions, rationale, and supporting evidence from meetings and study artifacts to build institutional memory that persists across personnel and study cycles.
+
+### Typical Inputs
+
+- Decision log entries from the Meeting Intelligence System
+- Structured artifact outputs from other operational engines
+- Annotated working paper revisions
+- Explicit assumption records
+
+### Typical Outputs
+
+- Decision records with rationale and evidence links
+- Assumption register with validation status
+- Institutional memory entries conforming to the provenance standard
+- Query-ready knowledge base entries
+
+### Why It Matters
+
+Institutional knowledge in spectrum studies is routinely lost when personnel change or when studies conclude. This engine converts informal outputs into structured, persistent records that can inform future studies.
+
+### Likely Repo / Ecosystem Placement
+
+`knowledge-capture-engine` repo. Outputs feed the Institutional Memory Engine.
+
+---
+
+# Layer 2 — Study-Scale Intelligence Systems
+
+These systems combine outputs from multiple operational engines to support the full lifecycle of a spectrum study. They operate at the scale of a study program rather than a single artifact or workflow step.
+
+---
+
+## Spectrum Study Operating System
+
+### Purpose
+
+Links assumptions, modeling outputs, working papers, comments, and decisions into a governed study lifecycle. Provides a structured backbone for a complete spectrum study.
+
+### Typical Inputs
+
+- Artifacts produced by all Layer 1 operational engines
+- Study plan from the Band Study Plan Generator
+- Governance standards from `spectrum-systems`
+
+### Typical Outputs
+
+- Governed study artifact graph with dependency tracking
+- Study lifecycle status record
+- Artifact maturity assessments
+- Compliance reports against governance standards
+
+### Why It Matters
+
+A spectrum study produces dozens of interconnected artifacts over months or years. Without a governing system, dependencies are informal, versions drift, and audit trails are incomplete. The Spectrum Study Operating System provides the connective tissue.
+
+### Likely Repo / Ecosystem Placement
+
+`spectrum-study-operating-system` repo or equivalent. Depends on artifact contracts from all Layer 1 engines. This is a high-dependency system and should be built after the engines it integrates are stable.
+
+---
+
+## Institutional Memory Engine
+
+### Purpose
+
+Stores persistent records of decisions, rationale, evidence, and modeling assumptions so that institutional reasoning is preserved and queryable across studies and personnel.
+
+### Typical Inputs
+
+- Knowledge Capture Engine outputs
+- Decision logs from the Meeting Intelligence System
+- Structured artifacts from all study phases
+- Provenance records conforming to the provenance standard
+
+### Typical Outputs
+
+- Persistent decision and assumption database
+- Queryable knowledge base for future studies
+- Provenance-linked artifact store
+- Cross-study pattern reports
+
+### Why It Matters
+
+Most institutional knowledge in spectrum studies exists only in informal documents, email threads, or individual memory. This engine provides a structured alternative that accumulates value over time.
+
+### Likely Repo / Ecosystem Placement
+
+`institutional-memory-engine` repo. This system underlies the Review Prediction Engine and feeds the Spectrum Intelligence Map.
+
+---
+
+## Regulatory Impact Simulator
+
+### Purpose
+
+Evaluates the technical and policy impact of proposed regulatory or allocation changes before adoption. Supports pre-decisional analysis by simulating change effects against existing rules and systems.
+
+### Typical Inputs
+
+- Candidate regulatory or allocation change proposals
+- Allocation Intelligence Engine outputs
+- Existing allocation tables and footnote records
+- Engineering analysis artifacts
+
+### Typical Outputs
+
+- Impact assessment report
+- Conflict analysis across affected services
+- Structured scenario comparison
+- Regulatory risk summary
+
+### Why It Matters
+
+Regulatory changes have cascading effects that are difficult to trace manually. This simulator provides a structured analysis capability before changes are adopted, reducing unintended consequences.
+
+### Likely Repo / Ecosystem Placement
+
+`regulatory-impact-simulator` repo. Depends on the Allocation Intelligence Engine and Institutional Memory Engine.
+
+---
+
+## Review Prediction Engine
+
+### Purpose
+
+Predicts likely reviewer objections and agency concerns when given a working paper or policy proposal. Uses historical comment and review data to anticipate response patterns.
+
+### Typical Inputs
+
+- Working paper or policy proposal draft
+- Institutional Memory Engine outputs
+- Agency Question Radar outputs
+- Historical comment and resolution records
+
+### Typical Outputs
+
+- Predicted objection list with historical precedent
+- Agency-specific concern predictions
+- Evidence gap report
+- Pre-review revision recommendations
+
+### Why It Matters
+
+Reviewers often raise concerns that could have been addressed before formal review. This engine systematizes pre-review intelligence and produces actionable recommendations.
+
+### Likely Repo / Ecosystem Placement
+
+`review-prediction-engine` repo. Depends on the Institutional Memory Engine and Agency Question Radar.
+
+---
+
+## Spectrum Study Autopilot
+
+### Purpose
+
+Monitors study progress and recommends next actions, sequencing changes, and risk mitigations. Acts as an intelligent study management assistant for program leadership.
+
+### Typical Inputs
+
+- Spectrum Study Operating System status feeds
+- Spectrum Study Program Advisor outputs
+- Open action registers
+- Artifact dependency graph
+
+### Typical Outputs
+
+- Recommended next action sequence
+- Sequencing conflict alerts
+- Risk mitigation recommendations
+- Escalation candidates
+
+### Why It Matters
+
+Study programs involve many parallel workstreams with complex dependencies. This system surfaces sequencing problems and recommends corrective actions before they become blocking issues.
+
+### Likely Repo / Ecosystem Placement
+
+`spectrum-study-autopilot` repo. Depends on the Spectrum Study Operating System and Spectrum Study Program Advisor.
+
+---
+
+# Layer 3 — Ecosystem-Scale Intelligence Layer
+
+## Spectrum Intelligence Map
+
+The Spectrum Intelligence Map is the apex system of this roadmap. It represents a long-term, high-dependency capability that integrates engineering, regulatory, and operational information into a single reasoning surface for the spectrum ecosystem.
+
+### Concept
+
+The Spectrum Intelligence Map integrates information from all lower-layer systems into a unified, queryable intelligence layer that spans spectrum use, interference relationships, allocation rules, modeling outputs, and policy constraints.
+
+It is not a dashboard or a report generator. It is a structured reasoning surface — an interconnected representation of the spectrum ecosystem that supports simulation, conflict detection, and policy analysis at ecosystem scale.
+
+The map is designed to answer questions that no single operational engine can answer, such as: What would be the downstream effects of modifying this footnote? Which existing systems conflict with this candidate allocation? What decisions led to this protection standard?
+
+### Core Layers
+
+**Allocation / Regulatory Terrain**
+The structured representation of the frequency table, service definitions, footnotes, and associated regulatory history. The foundational layer of the map.
+
+**Real-World System Layer**
+Records of deployed and planned systems operating in each band, including system parameters, protection criteria, and operational constraints. Populated from engineering analysis artifacts and study records.
+
+**Physics / Propagation Layer**
+Structured representations of propagation modeling results, interference scenarios, and link budget analyses. Populated from the Interference Analysis Assistant and related modeling tools.
+
+**Policy / Constraint Layer**
+Structured records of regulatory constraints, international obligations, statutory requirements, and agency positions that constrain the solution space for any allocation or study decision.
+
+**Decision / Scenario Layer**
+A structured log of past decisions, scenario analyses, and their rationale. Populated primarily by the Institutional Memory Engine. Allows the map to reason about how current conditions were produced and what alternatives were considered.
+
+### Why It Changes the Ecosystem
+
+A functioning Spectrum Intelligence Map would allow engineers and policymakers to:
+
+- Simulate proposed regulatory or allocation changes and observe predicted downstream effects
+- Visualize interference relationships across bands and services
+- Trace the lineage of allocation decisions to their technical and policy basis
+- Identify conflicts between existing rules before they become study problems
+- Query institutional memory at ecosystem scale rather than study scale
+
+This changes the mode of spectrum analysis from reactive — responding to problems as they arise — to anticipatory, where problems can be identified and analyzed before they become blocking issues.
+
+### Dependencies on Lower-Level Systems
+
+The Spectrum Intelligence Map cannot be built without stable, structured outputs from the Layer 1 and Layer 2 systems. Specifically, it depends on:
+
+- Allocation Intelligence Engine outputs to populate the Allocation / Regulatory Terrain layer
+- Interference Analysis Assistant outputs to populate the Physics / Propagation layer
+- Institutional Memory Engine outputs to populate the Decision / Scenario layer
+- Regulatory Impact Simulator outputs to support simulation capabilities
+- Spectrum Study Operating System outputs to maintain currency across active studies
+
+Attempting to build this system before the lower-layer engines are producing stable, structured artifacts would result in an intelligence layer with insufficient data to reason about.
+
+### Long-Term Strategic Value
+
+The Spectrum Intelligence Map could become the central intelligence layer for spectrum studies and spectrum policy planning across the ecosystem. It provides the capability to reason about spectrum as a system rather than as a set of isolated studies.
+
+Over time, as institutional memory accumulates and the artifact graph grows, this system increases in value. Early studies contribute to the map; later studies benefit from it. The system compounds institutional knowledge rather than allowing it to decay.
+
+---
+
+# Dependency Ladder
+
+The following build order reflects likely dependencies and operational value. Systems earlier in the sequence produce artifacts consumed by systems later in the sequence.
+
+1. Band Study – Study Plan Generator
+2. Meeting Intelligence System
+3. Agency Question Radar
+4. Comment Resolution Engine
+5. Working Paper Stress Test
+6. Interference Analysis Assistant
+7. Allocation Intelligence Engine
+8. Knowledge Capture Engine
+9. Spectrum Study Program Advisor
+10. Institutional Memory Engine
+11. Review Prediction Engine
+12. Regulatory Impact Simulator
+13. Spectrum Study Autopilot
+14. Spectrum Study Operating System
+15. Spectrum Intelligence Map
+
+Systems 1–8 are operational engines that can be built and deployed independently. Systems 9–14 require stable outputs from earlier systems. System 15 requires the full ecosystem of lower-layer outputs to function as designed.
+
+---
+
+# Architectural Implications for the Czar Repo Org
+
+This roadmap aligns with the following ecosystem architecture:
+
+**`system-factory`**
+Generates new repositories for each operational engine or study-scale system. New repos should be created from `system-factory` and should declare their artifact contracts at creation time.
+
+**`spectrum-systems`**
+Defines governance standards, artifact schemas, provenance requirements, and architectural standards that all operational engines must conform to. This repo is the authoritative source for artifact contracts and governance rules.
+
+**Operational engine repos**
+Implement artifact transformations as defined in their engine specifications. Each engine exposes an explicit artifact contract defining its inputs, outputs, and schema versions. Engines should not embed governance logic; they should conform to standards defined in `spectrum-systems`.
+
+**`spectrum-pipeline-engine`**
+Orchestrates workflows across multiple operational engines. Responsible for sequencing, artifact routing, and pipeline-level auditability. Does not implement engine logic directly.
+
+**`spectrum-program-advisor`**
+Provides program management intelligence by consuming outputs from operational engines and study-scale systems. This is a consumer of the ecosystem, not a producer of governance standards.
+
+Future repositories should align with this roadmap and expose explicit artifact contracts. Repos that produce artifacts without defining their output schema create integration debt that compounds as the ecosystem grows.
+
+---
+
+# Implementation Guidance
+
+**Begin with artifact-rich workflows.**
+Start with workflows that already produce semi-structured artifacts — comment matrices, meeting transcripts, working paper drafts — before attempting to automate workflows that depend entirely on informal inputs.
+
+**Prefer structured outputs over narrative text.**
+Every system should produce structured outputs that downstream systems can consume without re-parsing. Narrative text is appropriate for human-facing reports; structured data is required for machine-to-machine artifact flows.
+
+**Define contracts before automation.**
+Each engine should have a defined input contract and output contract before implementation begins. Contracts should be versioned and stored in `spectrum-systems`. Automation built without contracts cannot be composed.
+
+**Require validation and auditability.**
+Every engine should produce a structured provenance record with each output artifact. Outputs that cannot be traced to their inputs are not suitable for use in policy-relevant workflows.
+
+**Design engines to compose together.**
+Outputs of one engine should be usable as inputs to another without manual transformation. This requires consistent schema definitions and version discipline across the ecosystem.
+
+**Treat artifacts as institutional memory inputs.**
+Every structured artifact produced by an operational engine is a candidate input to the Institutional Memory Engine. Design artifact schemas with this in mind from the start.
+
+---
+
+# Candidate Near-Term Priorities
+
+The following systems are recommended as near-term priorities based on their operational value and the availability of existing artifacts to work with:
+
+- **Band Study – Study Plan Generator** — Operates on band inputs and prior study patterns; directly useful at study outset
+- **Meeting Intelligence System** — Operates on transcripts that are already produced in most programs
+- **Agency Question Radar** — Operates on comment matrices and transcripts that are already available
+- **Comment Resolution Engine** — Directly addresses one of the most labor-intensive recurring tasks
+- **Working Paper Stress Test** — Provides pre-review intelligence using artifacts already produced by other systems
+- **Knowledge Capture Engine** — Converts existing meeting and artifact outputs into persistent institutional records
+
+These systems share a common characteristic: they operate directly on artifacts that already exist in most spectrum study programs. They do not require new data collection infrastructure and can demonstrate operational value quickly.
+
+Later systems — the Institutional Memory Engine, Regulatory Impact Simulator, Spectrum Study Operating System, and Spectrum Intelligence Map — depend on the earlier systems producing stable, structured outputs. Building in this sequence reduces integration risk.
+
+---
+
+# Strategic View
+
+The long-term goal of this roadmap is not to automate isolated tasks. Isolated automation produces point solutions that do not compound in value and that often create new maintenance burdens.
+
+The goal is to create an institutional intelligence layer for spectrum studies and spectrum policy — a governed ecosystem of systems that accumulate knowledge, enforce consistency, and allow engineers and policymakers to reason about spectrum at a scale and speed that is not achievable with current manual processes.
+
+Each operational engine built according to this roadmap contributes artifacts to that intelligence layer. Each layer-2 system integrates those artifacts into study-scale intelligence. The Spectrum Intelligence Map integrates study-scale intelligence into ecosystem-scale reasoning.
+
+The value of this architecture is cumulative. The first engine produces immediate operational value. The tenth engine benefits from nine engines worth of structured artifacts. The Spectrum Intelligence Map benefits from the entire ecosystem.
+
+This is the correct direction for spectrum systems automation: governed, composable, and designed to accumulate institutional knowledge rather than discard it.


### PR DESCRIPTION
Defines the directional build plan for operational AI systems across the
spectrum-systems ecosystem, organized into three layers: operational
engines, study-scale intelligence systems, and the Spectrum Intelligence
Map as the apex ecosystem-scale layer.

Includes dependency ladder, architectural implications, implementation
guidance, near-term priorities, and strategic framing.

https://claude.ai/code/session_01XhfoWmznFhqhXrPuzhWTj7