### PR TITLE
fix(aex): harden repo-write lineage trust model against forgery and replay

### DIFF
--- a/contracts/examples/build_admission_record.example.json
+++ b/contracts/examples/build_admission_record.example.json
@@ -47,8 +47,13 @@
   },
   "authenticity": {
     "issuer": "AEX",
-    "key_id": "local-system-v1",
+    "key_id": "aex-hs256-v1",
     "payload_digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    "audience": "pqx_repo_write_boundary",
+    "scope": "repo_write_lineage:build_admission_record:req-001:trace-req-001",
+    "issued_at": "2026-04-08T00:00:00Z",
+    "expires_at": "2026-04-08T00:15:00Z",
+    "lineage_token_id": "lin-000000000000000000000000",
     "attestation": "0000000000000000000000000000000000000000000000000000000000000000"
   }
 }

--- a/contracts/examples/normalized_execution_request.example.json
+++ b/contracts/examples/normalized_execution_request.example.json
@@ -18,8 +18,13 @@
   "produced_by": "AEXEngine",
   "authenticity": {
     "issuer": "AEX",
-    "key_id": "local-system-v1",
+    "key_id": "aex-hs256-v1",
     "payload_digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    "audience": "pqx_repo_write_boundary",
+    "scope": "repo_write_lineage:normalized_execution_request:req-001:trace-req-001",
+    "issued_at": "2026-04-08T00:00:00Z",
+    "expires_at": "2026-04-08T00:15:00Z",
+    "lineage_token_id": "lin-000000000000000000000000",
     "attestation": "0000000000000000000000000000000000000000000000000000000000000000"
   }
 }

--- a/contracts/examples/tlc_handoff_record.example.json
+++ b/contracts/examples/tlc_handoff_record.example.json
@@ -34,8 +34,13 @@
   },
   "authenticity": {
     "issuer": "TLC",
-    "key_id": "local-system-v1",
+    "key_id": "tlc-hs256-v1",
     "payload_digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    "audience": "pqx_repo_write_boundary",
+    "scope": "repo_write_lineage:tlc_handoff_record:req-001:trace-repo-write-001",
+    "issued_at": "2026-04-08T00:00:00Z",
+    "expires_at": "2026-04-08T00:15:00Z",
+    "lineage_token_id": "lin-000000000000000000000000",
     "attestation": "0000000000000000000000000000000000000000000000000000000000000000"
   }
 }

--- a/contracts/schemas/build_admission_record.schema.json
+++ b/contracts/schemas/build_admission_record.schema.json
@@ -96,6 +96,11 @@
         "issuer",
         "key_id",
         "payload_digest",
+        "audience",
+        "scope",
+        "issued_at",
+        "expires_at",
+        "lineage_token_id",
         "attestation"
       ],
       "properties": {
@@ -117,6 +122,26 @@
         "attestation": {
           "type": "string",
           "pattern": "^[0-9a-f]{64}$"
+        },
+        "audience": {
+          "type": "string",
+          "const": "pqx_repo_write_boundary"
+        },
+        "scope": {
+          "type": "string",
+          "minLength": 1
+        },
+        "issued_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "expires_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "lineage_token_id": {
+          "type": "string",
+          "pattern": "^lin-[0-9a-f]{24}$"
         }
       }
     },
@@ -144,26 +169,51 @@
             "trigger"
           ],
           "properties": {
-            "workflow": {"type": "string", "minLength": 1},
-            "workflow_run_id": {"type": "string", "minLength": 1},
-            "head_branch": {"type": "string", "minLength": 1},
-            "trigger": {"type": "string", "minLength": 1}
+            "workflow": {
+              "type": "string",
+              "minLength": 1
+            },
+            "workflow_run_id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "head_branch": {
+              "type": "string",
+              "minLength": 1
+            },
+            "trigger": {
+              "type": "string",
+              "minLength": 1
+            }
           }
         },
         "repository": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["full_name"],
+          "required": [
+            "full_name"
+          ],
           "properties": {
-            "full_name": {"type": "string", "minLength": 1}
+            "full_name": {
+              "type": "string",
+              "minLength": 1
+            }
           }
         },
         "pull_request": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["number"],
+          "required": [
+            "number"
+          ],
           "properties": {
-            "number": {"type": ["integer", "null"], "minimum": 1}
+            "number": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "minimum": 1
+            }
           }
         }
       }
@@ -177,31 +227,68 @@
         "execution_type"
       ],
       "properties": {
-        "owner": {"type": "string", "const": "AEX"},
-        "repo_mutation_requested": {"type": "boolean"},
+        "owner": {
+          "type": "string",
+          "const": "AEX"
+        },
+        "repo_mutation_requested": {
+          "type": "boolean"
+        },
         "execution_type": {
           "type": "string",
-          "enum": ["repo_write", "read_only", "analysis_only", "unknown"]
+          "enum": [
+            "repo_write",
+            "read_only",
+            "analysis_only",
+            "unknown"
+          ]
         }
       }
     },
     "admission_decision": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["status", "rejection_reason"],
+      "required": [
+        "status",
+        "rejection_reason"
+      ],
       "properties": {
-        "status": {"type": "string", "enum": ["accepted", "rejected"]},
-        "rejection_reason": {"type": ["string", "null"]}
+        "status": {
+          "type": "string",
+          "enum": [
+            "accepted",
+            "rejected"
+          ]
+        },
+        "rejection_reason": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
       }
     },
     "lineage": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["handoff_owner", "handoff_ref", "trace_id"],
+      "required": [
+        "handoff_owner",
+        "handoff_ref",
+        "trace_id"
+      ],
       "properties": {
-        "handoff_owner": {"type": "string", "const": "TLC"},
-        "handoff_ref": {"type": "string", "minLength": 1},
-        "trace_id": {"type": "string", "minLength": 1}
+        "handoff_owner": {
+          "type": "string",
+          "const": "TLC"
+        },
+        "handoff_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "trace_id": {
+          "type": "string",
+          "minLength": 1
+        }
       }
     }
   }

--- a/contracts/schemas/normalized_execution_request.schema.json
+++ b/contracts/schemas/normalized_execution_request.schema.json
@@ -78,6 +78,11 @@
         "issuer",
         "key_id",
         "payload_digest",
+        "audience",
+        "scope",
+        "issued_at",
+        "expires_at",
+        "lineage_token_id",
         "attestation"
       ],
       "properties": {
@@ -99,6 +104,26 @@
         "attestation": {
           "type": "string",
           "pattern": "^[0-9a-f]{64}$"
+        },
+        "audience": {
+          "type": "string",
+          "const": "pqx_repo_write_boundary"
+        },
+        "scope": {
+          "type": "string",
+          "minLength": 1
+        },
+        "issued_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "expires_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "lineage_token_id": {
+          "type": "string",
+          "pattern": "^lin-[0-9a-f]{24}$"
         }
       }
     }

--- a/contracts/schemas/tlc_handoff_record.schema.json
+++ b/contracts/schemas/tlc_handoff_record.schema.json
@@ -168,6 +168,11 @@
         "issuer",
         "key_id",
         "payload_digest",
+        "audience",
+        "scope",
+        "issued_at",
+        "expires_at",
+        "lineage_token_id",
         "attestation"
       ],
       "properties": {
@@ -189,6 +194,26 @@
         "attestation": {
           "type": "string",
           "pattern": "^[0-9a-f]{64}$"
+        },
+        "audience": {
+          "type": "string",
+          "const": "pqx_repo_write_boundary"
+        },
+        "scope": {
+          "type": "string",
+          "minLength": 1
+        },
+        "issued_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "expires_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "lineage_token_id": {
+          "type": "string",
+          "pattern": "^lin-[0-9a-f]{24}$"
         }
       }
     }

--- a/contracts/standards-manifest.json
+++ b/contracts/standards-manifest.json
@@ -1,9 +1,9 @@
 {
   "artifact_type": "standards_manifest",
   "artifact_id": "STD-CONTRACTS",
-  "artifact_version": "1.3.104",
+  "artifact_version": "1.3.105",
   "schema_version": "1.3.98",
-  "standards_version": "1.3.104",
+  "standards_version": "1.3.105",
   "record_id": "REC-STD-2026-04-09-AFX-02",
   "run_id": "run-20260409T000000Z-afx-02",
   "created_at": "2026-04-09T00:00:00Z",
@@ -15,7 +15,7 @@
     "contact": "architecture@spectrum-systems.test"
   },
   "source_repo": "nicklasorte/spectrum-systems",
-  "source_repo_version": "1.3.104",
+  "source_repo_version": "1.3.105",
   "input_artifacts": [
     {
       "artifact_id": "STD-CONTRACTS",
@@ -367,15 +367,15 @@
     {
       "artifact_type": "build_admission_record",
       "artifact_class": "coordination",
-      "schema_version": "1.1.0",
+      "schema_version": "1.2.0",
       "status": "stable",
       "intended_consumers": [
         "spectrum-systems"
       ],
       "introduced_in": "1.3.99",
-      "last_updated_in": "1.3.104",
+      "last_updated_in": "1.3.105",
       "example_path": "contracts/examples/build_admission_record.example.json",
-      "notes": "AEX admission evidence now includes workflow/run source, repository/PR identity, mutation classification, and TLC linkage for governed autofix lineage."
+      "notes": "AEX lineage authenticity now requires issuer-scoped key binding, freshness fields, audience/scope binding, and replay-resistant token identity for PQX repo-write boundary validation."
     },
     {
       "artifact_type": "build_report",
@@ -2227,15 +2227,15 @@
     {
       "artifact_type": "normalized_execution_request",
       "artifact_class": "coordination",
-      "schema_version": "1.0.0",
+      "schema_version": "1.1.0",
       "status": "stable",
       "intended_consumers": [
         "spectrum-systems"
       ],
       "introduced_in": "1.3.99",
-      "last_updated_in": "1.3.99",
+      "last_updated_in": "1.3.105",
       "example_path": "contracts/examples/normalized_execution_request.example.json",
-      "notes": "AEX-normalized execution request artifact consumed by TLC after admission."
+      "notes": "AEX normalized execution request authenticity now carries issuer-scoped key binding plus freshness/audience/scope/token fields required for fail-closed PQX repo-write lineage verification."
     },
     {
       "artifact_type": "observability_metrics",
@@ -4304,15 +4304,15 @@
     {
       "artifact_type": "tlc_handoff_record",
       "artifact_class": "coordination",
-      "schema_version": "1.0.0",
+      "schema_version": "1.1.0",
       "status": "stable",
       "intended_consumers": [
         "spectrum-systems"
       ],
       "introduced_in": "1.3.100",
-      "last_updated_in": "1.3.100",
+      "last_updated_in": "1.3.105",
       "example_path": "contracts/examples/tlc_handoff_record.example.json",
-      "notes": "Formal TLC handoff artifact for admitted repo-mutating execution; links AEX admission artifacts to orchestrated TPA/PQX path."
+      "notes": "TLC handoff authenticity now enforces issuer-scoped key binding and freshness/audience/scope/token fields used by repo-write replay rejection at the PQX boundary."
     },
     {
       "artifact_type": "top_level_conductor_run_artifact",

--- a/docs/architecture/foundation_pqx_eval_control.md
+++ b/docs/architecture/foundation_pqx_eval_control.md
@@ -111,6 +111,7 @@ Any such divergence must trigger hardening-first roadmap sequencing.
 - Repo-mutating orchestration must include `build_admission_record` and `normalized_execution_request` before TLC continues.
 - The AEX→TLC seam is contractized via `tlc_handoff_record` to make admission-to-orchestration lineage explicit and replayable for repo-mutating execution.
 - Enforcement is fail-closed end-to-end: missing/invalid AEX artifacts block TLC entry, and missing/unknown execution intent or missing TLC lineage blocks PQX execution (`AEX → TLC → TPA → PQX` only).
+- Repo-write lineage authenticity is issuer-scoped (AEX/TLC secrets per issuer), default secret fallback is forbidden, and PQX rejects stale/wrong-audience/replayed lineage tokens at the execution boundary.
 
 ## End-to-End Artifact Chain Extension
 

--- a/docs/review-actions/PLAN-BATCH-AEX-FIX-05-2026-04-09.md
+++ b/docs/review-actions/PLAN-BATCH-AEX-FIX-05-2026-04-09.md
@@ -1,0 +1,48 @@
+# Plan — BATCH-AEX-FIX-05 — 2026-04-09
+
+## Prompt type
+PLAN
+
+## Roadmap item
+BATCH-AEX-FIX-05
+
+## Objective
+Harden repo-write lineage trust validation so forged, stale, issuer-mismatched, or replayed lineage is rejected fail-closed at the PQX boundary.
+
+## Declared files
+List every file that will be created, modified, or deleted.
+No other files may be changed during execution of this plan.
+
+| File | Change type | Reason |
+| --- | --- | --- |
+| spectrum_systems/modules/runtime/lineage_authenticity.py | MODIFY | Remove default secret fallback, enforce issuer-scoped key resolution, and add freshness fields/signing helpers. |
+| spectrum_systems/modules/runtime/repo_write_lineage_guard.py | MODIFY | Strengthen authoritative repo-write validator with issuer/key binding, freshness checks, and replay rejection. |
+| spectrum_systems/modules/runtime/*.py | MODIFY (targeted) | Update lineage emitters (`build_admission_record`, `normalized_execution_request`, `tlc_handoff_record`) to emit new authenticity fields through a shared helper. |
+| contracts/schemas/build_admission_record.schema.json | MODIFY | Require new authenticity fields and strict shape for updated trust model. |
+| contracts/schemas/normalized_execution_request.schema.json | MODIFY | Require new authenticity fields and strict shape for updated trust model. |
+| contracts/schemas/tlc_handoff_record.schema.json | MODIFY | Require new authenticity fields and strict shape for updated trust model. |
+| contracts/examples/*.json | MODIFY (if present for changed contracts) | Keep examples aligned with contract requirements. |
+| tests/test_*lineage*.py | MODIFY | Add adversarial regression coverage for missing secret, issuer mismatch, forgery, freshness, and replay. |
+| tests/test_*pqx*.py | MODIFY | Add boundary-level forged-lineage rejection coverage through public caller path. |
+| docs/architecture/foundation_pqx_eval_control.md | MODIFY | Minimal truthfulness update about issuer-scoped authenticity and replay rejection. |
+
+## Contracts touched
+- `build_admission_record.schema.json`
+- `normalized_execution_request.schema.json`
+- `tlc_handoff_record.schema.json`
+- `contracts/standards-manifest.json` (version bumps for touched contract versions)
+
+## Tests that must pass after execution
+1. `pytest tests/test_repo_write_lineage_guard.py`
+2. `pytest tests/test_contracts.py tests/test_contract_enforcement.py`
+3. `python scripts/run_contract_enforcement.py`
+4. `pytest` (targeted boundary/runtime tests impacted by lineage guard updates)
+
+## Scope exclusions
+- Do not introduce external KMS, PKI, or distributed trust frameworks.
+- Do not redesign PQX architecture or broaden authorization model.
+- Do not duplicate repo-write validation logic outside the authoritative validator.
+- Do not modify unrelated governance or roadmap artifacts.
+
+## Dependencies
+- Existing AEX lineage authenticity and repo-write guard paths remain the integration seam.

--- a/spectrum_systems/modules/runtime/lineage_authenticity.py
+++ b/spectrum_systems/modules/runtime/lineage_authenticity.py
@@ -5,20 +5,68 @@ from __future__ import annotations
 import hashlib
 import hmac
 import os
+import uuid
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from spectrum_systems.utils.deterministic_id import canonical_json
 
-DEFAULT_KEY_ID = "local-system-v1"
-DEFAULT_SHARED_SECRET = "spectrum-lineage-auth-secret-v1"
+AUDIENCE_REPO_WRITE_BOUNDARY = "pqx_repo_write_boundary"
+ISSUER_DEFAULT_KEY_IDS = {
+    "AEX": "aex-hs256-v1",
+    "TLC": "tlc-hs256-v1",
+}
+_ISSUER_SECRET_ENV = {
+    "AEX": "SPECTRUM_LINEAGE_AUTH_SECRET_AEX",
+    "TLC": "SPECTRUM_LINEAGE_AUTH_SECRET_TLC",
+}
+_ISSUER_KEY_ENV = {
+    "AEX": "SPECTRUM_LINEAGE_AUTH_KEY_ID_AEX",
+    "TLC": "SPECTRUM_LINEAGE_AUTH_KEY_ID_TLC",
+}
 
 
-def _lineage_secret() -> str:
-    return str(os.environ.get("SPECTRUM_LINEAGE_AUTH_SECRET") or DEFAULT_SHARED_SECRET)
+class LineageAuthenticityError(ValueError):
+    """Raised when lineage authenticity material is missing or invalid."""
 
 
-def _lineage_key_id() -> str:
-    return str(os.environ.get("SPECTRUM_LINEAGE_AUTH_KEY_ID") or DEFAULT_KEY_ID)
+def _utc_now() -> datetime:
+    return datetime.now(tz=timezone.utc).replace(microsecond=0)
+
+
+def _format_timestamp(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _parse_timestamp(value: str) -> datetime:
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    return datetime.fromisoformat(text).astimezone(timezone.utc)
+
+
+def _require_issuer(issuer: str) -> str:
+    normalized = str(issuer or "").strip()
+    if normalized not in ISSUER_DEFAULT_KEY_IDS:
+        raise LineageAuthenticityError(f"authenticity_unknown_issuer:{normalized or 'missing'}")
+    return normalized
+
+
+def _issuer_secret(issuer: str) -> str:
+    required_issuer = _require_issuer(issuer)
+    env_name = _ISSUER_SECRET_ENV[required_issuer]
+    secret = os.environ.get(env_name)
+    if not isinstance(secret, str) or not secret.strip():
+        raise LineageAuthenticityError(f"authenticity_secret_missing_for_issuer:{required_issuer}")
+    return secret.strip()
+
+
+def _issuer_key_id(issuer: str) -> str:
+    required_issuer = _require_issuer(issuer)
+    configured = os.environ.get(_ISSUER_KEY_ENV[required_issuer])
+    if isinstance(configured, str) and configured.strip():
+        return configured.strip()
+    return ISSUER_DEFAULT_KEY_IDS[required_issuer]
 
 
 def _canonical_payload(artifact: dict[str, Any]) -> dict[str, Any]:
@@ -27,62 +75,163 @@ def _canonical_payload(artifact: dict[str, Any]) -> dict[str, Any]:
     return payload
 
 
+def _auth_scope(artifact: dict[str, Any]) -> str:
+    artifact_type = str(artifact.get("artifact_type") or "unknown")
+    request_id = str(artifact.get("request_id") or "missing")
+    trace_id = str(artifact.get("trace_id") or "missing")
+    return f"repo_write_lineage:{artifact_type}:{request_id}:{trace_id}"
+
+
 def compute_payload_digest(artifact: dict[str, Any]) -> str:
     digest = hashlib.sha256(canonical_json(_canonical_payload(artifact)).encode("utf-8")).hexdigest()
     return f"sha256:{digest}"
 
 
-def _compute_attestation(*, issuer: str, key_id: str, payload_digest: str, secret: str) -> str:
-    message = f"{issuer}|{key_id}|{payload_digest}".encode("utf-8")
+def _lineage_token_id() -> str:
+    return f"lin-{uuid.uuid4().hex[:24]}"
+
+
+def _compute_attestation(
+    *,
+    issuer: str,
+    key_id: str,
+    payload_digest: str,
+    audience: str,
+    scope: str,
+    issued_at: str,
+    expires_at: str,
+    lineage_token_id: str,
+    secret: str,
+) -> str:
+    message = f"{issuer}|{key_id}|{payload_digest}|{audience}|{scope}|{issued_at}|{expires_at}|{lineage_token_id}".encode("utf-8")
     return hmac.new(secret.encode("utf-8"), message, hashlib.sha256).hexdigest()
 
 
 def issue_authenticity(*, artifact: dict[str, Any], issuer: str) -> dict[str, str]:
-    key_id = _lineage_key_id()
+    required_issuer = _require_issuer(issuer)
+    key_id = _issuer_key_id(required_issuer)
     payload_digest = compute_payload_digest(artifact)
+    audience = AUDIENCE_REPO_WRITE_BOUNDARY
+    scope = _auth_scope(artifact)
+    issued_at_dt = _utc_now()
+    ttl_seconds = int(os.environ.get("SPECTRUM_LINEAGE_AUTH_TTL_SECONDS") or "900")
+    if ttl_seconds <= 0:
+        raise LineageAuthenticityError("authenticity_ttl_invalid")
+    issued_at = _format_timestamp(issued_at_dt)
+    expires_at = _format_timestamp(issued_at_dt + timedelta(seconds=ttl_seconds))
+    lineage_token_id = _lineage_token_id()
     return {
-        "issuer": issuer,
+        "issuer": required_issuer,
         "key_id": key_id,
         "payload_digest": payload_digest,
+        "audience": audience,
+        "scope": scope,
+        "issued_at": issued_at,
+        "expires_at": expires_at,
+        "lineage_token_id": lineage_token_id,
         "attestation": _compute_attestation(
-            issuer=issuer,
+            issuer=required_issuer,
             key_id=key_id,
             payload_digest=payload_digest,
-            secret=_lineage_secret(),
+            audience=audience,
+            scope=scope,
+            issued_at=issued_at,
+            expires_at=expires_at,
+            lineage_token_id=lineage_token_id,
+            secret=_issuer_secret(required_issuer),
         ),
     }
 
 
-def verify_authenticity(*, artifact: dict[str, Any], expected_issuer: str) -> None:
+def verify_authenticity(*, artifact: dict[str, Any], expected_issuer: str) -> dict[str, str]:
     authenticity = artifact.get("authenticity")
     if not isinstance(authenticity, dict):
-        raise ValueError("authenticity_required")
+        raise LineageAuthenticityError("authenticity_required")
 
-    issuer = authenticity.get("issuer")
+    issuer = _require_issuer(str(authenticity.get("issuer") or ""))
     if issuer != expected_issuer:
-        raise ValueError("authenticity_issuer_mismatch")
+        raise LineageAuthenticityError("authenticity_issuer_mismatch")
 
     key_id = authenticity.get("key_id")
     if not isinstance(key_id, str) or not key_id.strip():
-        raise ValueError("authenticity_key_id_required")
+        raise LineageAuthenticityError("authenticity_key_id_required")
+    expected_key_id = _issuer_key_id(issuer)
+    if key_id.strip() != expected_key_id:
+        raise LineageAuthenticityError("authenticity_issuer_key_binding_mismatch")
 
     payload_digest = authenticity.get("payload_digest")
     if not isinstance(payload_digest, str) or not payload_digest.strip():
-        raise ValueError("authenticity_payload_digest_required")
+        raise LineageAuthenticityError("authenticity_payload_digest_required")
 
     expected_payload_digest = compute_payload_digest(artifact)
     if payload_digest != expected_payload_digest:
-        raise ValueError("authenticity_payload_digest_mismatch")
+        raise LineageAuthenticityError("authenticity_payload_digest_mismatch")
 
+    audience = authenticity.get("audience")
+    if audience != AUDIENCE_REPO_WRITE_BOUNDARY:
+        raise LineageAuthenticityError("authenticity_audience_invalid")
+
+    scope = authenticity.get("scope")
+    if not isinstance(scope, str) or not scope.strip():
+        raise LineageAuthenticityError("authenticity_scope_required")
+    expected_scope = _auth_scope(artifact)
+    if scope != expected_scope:
+        raise LineageAuthenticityError("authenticity_scope_mismatch")
+
+    issued_at = authenticity.get("issued_at")
+    expires_at = authenticity.get("expires_at")
+    if not isinstance(issued_at, str) or not issued_at.strip():
+        raise LineageAuthenticityError("authenticity_issued_at_required")
+    if not isinstance(expires_at, str) or not expires_at.strip():
+        raise LineageAuthenticityError("authenticity_expires_at_required")
+
+    try:
+        issued_at_dt = _parse_timestamp(issued_at)
+        expires_at_dt = _parse_timestamp(expires_at)
+    except ValueError as exc:
+        raise LineageAuthenticityError("authenticity_timestamp_invalid") from exc
+
+    if issued_at_dt >= expires_at_dt:
+        raise LineageAuthenticityError("authenticity_expiry_order_invalid")
+
+    now = _utc_now()
+    if now > expires_at_dt:
+        raise LineageAuthenticityError("authenticity_expired")
+    if issued_at_dt > now + timedelta(seconds=5):
+        raise LineageAuthenticityError("authenticity_issued_in_future")
+
+    max_age_seconds = int(os.environ.get("SPECTRUM_LINEAGE_AUTH_MAX_AGE_SECONDS") or "3600")
+    if max_age_seconds <= 0:
+        raise LineageAuthenticityError("authenticity_max_age_invalid")
+    if now - issued_at_dt > timedelta(seconds=max_age_seconds):
+        raise LineageAuthenticityError("authenticity_stale")
+
+    lineage_token_id = authenticity.get("lineage_token_id")
+    if not isinstance(lineage_token_id, str) or not lineage_token_id.strip():
+        raise LineageAuthenticityError("authenticity_lineage_token_id_required")
     attestation = authenticity.get("attestation")
     if not isinstance(attestation, str) or not attestation.strip():
-        raise ValueError("authenticity_attestation_required")
+        raise LineageAuthenticityError("authenticity_attestation_required")
 
     expected_attestation = _compute_attestation(
         issuer=issuer,
-        key_id=key_id,
+        key_id=expected_key_id,
         payload_digest=payload_digest,
-        secret=_lineage_secret(),
+        audience=audience,
+        scope=expected_scope,
+        issued_at=issued_at,
+        expires_at=expires_at,
+        lineage_token_id=lineage_token_id,
+        secret=_issuer_secret(issuer),
     )
     if not hmac.compare_digest(attestation, expected_attestation):
-        raise ValueError("authenticity_attestation_mismatch")
+        raise LineageAuthenticityError("authenticity_attestation_mismatch")
+
+    return {
+        "issuer": issuer,
+        "key_id": expected_key_id,
+        "lineage_token_id": lineage_token_id,
+        "scope": expected_scope,
+        "audience": audience,
+        "issued_at": issued_at,
+    }

--- a/spectrum_systems/modules/runtime/pqx_sequence_runner.py
+++ b/spectrum_systems/modules/runtime/pqx_sequence_runner.py
@@ -1093,6 +1093,7 @@ def execute_sequence_run(
                 normalized_execution_request=lineage.get("normalized_execution_request"),
                 tlc_handoff_record=lineage.get("tlc_handoff_record"),
                 expected_trace_id=trace_id,
+                replay_context=run_id,
             )
         except (RepoWriteLineageGuardError, Exception) as exc:
             raise PQXSequenceRunnerError(f"direct_pqx_repo_write_forbidden:{exc}") from exc

--- a/spectrum_systems/modules/runtime/pqx_slice_runner.py
+++ b/spectrum_systems/modules/runtime/pqx_slice_runner.py
@@ -192,6 +192,8 @@ def _enforce_repo_write_lineage_boundary(
             build_admission_record=lineage.get("build_admission_record"),
             normalized_execution_request=lineage.get("normalized_execution_request"),
             tlc_handoff_record=lineage.get("tlc_handoff_record"),
+            enforce_replay_protection=False,
+            replay_context=run_id,
         )
     except (RepoWriteLineageGuardError, Exception) as exc:
         return _block_payload(

--- a/spectrum_systems/modules/runtime/repo_write_lineage_guard.py
+++ b/spectrum_systems/modules/runtime/repo_write_lineage_guard.py
@@ -2,14 +2,25 @@
 
 from __future__ import annotations
 
+from threading import Lock
 from typing import Any
 
 from spectrum_systems.contracts import validate_artifact
-from spectrum_systems.modules.runtime.lineage_authenticity import verify_authenticity
+from spectrum_systems.modules.runtime.lineage_authenticity import LineageAuthenticityError, verify_authenticity
 
 
 class RepoWriteLineageGuardError(ValueError):
     """Raised when repo-write lineage requirements are missing or invalid."""
+
+
+_CONSUMED_REPO_WRITE_LINEAGE_TOKENS: set[str] = set()
+_CONSUMED_REPO_WRITE_LINEAGE_LOCK = Lock()
+
+
+def reset_repo_write_lineage_replay_state() -> None:
+    """Test helper to reset in-process replay state."""
+    with _CONSUMED_REPO_WRITE_LINEAGE_LOCK:
+        _CONSUMED_REPO_WRITE_LINEAGE_TOKENS.clear()
 
 
 def _require_non_empty_string(value: Any, *, field: str) -> str:
@@ -18,12 +29,23 @@ def _require_non_empty_string(value: Any, *, field: str) -> str:
     return value.strip()
 
 
+def _consume_repo_write_lineage_tokens(tokens: list[str], *, replay_context: str | None = None) -> None:
+    token_key = "|".join(sorted(tokens))
+    replay_key = f"{replay_context}:{token_key}" if replay_context else token_key
+    with _CONSUMED_REPO_WRITE_LINEAGE_LOCK:
+        if replay_key in _CONSUMED_REPO_WRITE_LINEAGE_TOKENS:
+            raise RepoWriteLineageGuardError("repo_write_lineage_rejected:lineage_replay_detected")
+        _CONSUMED_REPO_WRITE_LINEAGE_TOKENS.add(replay_key)
+
+
 def validate_repo_write_lineage(
     *,
     build_admission_record: Any,
     normalized_execution_request: Any,
     tlc_handoff_record: Any,
     expected_trace_id: str | None = None,
+    enforce_replay_protection: bool = True,
+    replay_context: str | None = None,
 ) -> dict[str, str]:
     """Validate strict AEX->TLC lineage requirements for repo-write execution."""
 
@@ -34,14 +56,18 @@ def validate_repo_write_lineage(
     if not isinstance(tlc_handoff_record, dict):
         raise RepoWriteLineageGuardError("repo_write_lineage_rejected:tlc_handoff_record_required")
 
-    validate_artifact(build_admission_record, "build_admission_record")
-    validate_artifact(normalized_execution_request, "normalized_execution_request")
-    validate_artifact(tlc_handoff_record, "tlc_handoff_record")
     try:
-        verify_authenticity(artifact=build_admission_record, expected_issuer="AEX")
-        verify_authenticity(artifact=normalized_execution_request, expected_issuer="AEX")
-        verify_authenticity(artifact=tlc_handoff_record, expected_issuer="TLC")
-    except ValueError as exc:
+        validate_artifact(build_admission_record, "build_admission_record")
+        validate_artifact(normalized_execution_request, "normalized_execution_request")
+        validate_artifact(tlc_handoff_record, "tlc_handoff_record")
+    except Exception as exc:
+        raise RepoWriteLineageGuardError(f"repo_write_lineage_rejected:schema_invalid:{exc}") from exc
+
+    try:
+        admission_auth = verify_authenticity(artifact=build_admission_record, expected_issuer="AEX")
+        normalized_auth = verify_authenticity(artifact=normalized_execution_request, expected_issuer="AEX")
+        handoff_auth = verify_authenticity(artifact=tlc_handoff_record, expected_issuer="TLC")
+    except (ValueError, LineageAuthenticityError) as exc:
         raise RepoWriteLineageGuardError(f"repo_write_lineage_rejected:{exc}") from exc
 
     admission_status = _require_non_empty_string(build_admission_record.get("admission_status"), field="admission_status")
@@ -106,6 +132,14 @@ def validate_repo_write_lineage(
 
     _require_non_empty_string(build_admission_record.get("produced_by"), field="build_admission_record.produced_by")
     _require_non_empty_string(normalized_execution_request.get("produced_by"), field="normalized_execution_request.produced_by")
+
+    if enforce_replay_protection:
+        _consume_repo_write_lineage_tokens(
+            [
+                _require_non_empty_string(handoff_auth["lineage_token_id"], field="tlc_handoff_record.authenticity.lineage_token_id"),
+            ],
+            replay_context=replay_context,
+        )
 
     return {
         "trace_id": admission_trace_id,

--- a/spectrum_systems/modules/runtime/top_level_conductor.py
+++ b/spectrum_systems/modules/runtime/top_level_conductor.py
@@ -89,6 +89,7 @@ def _require_repo_write_admission(
             normalized_execution_request=normalized,
             tlc_handoff_record=tlc_handoff_record,
             expected_trace_id=expected_trace_id,
+            enforce_replay_protection=False,
         )
     except (RepoWriteLineageGuardError, Exception) as exc:
         raise TopLevelConductorError(f"repo_mutation_without_admission:{exc}") from exc

--- a/spectrum_systems/orchestration/pqx_handoff_adapter.py
+++ b/spectrum_systems/orchestration/pqx_handoff_adapter.py
@@ -70,6 +70,8 @@ def _require_repo_write_admission_lineage(*, cycle_id: str, request: Dict[str, A
             normalized_execution_request=normalized,
             tlc_handoff_record=tlc_handoff_record,
             expected_trace_id=expected_trace,
+            enforce_replay_protection=False,
+            replay_context=cycle_id,
         )
     except (RepoWriteLineageGuardError, Exception) as exc:
         raise PQXHandoffError(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,19 @@ from __future__ import annotations
 
 import os
 
+import pytest
 
-os.environ.setdefault("SPECTRUM_LINEAGE_AUTH_SECRET", "test-lineage-auth-secret")
-os.environ.setdefault("SPECTRUM_LINEAGE_AUTH_KEY_ID", "local-system-v1")
+from spectrum_systems.modules.runtime.repo_write_lineage_guard import reset_repo_write_lineage_replay_state
+
+
+os.environ.setdefault("SPECTRUM_LINEAGE_AUTH_SECRET_AEX", "test-lineage-auth-secret-aex")
+os.environ.setdefault("SPECTRUM_LINEAGE_AUTH_SECRET_TLC", "test-lineage-auth-secret-tlc")
+os.environ.setdefault("SPECTRUM_LINEAGE_AUTH_KEY_ID_AEX", "aex-hs256-v1")
+os.environ.setdefault("SPECTRUM_LINEAGE_AUTH_KEY_ID_TLC", "tlc-hs256-v1")
+os.environ.setdefault("SPECTRUM_LINEAGE_AUTH_TTL_SECONDS", "900")
+os.environ.setdefault("SPECTRUM_LINEAGE_AUTH_MAX_AGE_SECONDS", "3600")
+
+
+@pytest.fixture(autouse=True)
+def _reset_lineage_replay_state() -> None:
+    reset_repo_write_lineage_replay_state()

--- a/tests/test_cycle_runner.py
+++ b/tests/test_cycle_runner.py
@@ -480,6 +480,20 @@ def test_fix_reentry_repo_write_succeeds_with_admission_lineage(tmp_path: Path) 
     fix_roadmap_result = cycle_runner.run_cycle(manifest_path)
     assert fix_roadmap_result["next_state"] == "fix_roadmap_ready"
 
+    after_fix_roadmap = _load(manifest_path)
+    refreshed_request_path = Path(after_fix_roadmap["pqx_execution_request_path"])
+    refreshed_request = _load(refreshed_request_path)
+    refreshed_request["build_admission_record"]["authenticity"] = issue_authenticity(
+        artifact=refreshed_request["build_admission_record"], issuer="AEX"
+    )
+    refreshed_request["normalized_execution_request"]["authenticity"] = issue_authenticity(
+        artifact=refreshed_request["normalized_execution_request"], issuer="AEX"
+    )
+    refreshed_request["tlc_handoff_record"]["authenticity"] = issue_authenticity(
+        artifact=refreshed_request["tlc_handoff_record"], issuer="TLC"
+    )
+    _write(refreshed_request_path, refreshed_request)
+
     reentry_result = cycle_runner.run_cycle(manifest_path)
     assert reentry_result["status"] == "ok"
     assert reentry_result["next_state"] == "fixes_in_progress"

--- a/tests/test_pqx_repo_write_lineage_guard.py
+++ b/tests/test_pqx_repo_write_lineage_guard.py
@@ -1,19 +1,21 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from pathlib import Path
 
 import pytest
 
 from spectrum_systems.modules.runtime.lineage_authenticity import issue_authenticity
 from spectrum_systems.modules.runtime.pqx_sequence_runner import PQXSequenceRunnerError, execute_sequence_run
+from spectrum_systems.modules.runtime.repo_write_lineage_guard import RepoWriteLineageGuardError, validate_repo_write_lineage
 
 
 def _slice_requests() -> list[dict[str, str]]:
     return [{"slice_id": "fix-step:plan", "trace_id": "trace-repo-write"}]
 
 
-def _lineage() -> dict[str, object]:
-    lineage = {
+def _base_lineage() -> dict[str, object]:
+    return {
         "build_admission_record": {
             "artifact_type": "build_admission_record",
             "admission_id": "adm-1",
@@ -66,6 +68,10 @@ def _lineage() -> dict[str, object]:
             },
         },
     }
+
+
+def _lineage() -> dict[str, object]:
+    lineage = deepcopy(_base_lineage())
     lineage["build_admission_record"]["authenticity"] = issue_authenticity(artifact=lineage["build_admission_record"], issuer="AEX")
     lineage["normalized_execution_request"]["authenticity"] = issue_authenticity(
         artifact=lineage["normalized_execution_request"], issuer="AEX"
@@ -104,20 +110,6 @@ def test_pqx_rejects_repo_write_missing_trace_id(tmp_path: Path) -> None:
         )
 
 
-def test_pqx_allows_valid_repo_write_lineage(tmp_path: Path) -> None:
-    state = execute_sequence_run(
-        slice_requests=_slice_requests(),
-        state_path=tmp_path / "state.json",
-        queue_run_id="queue-1",
-        run_id="run-1",
-        trace_id="trace-repo-write",
-        max_slices=1,
-        execution_class="repo_write",
-        repo_write_lineage=_lineage(),
-    )
-    assert state["status"] in {"completed", "blocked", "failed"}
-
-
 def test_pqx_rejects_repo_write_with_missing_authenticity(tmp_path: Path) -> None:
     lineage = _lineage()
     lineage["build_admission_record"].pop("authenticity", None)
@@ -134,9 +126,111 @@ def test_pqx_rejects_repo_write_with_missing_authenticity(tmp_path: Path) -> Non
         )
 
 
-def test_pqx_rejects_repo_write_with_forged_authenticity(tmp_path: Path) -> None:
+def test_repo_write_lineage_rejects_default_or_missing_secret(monkeypatch: pytest.MonkeyPatch) -> None:
     lineage = _lineage()
-    lineage["build_admission_record"]["trace_id"] = "trace-forged"
+    monkeypatch.delenv("SPECTRUM_LINEAGE_AUTH_SECRET_AEX", raising=False)
+    monkeypatch.delenv("SPECTRUM_LINEAGE_AUTH_SECRET_TLC", raising=False)
+
+    with pytest.raises(RepoWriteLineageGuardError, match="authenticity_secret_missing_for_issuer"):
+        validate_repo_write_lineage(
+            build_admission_record=lineage["build_admission_record"],
+            normalized_execution_request=lineage["normalized_execution_request"],
+            tlc_handoff_record=lineage["tlc_handoff_record"],
+            expected_trace_id="trace-repo-write",
+        )
+
+
+def test_repo_write_lineage_rejects_wrong_issuer_key_binding(monkeypatch: pytest.MonkeyPatch) -> None:
+    lineage = _lineage()
+    tampered = deepcopy(lineage)
+    tampered["build_admission_record"]["authenticity"]["key_id"] = "tlc-hs256-v1"
+    with pytest.raises(RepoWriteLineageGuardError, match="authenticity_issuer_key_binding_mismatch"):
+        validate_repo_write_lineage(
+            build_admission_record=tampered["build_admission_record"],
+            normalized_execution_request=tampered["normalized_execution_request"],
+            tlc_handoff_record=tampered["tlc_handoff_record"],
+            expected_trace_id="trace-repo-write",
+        )
+
+
+def test_repo_write_lineage_rejects_forged_lineage_with_old_default_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    forged = deepcopy(_base_lineage())
+    legacy_auth = {
+        "issuer": "AEX",
+        "key_id": "local-system-v1",
+        "payload_digest": "sha256:" + ("0" * 64),
+        "attestation": "0" * 64,
+    }
+    forged["build_admission_record"]["authenticity"] = dict(legacy_auth)
+    forged["normalized_execution_request"]["authenticity"] = dict(legacy_auth)
+    forged["tlc_handoff_record"]["authenticity"] = {**legacy_auth, "issuer": "TLC"}
+    monkeypatch.setenv("SPECTRUM_LINEAGE_AUTH_SECRET", "spectrum-lineage-auth-secret-v1")
+
+    with pytest.raises(RepoWriteLineageGuardError, match="schema_invalid|authenticity_issuer_key_binding_mismatch|authenticity_audience_invalid"):
+        validate_repo_write_lineage(
+            build_admission_record=forged["build_admission_record"],
+            normalized_execution_request=forged["normalized_execution_request"],
+            tlc_handoff_record=forged["tlc_handoff_record"],
+            expected_trace_id="trace-repo-write",
+        )
+
+
+def test_repo_write_lineage_rejects_replay() -> None:
+    lineage = _lineage()
+    validate_repo_write_lineage(
+        build_admission_record=lineage["build_admission_record"],
+        normalized_execution_request=lineage["normalized_execution_request"],
+        tlc_handoff_record=lineage["tlc_handoff_record"],
+        expected_trace_id="trace-repo-write",
+    )
+    with pytest.raises(RepoWriteLineageGuardError, match="lineage_replay_detected"):
+        validate_repo_write_lineage(
+            build_admission_record=lineage["build_admission_record"],
+            normalized_execution_request=lineage["normalized_execution_request"],
+            tlc_handoff_record=lineage["tlc_handoff_record"],
+            expected_trace_id="trace-repo-write",
+        )
+
+
+def test_repo_write_lineage_rejects_stale_or_wrong_audience(monkeypatch: pytest.MonkeyPatch) -> None:
+    wrong_audience = _lineage()
+    wrong_audience["build_admission_record"]["authenticity"]["audience"] = "not_pqx"
+    with pytest.raises(RepoWriteLineageGuardError, match="schema_invalid|authenticity_audience_invalid"):
+        validate_repo_write_lineage(
+            build_admission_record=wrong_audience["build_admission_record"],
+            normalized_execution_request=wrong_audience["normalized_execution_request"],
+            tlc_handoff_record=wrong_audience["tlc_handoff_record"],
+            expected_trace_id="trace-repo-write",
+        )
+
+    stale = _lineage()
+    stale["build_admission_record"]["authenticity"]["issued_at"] = "2020-01-01T00:00:00Z"
+    stale["build_admission_record"]["authenticity"]["expires_at"] = "2030-01-01T00:00:00Z"
+    monkeypatch.setenv("SPECTRUM_LINEAGE_AUTH_MAX_AGE_SECONDS", "1")
+    with pytest.raises(RepoWriteLineageGuardError, match="authenticity_stale|authenticity_attestation_mismatch"):
+        validate_repo_write_lineage(
+            build_admission_record=stale["build_admission_record"],
+            normalized_execution_request=stale["normalized_execution_request"],
+            tlc_handoff_record=stale["tlc_handoff_record"],
+            expected_trace_id="trace-repo-write",
+        )
+
+
+def test_repo_write_lineage_accepts_valid_fresh_authentic_lineage() -> None:
+    lineage = _lineage()
+    validated = validate_repo_write_lineage(
+        build_admission_record=lineage["build_admission_record"],
+        normalized_execution_request=lineage["normalized_execution_request"],
+        tlc_handoff_record=lineage["tlc_handoff_record"],
+        expected_trace_id="trace-repo-write",
+    )
+    assert validated["trace_id"] == "trace-repo-write"
+    assert validated["request_id"] == "req-1"
+
+
+def test_pqx_boundary_rejects_repo_write_with_forged_lineage(tmp_path: Path) -> None:
+    lineage = _lineage()
+    lineage["build_admission_record"]["authenticity"]["scope"] = "repo_write_lineage:build_admission_record:req-1:forged"
     with pytest.raises(PQXSequenceRunnerError, match="direct_pqx_repo_write_forbidden"):
         execute_sequence_run(
             slice_requests=_slice_requests(),
@@ -148,3 +242,17 @@ def test_pqx_rejects_repo_write_with_forged_authenticity(tmp_path: Path) -> None
             execution_class="repo_write",
             repo_write_lineage=lineage,
         )
+
+
+def test_pqx_allows_valid_repo_write_lineage(tmp_path: Path) -> None:
+    state = execute_sequence_run(
+        slice_requests=_slice_requests(),
+        state_path=tmp_path / "state.json",
+        queue_run_id="queue-1",
+        run_id="run-1",
+        trace_id="trace-repo-write",
+        max_slices=1,
+        execution_class="repo_write",
+        repo_write_lineage=_lineage(),
+    )
+    assert state["status"] in {"completed", "blocked", "failed"}


### PR DESCRIPTION
### Motivation

- Close a trust-model gap that allowed forged or replayed repo-write lineage by removing a global default secret and enforcing issuer-scoped authenticity. 
- Ensure repo-write PQX execution only proceeds when lineage is schema-valid, continuity-valid, authenticity-valid, issuer-bound, and fresh / non-replayed. 

### Description

- Remove the insecure default shared secret and require issuer-scoped secrets, lookupable via `SPECTRUM_LINEAGE_AUTH_SECRET_AEX` and `SPECTRUM_LINEAGE_AUTH_SECRET_TLC`, with typed failure if missing (`spectrum_systems/modules/runtime/lineage_authenticity.py`).
- Extend the authenticity payload to include `audience`, `scope`, `issued_at`, `expires_at`, and `lineage_token_id`, include them in the HMAC attestation, and enforce freshness/ttl checks during verification.
- Enforce issuer→key_id binding and deterministic issuer key id mapping, and strengthen `verify_authenticity(...)` to fail closed on any mismatch or malformed fields.
- Add replay-protection token consumption and replay-context scoping in the authoritative validator `validate_repo_write_lineage(...)` and wire callers to validate without double-consuming where appropriate (`spectrum_systems/modules/runtime/repo_write_lineage_guard.py`, `pqx_*` and `top_level_conductor` caller changes).
- Update the three affected schemas and example artifacts to require the new authenticity fields, bump contract manifest entries, and add a minimal doc note and PLAN file describing the change set.
- Add test fixtures and adversarial regression tests to prove missing-secret, wrong issuer/key binding, legacy-default-secret forgery, stale/wrong-audience, replay, and valid acceptance behaviors (`tests/*`).

### Testing

- Ran `pytest tests/test_pqx_repo_write_lineage_guard.py` and observed all tests pass (`11 passed`).
- Ran a broader integration set with `pytest tests/test_tlc_requires_admission_for_repo_write.py tests/test_cycle_runner.py tests/test_pqx_slice_runner.py tests/test_pqx_handoff_adapter.py tests/test_pqx_repo_write_lineage_guard.py` and observed all tests pass.
- Verified contract changes by running `pytest tests/test_contracts.py tests/test_contract_enforcement.py` and `python scripts/run_contract_enforcement.py`, with enforcement and schema checks passing.
- Additional targeted validation including `pytest tests/test_aex_admission.py` and selected cycle/hand-off integration tests were executed and passed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d787f993a883298b29613f3fbc09af)