### PR TITLE
feat(autofix): add AFX-02 artifact spine (admission / validation / repair)

### DIFF
--- a/contracts/examples/build_admission_record.example.json
+++ b/contracts/examples/build_admission_record.example.json
@@ -16,6 +16,35 @@
       "spectrum_systems/modules/runtime/top_level_conductor.py"
     ]
   },
+  "request_source": {
+    "owner": "AEX",
+    "source_workflow": {
+      "workflow": "review-artifact-validation",
+      "workflow_run_id": "12345",
+      "head_branch": "feature/governed-autofix",
+      "trigger": "workflow_run"
+    },
+    "repository": {
+      "full_name": "nicklasorte/spectrum-systems"
+    },
+    "pull_request": {
+      "number": 42
+    }
+  },
+  "repo_mutation_classification": {
+    "owner": "AEX",
+    "repo_mutation_requested": true,
+    "execution_type": "repo_write"
+  },
+  "admission_decision": {
+    "status": "accepted",
+    "rejection_reason": null
+  },
+  "lineage": {
+    "handoff_owner": "TLC",
+    "handoff_ref": "tlc_handoff_record:tlc-handoff-req-001",
+    "trace_id": "trace-req-001"
+  },
   "authenticity": {
     "issuer": "AEX",
     "key_id": "local-system-v1",

--- a/contracts/examples/repair_attempt_record.example.json
+++ b/contracts/examples/repair_attempt_record.example.json
@@ -1,0 +1,17 @@
+{
+  "artifact_type": "repair_attempt_record",
+  "attempt_id": "repair-autofix-12345-1",
+  "owner": "FRE",
+  "request_id": "autofix-12345",
+  "source_failure_ref": "ril_failure_signal:autofix-12345",
+  "repair_scope_summary": "Bounded deterministic text replacement for explicit assertion failure.",
+  "target_scope": [
+    "tests/test_demo.py"
+  ],
+  "execution_outcome": "completed",
+  "validation_result_ref": "validation_result_record:vr-autofix-12345-1",
+  "validation_status": "passed",
+  "push_outcome": "blocked",
+  "trace_id": "trace-12345",
+  "emitted_at": "2026-04-09T00:00:00Z"
+}

--- a/contracts/examples/validation_result_record.example.json
+++ b/contracts/examples/validation_result_record.example.json
@@ -1,0 +1,28 @@
+{
+  "artifact_type": "validation_result_record",
+  "validation_result_id": "vr-autofix-12345-1",
+  "attempt_id": "repair-autofix-12345-1",
+  "admission_ref": "build_admission_record:adm-123456789abc",
+  "trace_id": "trace-12345",
+  "workflow_equivalent": "review-artifact-validation",
+  "validation_target": {
+    "type": "pull_request",
+    "value": "nicklasorte/spectrum-systems#42"
+  },
+  "validation_scope": "full",
+  "validation_path": "pre_push_replay",
+  "commands": [
+    {
+      "command": "node scripts/validate-review-artifacts.js",
+      "exit_code": 0,
+      "stdout_excerpt": "ok",
+      "stderr_excerpt": ""
+    }
+  ],
+  "status": "passed",
+  "blocking_reason": null,
+  "failure_summary": null,
+  "passed": true,
+  "enforcement_owner": "SEL",
+  "emitted_at": "2026-04-09T00:00:00Z"
+}

--- a/contracts/schemas/build_admission_record.schema.json
+++ b/contracts/schemas/build_admission_record.schema.json
@@ -119,6 +119,90 @@
           "pattern": "^[0-9a-f]{64}$"
         }
       }
+    },
+    "request_source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "owner",
+        "source_workflow",
+        "repository",
+        "pull_request"
+      ],
+      "properties": {
+        "owner": {
+          "type": "string",
+          "const": "AEX"
+        },
+        "source_workflow": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "workflow",
+            "workflow_run_id",
+            "head_branch",
+            "trigger"
+          ],
+          "properties": {
+            "workflow": {"type": "string", "minLength": 1},
+            "workflow_run_id": {"type": "string", "minLength": 1},
+            "head_branch": {"type": "string", "minLength": 1},
+            "trigger": {"type": "string", "minLength": 1}
+          }
+        },
+        "repository": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["full_name"],
+          "properties": {
+            "full_name": {"type": "string", "minLength": 1}
+          }
+        },
+        "pull_request": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["number"],
+          "properties": {
+            "number": {"type": ["integer", "null"], "minimum": 1}
+          }
+        }
+      }
+    },
+    "repo_mutation_classification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "owner",
+        "repo_mutation_requested",
+        "execution_type"
+      ],
+      "properties": {
+        "owner": {"type": "string", "const": "AEX"},
+        "repo_mutation_requested": {"type": "boolean"},
+        "execution_type": {
+          "type": "string",
+          "enum": ["repo_write", "read_only", "analysis_only", "unknown"]
+        }
+      }
+    },
+    "admission_decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "rejection_reason"],
+      "properties": {
+        "status": {"type": "string", "enum": ["accepted", "rejected"]},
+        "rejection_reason": {"type": ["string", "null"]}
+      }
+    },
+    "lineage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["handoff_owner", "handoff_ref", "trace_id"],
+      "properties": {
+        "handoff_owner": {"type": "string", "const": "TLC"},
+        "handoff_ref": {"type": "string", "minLength": 1},
+        "trace_id": {"type": "string", "minLength": 1}
+      }
     }
   }
 }

--- a/contracts/schemas/repair_attempt_record.schema.json
+++ b/contracts/schemas/repair_attempt_record.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/repair_attempt_record.schema.json",
+  "title": "Repair Attempt Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "attempt_id",
+    "owner",
+    "request_id",
+    "source_failure_ref",
+    "repair_scope_summary",
+    "target_scope",
+    "execution_outcome",
+    "validation_result_ref",
+    "validation_status",
+    "push_outcome",
+    "trace_id",
+    "emitted_at"
+  ],
+  "properties": {
+    "artifact_type": {"type": "string", "const": "repair_attempt_record"},
+    "attempt_id": {"type": "string", "minLength": 1},
+    "owner": {"type": "string", "const": "FRE"},
+    "request_id": {"type": "string", "minLength": 1},
+    "source_failure_ref": {"type": "string", "minLength": 1},
+    "repair_scope_summary": {"type": "string", "minLength": 1},
+    "target_scope": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1},
+      "uniqueItems": true
+    },
+    "execution_outcome": {"type": "string", "enum": ["completed", "blocked", "no_safe_fix"]},
+    "validation_result_ref": {"type": "string", "minLength": 1},
+    "validation_status": {"type": "string", "enum": ["passed", "failed", "not_run"]},
+    "push_outcome": {"type": "string", "enum": ["pushed", "blocked", "no_safe_fix"]},
+    "trace_id": {"type": "string", "minLength": 1},
+    "emitted_at": {"type": "string", "format": "date-time"}
+  }
+}

--- a/contracts/schemas/validation_result_record.schema.json
+++ b/contracts/schemas/validation_result_record.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/validation_result_record.schema.json",
+  "title": "Validation Result Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "validation_result_id",
+    "attempt_id",
+    "admission_ref",
+    "trace_id",
+    "workflow_equivalent",
+    "validation_target",
+    "validation_scope",
+    "validation_path",
+    "commands",
+    "status",
+    "enforcement_owner",
+    "emitted_at"
+  ],
+  "properties": {
+    "artifact_type": {"type": "string", "const": "validation_result_record"},
+    "validation_result_id": {"type": "string", "minLength": 1},
+    "attempt_id": {"type": "string", "minLength": 1},
+    "admission_ref": {"type": "string", "minLength": 1},
+    "trace_id": {"type": "string", "minLength": 1},
+    "workflow_equivalent": {"type": "string", "minLength": 1},
+    "validation_target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "value"],
+      "properties": {
+        "type": {"type": "string", "enum": ["pull_request", "repo_branch"]},
+        "value": {"type": "string", "minLength": 1}
+      }
+    },
+    "validation_scope": {"type": "string", "enum": ["full", "narrow"]},
+    "validation_path": {"type": "string", "minLength": 1},
+    "commands": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["command", "exit_code", "stdout_excerpt", "stderr_excerpt"],
+        "properties": {
+          "command": {"type": "string", "minLength": 1},
+          "exit_code": {"type": "integer"},
+          "stdout_excerpt": {"type": "string"},
+          "stderr_excerpt": {"type": "string"}
+        }
+      }
+    },
+    "status": {"type": "string", "enum": ["passed", "failed"]},
+    "blocking_reason": {"type": ["string", "null"]},
+    "failure_summary": {"type": ["string", "null"]},
+    "passed": {"type": "boolean"},
+    "enforcement_owner": {"type": "string", "const": "SEL"},
+    "emitted_at": {"type": "string", "format": "date-time"}
+  }
+}

--- a/contracts/standards-manifest.json
+++ b/contracts/standards-manifest.json
@@ -1,12 +1,12 @@
 {
   "artifact_type": "standards_manifest",
   "artifact_id": "STD-CONTRACTS",
-  "artifact_version": "1.3.103",
+  "artifact_version": "1.3.104",
   "schema_version": "1.3.98",
-  "standards_version": "1.3.103",
-  "record_id": "REC-STD-2026-04-08-AEX-06",
-  "run_id": "run-20260408T180000Z-aex-06",
-  "created_at": "2026-04-08T00:00:00Z",
+  "standards_version": "1.3.104",
+  "record_id": "REC-STD-2026-04-09-AFX-02",
+  "run_id": "run-20260409T000000Z-afx-02",
+  "created_at": "2026-04-09T00:00:00Z",
   "created_by": {
     "name": "Spectrum Systems Architecture Team",
     "role": "standards-publication",
@@ -15,7 +15,7 @@
     "contact": "architecture@spectrum-systems.test"
   },
   "source_repo": "nicklasorte/spectrum-systems",
-  "source_repo_version": "1.3.103",
+  "source_repo_version": "1.3.104",
   "input_artifacts": [
     {
       "artifact_id": "STD-CONTRACTS",
@@ -367,15 +367,15 @@
     {
       "artifact_type": "build_admission_record",
       "artifact_class": "coordination",
-      "schema_version": "1.0.0",
+      "schema_version": "1.1.0",
       "status": "stable",
       "intended_consumers": [
         "spectrum-systems"
       ],
       "introduced_in": "1.3.99",
-      "last_updated_in": "1.3.99",
+      "last_updated_in": "1.3.104",
       "example_path": "contracts/examples/build_admission_record.example.json",
-      "notes": "AEX admission artifact gating repo-mutating Codex requests before TLC orchestration."
+      "notes": "AEX admission evidence now includes workflow/run source, repository/PR identity, mutation classification, and TLC linkage for governed autofix lineage."
     },
     {
       "artifact_type": "build_report",
@@ -3404,6 +3404,19 @@
       "notes": "BATCH-FRE-03 deterministic bounded recovery-loop outcome artifact linking diagnosis, repair prompt, execution evidence, validation outcomes, and retry guidance."
     },
     {
+      "artifact_type": "repair_attempt_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.104",
+      "last_updated_in": "1.3.104",
+      "example_path": "contracts/examples/repair_attempt_record.example.json",
+      "notes": "FRE-linked bounded repair attempt evidence with validation linkage and push outcome for governed autofix runs."
+    },
+    {
       "artifact_type": "repair_attempt_record_artifact",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -3626,6 +3639,19 @@
       "notes": "RQX-02 bounded single-slice fix request artifact emitted only for fix_required review verdicts; execution remains PQX-owned."
     },
     {
+      "artifact_type": "review_handoff_disposition_artifact",
+      "artifact_class": "governance",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.102",
+      "last_updated_in": "1.3.102",
+      "example_path": "contracts/examples/review_handoff_disposition_artifact.json",
+      "notes": "RQX-B4 bounded control/scheduling disposition artifact classifying review_operator_handoff_artifact outcomes for manual hold/queue/escalation decisions without auto-recursion or execution authority transfer."
+    },
+    {
       "artifact_type": "review_hotspot_report",
       "artifact_class": "review",
       "schema_version": "1.0.0",
@@ -3678,17 +3704,17 @@
       "notes": "RQX-B3 strict unresolved post-cycle operator handoff artifact emitted after bounded one-cycle execution without automatic recursion."
     },
     {
-      "artifact_type": "review_handoff_disposition_artifact",
-      "artifact_class": "governance",
-      "schema_version": "1.0.0",
+      "artifact_type": "review_projection_bundle_artifact",
+      "artifact_class": "coordination",
+      "schema_version": "1.1.0",
       "status": "stable",
       "intended_consumers": [
         "spectrum-systems"
       ],
-      "introduced_in": "1.3.102",
-      "last_updated_in": "1.3.102",
-      "example_path": "contracts/examples/review_handoff_disposition_artifact.json",
-      "notes": "RQX-B4 bounded control/scheduling disposition artifact classifying review_operator_handoff_artifact outcomes for manual hold/queue/escalation decisions without auto-recursion or execution authority transfer."
+      "introduced_in": "1.3.80",
+      "last_updated_in": "1.3.81",
+      "example_path": "contracts/examples/review_projection_bundle_artifact.json",
+      "notes": "RIL-004 deterministic top-level read-only bundle linking roadmap/control-loop/readiness review projections and source packet provenance with strongly typed nested projection artifacts."
     },
     {
       "artifact_type": "review_promotion_gate_artifact",
@@ -3702,19 +3728,6 @@
       "last_updated_in": "1.3.103",
       "example_path": "contracts/examples/review_promotion_gate_artifact.json",
       "notes": "RQX-B5 bounded fail-closed merge/promotion readiness gate artifact integrating review result, merge readiness, and unresolved handoff/disposition state without automatic merge/promotion or closure authority transfer."
-    },
-    {
-      "artifact_type": "review_projection_bundle_artifact",
-      "artifact_class": "coordination",
-      "schema_version": "1.1.0",
-      "status": "stable",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.80",
-      "last_updated_in": "1.3.81",
-      "example_path": "contracts/examples/review_projection_bundle_artifact.json",
-      "notes": "RIL-004 deterministic top-level read-only bundle linking roadmap/control-loop/readiness review projections and source packet provenance with strongly typed nested projection artifacts."
     },
     {
       "artifact_type": "review_request",
@@ -4482,6 +4495,19 @@
       "last_updated_in": "1.3.59",
       "example_path": "contracts/examples/unknown_state_signal.json",
       "notes": "BATCH-10 explicit unknown-state modeling artifact with severity/blocking semantics for fail-closed control."
+    },
+    {
+      "artifact_type": "validation_result_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.104",
+      "last_updated_in": "1.3.104",
+      "example_path": "contracts/examples/validation_result_record.example.json",
+      "notes": "PQX replay execution + SEL pre-push enforcement evidence for governed autofix validation outcomes."
     },
     {
       "artifact_type": "viewpoint_pack",

--- a/docs/architecture/pr_autofix_review_artifact_validation.md
+++ b/docs/architecture/pr_autofix_review_artifact_validation.md
@@ -98,6 +98,22 @@ SEL enforcement:
 - missing replay artifact -> block push
 - ambiguous replay artifact -> block push
 
+## AFX-02 artifact spine (thin evidence layer)
+The autofix entrypoint emits three required governed artifacts as repo-native JSON files in `<output-dir>/artifacts/`:
+
+1. **`build_admission_record`** (AEX-owned admission evidence)
+   - Captures request identity, workflow run source, repository + PR identity, repo-mutation classification, admission decision, and TLC handoff lineage reference.
+2. **`validation_result_record`** (PQX execution + SEL enforcement evidence)
+   - Captures pre-push replay target/scope/path, command evidence, pass/fail status, blocking summary, and linkage to the admission + repair attempt.
+3. **`repair_attempt_record`** (FRE-linked bounded repair evidence)
+   - Captures failure reference, bounded scope/targets, execution outcome, validation linkage, and push outcome (`pushed`, `blocked`, `no_safe_fix`).
+
+Fail-closed conditions added for AFX-02:
+- required artifact file write failure
+- missing admission evidence before repo mutation
+- missing/failed validation result before commit/push progression
+- repair attempt record missing a validation linkage
+
 ## Security model
 1. Secrets boundary:
    - `OPENAI_API_KEY` for model access (if later repair planning needs it).

--- a/docs/review-actions/PLAN-AFX-02-ARTIFACT-SPINE-2026-04-09.md
+++ b/docs/review-actions/PLAN-AFX-02-ARTIFACT-SPINE-2026-04-09.md
@@ -1,0 +1,26 @@
+# PLAN — AFX-02 Artifact Spine (Admission / Validation / Repair)
+
+## Prompt type
+BUILD
+
+## Scope
+Implement a thin, repo-native artifact spine for the existing PR autofix path so every attempt emits governed, replayable evidence without introducing a new subsystem.
+
+## Files in scope
+| File | Action | Purpose |
+| --- | --- | --- |
+| `spectrum_systems/modules/runtime/github_pr_autofix_review_artifact_validation.py` | MODIFY | Emit and enforce required `build_admission_record`, `validation_result_record`, and `repair_attempt_record` artifacts with fail-closed linkage checks. |
+| `contracts/schemas/build_admission_record.schema.json` | MODIFY | Extend AEX admission record shape with optional source workflow/repo/PR/mutation-classification/lineage fields for autofix admission evidence. |
+| `contracts/examples/build_admission_record.example.json` | MODIFY | Show canonical admission evidence fields in a thin example. |
+| `contracts/schemas/validation_result_record.schema.json` | CREATE | Define minimal governed pre-push replay result artifact schema. |
+| `contracts/examples/validation_result_record.example.json` | CREATE | Provide a minimal valid replay result example. |
+| `contracts/schemas/repair_attempt_record.schema.json` | CREATE | Define minimal FRE-linked bounded repair attempt artifact schema. |
+| `contracts/examples/repair_attempt_record.example.json` | CREATE | Provide a minimal valid repair attempt example. |
+| `contracts/standards-manifest.json` | MODIFY | Register new contracts and bump manifest versions consistent with contract updates. |
+| `tests/test_github_pr_autofix_review_artifact_validation.py` | MODIFY | Validate artifact emission/linkage and fail-closed behavior for missing artifact/link conditions. |
+| `docs/architecture/pr_autofix_review_artifact_validation.md` | MODIFY | Concise operational note for AFX-02 artifact ownership, emission points, and fail-closed rules. |
+
+## Validation plan
+1. `pytest tests/test_github_pr_autofix_review_artifact_validation.py`
+2. `pytest tests/test_contracts.py tests/test_contract_enforcement.py`
+3. `python scripts/run_contract_enforcement.py`

--- a/spectrum_systems/modules/runtime/github_pr_autofix_review_artifact_validation.py
+++ b/spectrum_systems/modules/runtime/github_pr_autofix_review_artifact_validation.py
@@ -63,6 +63,13 @@ def _write_json(path: Path, payload: dict[str, Any]) -> None:
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
+def _write_required_artifact(*, path: Path, payload: dict[str, Any], artifact_type: str) -> None:
+    try:
+        _write_json(path, payload)
+    except OSError as exc:
+        raise GovernedAutofixError(f"artifact_write_failed:{artifact_type}") from exc
+
+
 def _build_tlc_handoff(*, request_id: str, trace_id: str, branch_ref: str, admission_id: str, emitted_at: str) -> dict[str, Any]:
     artifact = {
         "artifact_type": "tlc_handoff_record",
@@ -313,10 +320,19 @@ def run_validation_replay(*, repo_root: Path, narrow_test_targets: list[str] | N
 
     return {
         "artifact_type": "validation_result_record",
+        "validation_result_id": "",
+        "attempt_id": "",
+        "admission_ref": "",
+        "trace_id": "",
+        "enforcement_owner": "SEL",
         "workflow_equivalent": "review-artifact-validation",
         "validation_scope": validation_scope,
-        "passed": passed,
-        "results": [
+        "validation_target": {"type": "repo_branch", "value": ""},
+        "validation_path": "pre_push_replay",
+        "status": "passed" if passed else "failed",
+        "blocking_reason": None if passed else "validation_command_failed",
+        "failure_summary": None if passed else "One or more replay commands failed.",
+        "commands": [
             {
                 "command": item.command,
                 "exit_code": item.exit_code,
@@ -325,6 +341,7 @@ def run_validation_replay(*, repo_root: Path, narrow_test_targets: list[str] | N
             }
             for item in results
         ],
+        "passed": passed,
         "emitted_at": _utc_now(),
     }
 
@@ -343,6 +360,12 @@ def enforce_replay_gate(validation_result_record: dict[str, Any]) -> None:
         raise GovernedAutofixError("validation_replay_ambiguous")
     if validation_result_record.get("passed") is not True:
         raise GovernedAutofixError("validation_replay_failed")
+
+
+def enforce_repair_validation_linkage(repair_attempt_record: dict[str, Any]) -> None:
+    validation_ref = repair_attempt_record.get("validation_result_ref")
+    if not isinstance(validation_ref, str) or not validation_ref.strip():
+        raise GovernedAutofixError("repair_validation_link_missing")
 
 
 def run_governed_autofix(
@@ -386,6 +409,39 @@ def run_governed_autofix(
     admission = AEXEngine().admit_codex_request(codex_request)
     if not admission.accepted or admission.build_admission_record is None or admission.normalized_execution_request is None:
         raise GovernedAutofixError("aex_admission_failed")
+    admission_record = dict(admission.build_admission_record)
+    pr_number = pr_list[0].get("number")
+    admission_record["request_source"] = {
+        "owner": "AEX",
+        "source_workflow": {
+            "workflow": "review-artifact-validation",
+            "workflow_run_id": str(workflow_run.get("id") or "unknown"),
+            "head_branch": branch_ref,
+            "trigger": "workflow_run",
+        },
+        "repository": {
+            "full_name": str(event_payload.get("repository", {}).get("full_name") or "unknown"),
+        },
+        "pull_request": {
+            "number": int(pr_number) if isinstance(pr_number, int) else None,
+        },
+    }
+    admission_record["repo_mutation_classification"] = {
+        "owner": "AEX",
+        "repo_mutation_requested": bool(admission.normalized_execution_request.get("repo_mutation_requested")),
+        "execution_type": str(admission_record.get("execution_type") or "unknown"),
+    }
+    admission_record["admission_decision"] = {
+        "status": str(admission_record.get("admission_status") or "rejected"),
+        "rejection_reason": None,
+    }
+    admission_record["lineage"] = {
+        "handoff_owner": "TLC",
+        "handoff_ref": f"tlc_handoff_record:tlc-handoff-{request_id}",
+        "trace_id": trace_id,
+    }
+    admission_record["authenticity"] = issue_authenticity(artifact=admission_record, issuer="AEX")
+    validate_artifact(admission_record, "build_admission_record")
 
     tlc_handoff = _build_tlc_handoff(
         request_id=request_id,
@@ -398,7 +454,7 @@ def run_governed_autofix(
 
     bounded_actions = _derive_bounded_actions(logs_text=logs_text)
     governed_context: dict[str, Any] = {
-        "build_admission_record": admission.build_admission_record,
+        "build_admission_record": admission_record,
         "normalized_execution_request": admission.normalized_execution_request,
         "tlc_handoff_record": tlc_handoff,
         "tpa_slice_artifact": tpa_slice,
@@ -434,15 +490,41 @@ def run_governed_autofix(
     artifacts_dir = output_dir / "artifacts"
     artifacts_dir.mkdir(parents=True, exist_ok=True)
 
-    _write_json(artifacts_dir / "build_admission_record.json", admission.build_admission_record)
-    _write_json(artifacts_dir / "normalized_execution_request.json", admission.normalized_execution_request)
-    _write_json(artifacts_dir / "tlc_handoff_record.json", tlc_handoff)
-    _write_json(artifacts_dir / "tpa_slice_artifact.json", tpa_slice)
-    _write_json(artifacts_dir / "ril_failure_signal.json", governed_context["ril_failure_signal"])
-    _write_json(artifacts_dir / "fre_repair_plan.json", governed_context["fre_repair_plan"])
+    _write_required_artifact(
+        path=artifacts_dir / "build_admission_record.json",
+        payload=admission_record,
+        artifact_type="build_admission_record",
+    )
+    _write_required_artifact(path=artifacts_dir / "normalized_execution_request.json", payload=admission.normalized_execution_request, artifact_type="normalized_execution_request")
+    _write_required_artifact(path=artifacts_dir / "tlc_handoff_record.json", payload=tlc_handoff, artifact_type="tlc_handoff_record")
+    _write_required_artifact(path=artifacts_dir / "tpa_slice_artifact.json", payload=tpa_slice, artifact_type="tpa_slice_artifact")
+    _write_required_artifact(path=artifacts_dir / "ril_failure_signal.json", payload=governed_context["ril_failure_signal"], artifact_type="ril_failure_signal")
+    _write_required_artifact(path=artifacts_dir / "fre_repair_plan.json", payload=governed_context["fre_repair_plan"], artifact_type="fre_repair_plan")
 
     # Fail closed when there is no bounded safe repair plan.
     if not governed_context["fre_repair_plan"].get("bounded_actions"):
+        no_safe_repair_attempt = {
+            "artifact_type": "repair_attempt_record",
+            "attempt_id": f"repair-{request_id}-1",
+            "owner": "FRE",
+            "request_id": request_id,
+            "source_failure_ref": f"ril_failure_signal:{request_id}",
+            "repair_scope_summary": "No deterministic bounded repair action available from provided failure signal.",
+            "target_scope": [],
+            "execution_outcome": "no_safe_fix",
+            "validation_result_ref": "validation_result_record:not_run_no_safe_fix",
+            "validation_status": "not_run",
+            "push_outcome": "no_safe_fix",
+            "trace_id": trace_id,
+            "emitted_at": _utc_now(),
+        }
+        validate_artifact(no_safe_repair_attempt, "repair_attempt_record")
+        enforce_repair_validation_linkage(no_safe_repair_attempt)
+        _write_required_artifact(
+            path=artifacts_dir / "repair_attempt_record.json",
+            payload=no_safe_repair_attempt,
+            artifact_type="repair_attempt_record",
+        )
         summary = {
             "status": "blocked",
             "reason": "no_safe_fix_found",
@@ -471,8 +553,15 @@ def run_governed_autofix(
         raise GovernedAutofixError("repair_applied_but_no_git_change")
 
     narrow_targets = _narrow_test_targets_if_safe(actions=bounded_actions, logs_text=logs_text)
+    attempt_id = f"repair-{request_id}-1"
     validation_record = run_validation_replay(repo_root=repo_root, narrow_test_targets=narrow_targets)
-    _write_json(artifacts_dir / "validation_result_record.json", validation_record)
+    validation_record["validation_result_id"] = f"vr-{request_id}-1"
+    validation_record["attempt_id"] = attempt_id
+    validation_record["admission_ref"] = f"build_admission_record:{admission_record['admission_id']}"
+    validation_record["trace_id"] = trace_id
+    validation_record["validation_target"] = {"type": "pull_request", "value": f"{event_payload.get('repository', {}).get('full_name')}#{pr_number}"}
+    validate_artifact(validation_record, "validation_result_record")
+    _write_required_artifact(path=artifacts_dir / "validation_result_record.json", payload=validation_record, artifact_type="validation_result_record")
     enforce_replay_gate(validation_record)
 
     commit_sha = _git_commit_changes(
@@ -481,11 +570,32 @@ def run_governed_autofix(
         request_id=request_id,
     )
     pushed_branch = None
+    push_outcome = "blocked"
     if push:
         token = os.getenv("GITHUB_APP_TOKEN") or os.getenv("AUTOFIX_PUSH_TOKEN")
         if not token:
             raise GovernedAutofixError("push_token_missing")
         pushed_branch = _push_with_governed_token(repo_root=repo_root, branch_ref=branch_ref, token=token)
+        push_outcome = "pushed"
+
+    repair_attempt_record = {
+        "artifact_type": "repair_attempt_record",
+        "attempt_id": attempt_id,
+        "owner": "FRE",
+        "request_id": request_id,
+        "source_failure_ref": f"ril_failure_signal:{request_id}",
+        "repair_scope_summary": "Bounded deterministic text replacement derived from explicit pytest assertion failure signal.",
+        "target_scope": mutation_record["applied_paths"],
+        "execution_outcome": "completed",
+        "validation_result_ref": f"validation_result_record:{validation_record['validation_result_id']}",
+        "validation_status": validation_record["status"],
+        "push_outcome": push_outcome if validation_record["passed"] else "blocked",
+        "trace_id": trace_id,
+        "emitted_at": _utc_now(),
+    }
+    validate_artifact(repair_attempt_record, "repair_attempt_record")
+    enforce_repair_validation_linkage(repair_attempt_record)
+    _write_required_artifact(path=artifacts_dir / "repair_attempt_record.json", payload=repair_attempt_record, artifact_type="repair_attempt_record")
 
     summary = {
         "status": "pushed" if push else "validated_committed_no_push",

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -275,6 +275,11 @@ class ContractSchemaTests(unittest.TestCase):
         instance = load_example("replay_result")
         validate_artifact(instance, "replay_result")
 
+    def test_afx_02_artifact_spine_examples_validate(self) -> None:
+        for name in ("build_admission_record", "validation_result_record", "repair_attempt_record"):
+            instance = load_example(name)
+            validate_artifact(instance, name)
+
     def test_drift_and_baseline_gate_contract_examples_validate(self) -> None:
         for name in ("drift_detection_result", "baseline_gate_decision", "baseline_gate_policy"):
             instance = load_example(name)

--- a/tests/test_github_pr_autofix_review_artifact_validation.py
+++ b/tests/test_github_pr_autofix_review_artifact_validation.py
@@ -10,6 +10,7 @@ from spectrum_systems.modules.runtime.github_pr_autofix_review_artifact_validati
     GovernedAutofixError,
     _narrow_test_targets_if_safe,
     enforce_entry_invariant,
+    enforce_repair_validation_linkage,
     enforce_replay_gate,
     run_governed_autofix,
 )
@@ -26,6 +27,11 @@ def test_replay_gate_fails_closed_on_missing_or_failed_result() -> None:
 
     with pytest.raises(GovernedAutofixError, match='validation_replay_failed'):
         enforce_replay_gate({'artifact_type': 'validation_result_record', 'passed': False})
+
+
+def test_repair_attempt_requires_validation_linkage() -> None:
+    with pytest.raises(GovernedAutofixError, match='repair_validation_link_missing'):
+        enforce_repair_validation_linkage({'artifact_type': 'repair_attempt_record', 'validation_result_ref': ''})
 
 
 def test_run_governed_autofix_blocks_without_safe_fix_plan(tmp_path: Path) -> None:
@@ -56,6 +62,10 @@ def test_run_governed_autofix_blocks_without_safe_fix_plan(tmp_path: Path) -> No
     assert out['reason'] == 'no_safe_fix_found'
     assert out['lineage_present'] is True
     assert out['validation_replay_passed'] is False
+    repair_attempt = json.loads((tmp_path / 'out' / 'artifacts' / 'repair_attempt_record.json').read_text(encoding='utf-8'))
+    assert repair_attempt['artifact_type'] == 'repair_attempt_record'
+    assert repair_attempt['execution_outcome'] == 'no_safe_fix'
+    assert repair_attempt['push_outcome'] == 'no_safe_fix'
 
 
 def _init_git_repo(tmp_path: Path) -> Path:
@@ -97,7 +107,24 @@ def test_run_governed_autofix_applies_bounded_fix_and_commits(monkeypatch: pytes
 
     monkeypatch.setattr(
         'spectrum_systems.modules.runtime.github_pr_autofix_review_artifact_validation.run_validation_replay',
-        lambda **_: {'artifact_type': 'validation_result_record', 'passed': True, 'validation_scope': 'narrow', 'results': []},
+        lambda **_: {
+            'artifact_type': 'validation_result_record',
+            'validation_result_id': '',
+            'attempt_id': '',
+            'admission_ref': '',
+            'trace_id': '',
+            'workflow_equivalent': 'review-artifact-validation',
+            'validation_target': {'type': 'repo_branch', 'value': 'feature/test'},
+            'validation_scope': 'narrow',
+            'validation_path': 'pre_push_replay',
+            'commands': [{'command': 'pytest tests/test_demo.py', 'exit_code': 0, 'stdout_excerpt': '', 'stderr_excerpt': ''}],
+            'status': 'passed',
+            'blocking_reason': None,
+            'failure_summary': None,
+            'enforcement_owner': 'SEL',
+            'passed': True,
+            'emitted_at': '2026-04-09T00:00:00Z',
+        },
     )
 
     out = run_governed_autofix(
@@ -111,6 +138,19 @@ def test_run_governed_autofix_applies_bounded_fix_and_commits(monkeypatch: pytes
     assert out['validation_replay_passed'] is True
     assert out['repair_applied'] is True
     assert (repo_root / 'tests' / 'test_demo.py').read_text(encoding='utf-8').endswith('assert 1 == 1\n')
+    admission_record = json.loads((repo_root / 'out' / 'artifacts' / 'build_admission_record.json').read_text(encoding='utf-8'))
+    assert admission_record['request_source']['owner'] == 'AEX'
+    assert admission_record['request_source']['source_workflow']['workflow'] == 'review-artifact-validation'
+    assert admission_record['repo_mutation_classification']['repo_mutation_requested'] is True
+    validation_record = json.loads((repo_root / 'out' / 'artifacts' / 'validation_result_record.json').read_text(encoding='utf-8'))
+    assert validation_record['artifact_type'] == 'validation_result_record'
+    assert validation_record['validation_scope'] == 'narrow'
+    assert validation_record['status'] == 'passed'
+    repair_attempt = json.loads((repo_root / 'out' / 'artifacts' / 'repair_attempt_record.json').read_text(encoding='utf-8'))
+    assert repair_attempt['artifact_type'] == 'repair_attempt_record'
+    assert repair_attempt['owner'] == 'FRE'
+    assert repair_attempt['validation_result_ref'].startswith('validation_result_record:')
+    assert repair_attempt['push_outcome'] == 'blocked'
 
 
 def test_narrowing_is_blocked_when_multilayer_failure_signal_present() -> None:
@@ -208,7 +248,24 @@ def test_push_path_rejects_github_token_only(monkeypatch: pytest.MonkeyPatch, tm
     monkeypatch.delenv('GITHUB_APP_TOKEN', raising=False)
     monkeypatch.setattr(
         'spectrum_systems.modules.runtime.github_pr_autofix_review_artifact_validation.run_validation_replay',
-        lambda **_: {'artifact_type': 'validation_result_record', 'passed': True, 'validation_scope': 'narrow', 'results': []},
+        lambda **_: {
+            'artifact_type': 'validation_result_record',
+            'validation_result_id': '',
+            'attempt_id': '',
+            'admission_ref': '',
+            'trace_id': '',
+            'workflow_equivalent': 'review-artifact-validation',
+            'validation_target': {'type': 'repo_branch', 'value': 'feature/test'},
+            'validation_scope': 'narrow',
+            'validation_path': 'pre_push_replay',
+            'commands': [{'command': 'pytest tests/test_push_demo.py', 'exit_code': 0, 'stdout_excerpt': '', 'stderr_excerpt': ''}],
+            'status': 'passed',
+            'blocking_reason': None,
+            'failure_summary': None,
+            'enforcement_owner': 'SEL',
+            'passed': True,
+            'emitted_at': '2026-04-09T00:00:00Z',
+        },
     )
 
     with pytest.raises(GovernedAutofixError, match='push_token_missing'):


### PR DESCRIPTION
### Motivation
- Provide the minimal, repo-native evidence layer so every governed PR autofix attempt emits admission, pre-push validation, and repair attempt artifacts for replay and audit. 
- Keep artifacts thin, deterministic, and aligned to the canonical ownership model (AEX / PQX+SEL / FRE) without introducing new subsystems. 
- Enforce fail-closed behavior so missing or invalid evidence blocks any repo mutation or push. 

### Description
- Added two new artifact contracts and examples: `validation_result_record` (`contracts/schemas/validation_result_record.schema.json` + `contracts/examples/validation_result_record.example.json`) and `repair_attempt_record` (`contracts/schemas/repair_attempt_record.schema.json` + `contracts/examples/repair_attempt_record.example.json`).
- Extended the existing `build_admission_record` schema/example to include optional AFX-02 admission evidence fields (`request_source`, `repo_mutation_classification`, `admission_decision`, `lineage`) and kept it AEX-shaped. (`contracts/schemas/build_admission_record.schema.json`, `contracts/examples/build_admission_record.example.json`).
- Wired artifact emission and fail-closed enforcement into the repo-native autofix entrypoint: `spectrum_systems/modules/runtime/github_pr_autofix_review_artifact_validation.py` now writes required artifacts via `_write_required_artifact`, validates artifacts against schemas with `validate_artifact`, enriches the validation result with admission/trace/target linkage, and emits a `repair_attempt_record` for both `no_safe_fix` and executed repair paths; missing/invalid artifacts or missing validation linkage raise `GovernedAutofixError` and block progression. 
- Registered new/updated contracts in `contracts/standards-manifest.json`, added a short plan (`docs/review-actions/PLAN-AFX-02-ARTIFACT-SPINE-2026-04-09.md`), and documented the AFX-02 artifact spine and fail-closed invariants in `docs/architecture/pr_autofix_review_artifact_validation.md`.

### Testing
- Ran unit tests for the autofix path: `pytest tests/test_github_pr_autofix_review_artifact_validation.py` — all tests passed (9 passed). 
- Ran contract validation suites: `pytest tests/test_contracts.py tests/test_contract_enforcement.py` — all tests passed (116 passed). 
- Executed contract enforcement script: `python scripts/run_contract_enforcement.py` — completed with no failures and wrote governance reports. 
- The changes include schema validation during runtime emission and the tests assert emitted artifacts exist, conform to schemas, and that fail-closed behaviors (missing artifacts, missing validation linkage, push-token rules) block progression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d784e3e6c48329bc7833710a3bab08)