### PR TITLE
Add scope field to review registry schema

### DIFF
--- a/docs/reviews/review-registry.schema.json
+++ b/docs/reviews/review-registry.schema.json
@@ -79,6 +79,10 @@
         },
         "uniqueItems": true
       },
+      "scope": {
+        "type": "string",
+        "description": "Scope of the design or architecture review (e.g., full repo audit, pipeline review, governance review)."
+      },
       "notes": {
         "type": "string"
       }


### PR DESCRIPTION
## Summary
Added a new `scope` field to the review registry schema to capture the scope or type of design and architecture reviews.

## Changes
- Added `scope` property to the review registry schema as an optional string field
- Includes descriptive documentation indicating the field should contain the scope of the review (e.g., full repo audit, pipeline review, governance review)

## Details
The new field allows reviewers to categorize and document the scope of each review, making it easier to track and filter reviews by their type or coverage area.

https://claude.ai/code/session_01Pizm5vGq3WLQkx61zX7bFj