### PR TITLE
Add CI workflow to surface Repository Actions from design reviews

### DIFF
--- a/.github/workflows/design-review-scan.yml
+++ b/.github/workflows/design-review-scan.yml
@@ -1,0 +1,20 @@
+name: Design Review Scanner
+
+on:
+  push:
+    paths:
+      - "design-reviews/*.md"
+
+jobs:
+  scan-review:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract Repository Actions
+        run: |
+          echo "Scanning design reviews for Repository Actions..."
+          grep -A 10 "## Repository Actions" design-reviews/*.md || echo "No actions found"
+          echo "## Repository Actions Found" >> $GITHUB_STEP_SUMMARY
+          grep -A 10 "## Repository Actions" design-reviews/*.md >> $GITHUB_STEP_SUMMARY || echo "None found" >> $GITHUB_STEP_SUMMARY

--- a/docs/governance/design-review-process.md
+++ b/docs/governance/design-review-process.md
@@ -13,3 +13,8 @@ Reviews must be converted into one or more of the following:
 No review should exist only as chat output.
 
 The repository is the source of truth for architectural decisions and findings.
+
+## CI Surfacing of Repository Actions
+
+Architecture reviews placed in `/design-reviews/` will automatically be scanned by CI.
+The workflow surfaces recommended repository actions in the GitHub job summary so maintainers can quickly convert them into ADRs or issues.


### PR DESCRIPTION
### Motivation
- Ensure repository-level action items identified in architecture reviews are visible to maintainers via CI so they can be converted into ADRs or issues.

### Description
- Add `.github/workflows/design-review-scan.yml` which runs on `push` events touching `design-reviews/*.md` and checks out the repository.
- Add a step that scans `design-reviews/*.md` for the `## Repository Actions` section and prints matches to the job log using `grep`.
- Append the extracted actions to the GitHub job summary by writing to `$GITHUB_STEP_SUMMARY` so findings are surfaced in the workflow UI.
- Update `docs/governance/design-review-process.md` with a note that files under `/design-reviews/` are automatically scanned by CI and surfaced for maintainers.

### Testing
- Ran `git diff --check` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b85d9a992c8329b48f9d80690c1969)