### PR TITLE
BATCH-AEX-FIX-08: require persisted authoritative issuance for repo-write lineage

### DIFF
--- a/docs/architecture/foundation_pqx_eval_control.md
+++ b/docs/architecture/foundation_pqx_eval_control.md
@@ -112,6 +112,7 @@ Any such divergence must trigger hardening-first roadmap sequencing.
 - The AEX→TLC seam is contractized via `tlc_handoff_record` to make admission-to-orchestration lineage explicit and replayable for repo-mutating execution.
 - Enforcement is fail-closed end-to-end: missing/invalid AEX artifacts block TLC entry, and missing/unknown execution intent or missing TLC lineage blocks PQX execution (`AEX → TLC → TPA → PQX` only).
 - Repo-write lineage authenticity issuance is boundary-owned: only authoritative AEX emission paths can sign `normalized_execution_request` / `build_admission_record`, and only authoritative TLC handoff emission paths can sign `tlc_handoff_record`.
+- Repo-write lineage acceptance at PQX now requires **both** valid authenticity and persisted authoritative issuance proof from the boundary-owned issuance registry; valid signatures alone are rejected when issuance records are missing or mismatched.
 - Repo-write lineage replay protection is persistent and system-wide (repo-native consumed-token registry), so replay is rejected across process boundaries, not only within one process.
 - PQX repo-write capability detection uses canonical resolved runtime paths (including symlink traversal) and fails closed when path classification is ambiguous, so lexical path tricks cannot bypass lineage requirements.
 

--- a/docs/review-actions/PLAN-BATCH-AEX-FIX-08-2026-04-09.md
+++ b/docs/review-actions/PLAN-BATCH-AEX-FIX-08-2026-04-09.md
@@ -1,0 +1,32 @@
+# Plan — BATCH-AEX-FIX-08 — 2026-04-09
+
+## Prompt type
+PLAN
+
+## Roadmap item
+BATCH-AEX-FIX-08
+
+## Objective
+Make repo-write lineage acceptance authoritative by requiring persisted issuance registry confirmation in addition to schema, continuity, authenticity, freshness, and replay checks.
+
+## Declared files
+| File | Change type | Reason |
+| --- | --- | --- |
+| docs/review-actions/PLAN-BATCH-AEX-FIX-08-2026-04-09.md | CREATE | Required plan-first record for multi-file change set. |
+| spectrum_systems/modules/runtime/lineage_issuance_registry.py | CREATE | Add narrow persisted issuance registry helper for authoritative lineage artifacts. |
+| spectrum_systems/modules/runtime/lineage_authenticity.py | MODIFY | Automatically record issuance from authoritative issuer paths when authenticity is issued. |
+| spectrum_systems/modules/runtime/repo_write_lineage_guard.py | MODIFY | Require registry-backed issuance confirmation in authoritative repo-write lineage validation. |
+| tests/conftest.py | MODIFY | Reset issuance registry state per test for deterministic execution. |
+| tests/test_pqx_repo_write_lineage_guard.py | MODIFY | Add regression tests proving forged-but-valid lineage is rejected without authoritative issuance registry confirmation. |
+| docs/architecture/foundation_pqx_eval_control.md | MODIFY | Document that PQX repo-write lineage acceptance requires registry-backed authoritative issuance proof. |
+
+## Scope exclusions
+- No external KMS or public-key redesign.
+- No role changes for AEX/TLC/PQX.
+- No generic new platform subsystem.
+- No caller-by-caller policy rewrite.
+
+## Validation commands
+1. `pytest tests/test_pqx_repo_write_lineage_guard.py`
+2. `pytest tests/test_aex_admission.py tests/test_tlc_handoff_flow.py tests/test_pqx_handoff_adapter.py tests/test_pqx_slice_runner.py tests/test_cycle_runner.py tests/test_tlc_requires_admission_for_repo_write.py`
+3. `pytest tests/test_contracts.py`

--- a/spectrum_systems/modules/runtime/lineage_authenticity.py
+++ b/spectrum_systems/modules/runtime/lineage_authenticity.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from spectrum_systems.utils.deterministic_id import canonical_json
+from spectrum_systems.modules.runtime.lineage_issuance_registry import record_authoritative_lineage_issuance
 
 AUDIENCE_REPO_WRITE_BOUNDARY = "pqx_repo_write_boundary"
 ISSUER_DEFAULT_KEY_IDS = {
@@ -164,7 +165,7 @@ def issue_authenticity(*, artifact: dict[str, Any], issuer: str) -> dict[str, st
     issued_at = _format_timestamp(issued_at_dt)
     expires_at = _format_timestamp(issued_at_dt + timedelta(seconds=ttl_seconds))
     lineage_token_id = _lineage_token_id()
-    return {
+    authenticity = {
         "issuer": required_issuer,
         "key_id": key_id,
         "payload_digest": payload_digest,
@@ -185,6 +186,14 @@ def issue_authenticity(*, artifact: dict[str, Any], issuer: str) -> dict[str, st
             secret=_issuer_secret(required_issuer),
         ),
     }
+    record_authoritative_lineage_issuance(
+        artifact=artifact,
+        issuer=required_issuer,
+        key_id=authenticity["key_id"],
+        payload_digest=authenticity["payload_digest"],
+        issued_at=authenticity["issued_at"],
+    )
+    return authenticity
 
 
 def verify_authenticity(*, artifact: dict[str, Any], expected_issuer: str) -> dict[str, str]:
@@ -274,6 +283,7 @@ def verify_authenticity(*, artifact: dict[str, Any], expected_issuer: str) -> di
     return {
         "issuer": issuer,
         "key_id": expected_key_id,
+        "payload_digest": payload_digest,
         "lineage_token_id": lineage_token_id,
         "scope": expected_scope,
         "audience": audience,

--- a/spectrum_systems/modules/runtime/lineage_issuance_registry.py
+++ b/spectrum_systems/modules/runtime/lineage_issuance_registry.py
@@ -1,0 +1,207 @@
+"""Persisted authoritative issuance registry for repo-write lineage artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from threading import Lock
+from typing import Any
+
+from spectrum_systems.modules.pqx_backbone import REPO_ROOT
+
+
+class LineageIssuanceRegistryError(ValueError):
+    """Raised when lineage issuance registry state is missing, invalid, or mismatched."""
+
+
+_ISSUANCE_REGISTRY_PATH = REPO_ROOT / "state" / "lineage_issuance_registry.json"
+_ISSUANCE_REGISTRY_LOCK = Lock()
+
+_EXPECTED_ISSUER_BY_ARTIFACT = {
+    "build_admission_record": "AEX",
+    "normalized_execution_request": "AEX",
+    "tlc_handoff_record": "TLC",
+}
+
+_ARTIFACT_ID_FIELD_BY_TYPE = {
+    "build_admission_record": "admission_id",
+    "normalized_execution_request": "request_id",
+    "tlc_handoff_record": "handoff_id",
+}
+
+
+def _require_non_empty_string(value: Any, *, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise LineageIssuanceRegistryError(f"lineage_issuance_registry_invalid:{field}_required")
+    return value.strip()
+
+
+def _artifact_identity(artifact: dict[str, Any]) -> tuple[str, str]:
+    artifact_type = _require_non_empty_string(artifact.get("artifact_type"), field="artifact_type")
+    id_field = _ARTIFACT_ID_FIELD_BY_TYPE.get(artifact_type)
+    if not id_field:
+        raise LineageIssuanceRegistryError(f"lineage_issuance_registry_invalid:unsupported_artifact_type:{artifact_type}")
+    artifact_id = _require_non_empty_string(artifact.get(id_field), field=f"{artifact_type}.{id_field}")
+    return artifact_type, artifact_id
+
+
+def _issuance_record_id(
+    *,
+    artifact_type: str,
+    artifact_id: str,
+    issuer: str,
+    key_id: str,
+    payload_digest: str,
+    request_id: str,
+    trace_id: str,
+) -> str:
+    material = f"{artifact_type}|{artifact_id}|{issuer}|{key_id}|{payload_digest}|{request_id}|{trace_id}"
+    digest = hashlib.sha256(material.encode("utf-8")).hexdigest()[:24]
+    return f"lir-{digest}"
+
+
+def _read_registry(path: Path) -> dict[str, dict[str, str]]:
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise LineageIssuanceRegistryError("lineage_issuance_registry_unreadable") from exc
+    if not isinstance(payload, dict):
+        raise LineageIssuanceRegistryError("lineage_issuance_registry_invalid")
+    records = payload.get("issuance_records")
+    if not isinstance(records, list):
+        raise LineageIssuanceRegistryError("lineage_issuance_registry_invalid")
+
+    indexed: dict[str, dict[str, str]] = {}
+    required_fields = {
+        "issuance_record_id",
+        "artifact_type",
+        "artifact_id",
+        "issuer",
+        "key_id",
+        "payload_digest",
+        "trace_id",
+        "request_id",
+        "issued_at",
+    }
+    for record in records:
+        if not isinstance(record, dict):
+            raise LineageIssuanceRegistryError("lineage_issuance_registry_invalid")
+        normalized: dict[str, str] = {}
+        for field in required_fields:
+            normalized[field] = _require_non_empty_string(record.get(field), field=f"issuance_records.{field}")
+        indexed[normalized["issuance_record_id"]] = normalized
+    return indexed
+
+
+def _write_registry(path: Path, indexed: dict[str, dict[str, str]]) -> None:
+    payload = {
+        "schema_version": "1.0",
+        "issuance_records": [indexed[key] for key in sorted(indexed)],
+    }
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = path.with_suffix(".tmp")
+        tmp_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        tmp_path.replace(path)
+    except OSError as exc:
+        raise LineageIssuanceRegistryError("lineage_issuance_registry_write_failed") from exc
+
+
+def record_authoritative_lineage_issuance(
+    *,
+    artifact: dict[str, Any],
+    issuer: str,
+    key_id: str,
+    payload_digest: str,
+    issued_at: str,
+) -> dict[str, str]:
+    artifact_type, artifact_id = _artifact_identity(artifact)
+    expected_issuer = _EXPECTED_ISSUER_BY_ARTIFACT[artifact_type]
+    if issuer != expected_issuer:
+        raise LineageIssuanceRegistryError("lineage_issuance_registry_invalid:issuer_artifact_mismatch")
+
+    request_id = _require_non_empty_string(artifact.get("request_id"), field=f"{artifact_type}.request_id")
+    trace_id = _require_non_empty_string(artifact.get("trace_id"), field=f"{artifact_type}.trace_id")
+    normalized_key_id = _require_non_empty_string(key_id, field="key_id")
+    normalized_digest = _require_non_empty_string(payload_digest, field="payload_digest")
+    normalized_issued_at = _require_non_empty_string(issued_at, field="issued_at")
+
+    issuance_record_id = _issuance_record_id(
+        artifact_type=artifact_type,
+        artifact_id=artifact_id,
+        issuer=issuer,
+        key_id=normalized_key_id,
+        payload_digest=normalized_digest,
+        request_id=request_id,
+        trace_id=trace_id,
+    )
+    entry = {
+        "issuance_record_id": issuance_record_id,
+        "artifact_type": artifact_type,
+        "artifact_id": artifact_id,
+        "issuer": issuer,
+        "key_id": normalized_key_id,
+        "payload_digest": normalized_digest,
+        "trace_id": trace_id,
+        "request_id": request_id,
+        "issued_at": normalized_issued_at,
+    }
+
+    with _ISSUANCE_REGISTRY_LOCK:
+        indexed = _read_registry(_ISSUANCE_REGISTRY_PATH)
+        indexed[issuance_record_id] = entry
+        _write_registry(_ISSUANCE_REGISTRY_PATH, indexed)
+    return dict(entry)
+
+
+def verify_authoritative_lineage_issuance(
+    *,
+    artifact: dict[str, Any],
+    issuer: str,
+    key_id: str,
+    payload_digest: str,
+) -> dict[str, str]:
+    artifact_type, artifact_id = _artifact_identity(artifact)
+    request_id = _require_non_empty_string(artifact.get("request_id"), field=f"{artifact_type}.request_id")
+    trace_id = _require_non_empty_string(artifact.get("trace_id"), field=f"{artifact_type}.trace_id")
+    normalized_key_id = _require_non_empty_string(key_id, field="key_id")
+    normalized_digest = _require_non_empty_string(payload_digest, field="payload_digest")
+
+    issuance_record_id = _issuance_record_id(
+        artifact_type=artifact_type,
+        artifact_id=artifact_id,
+        issuer=issuer,
+        key_id=normalized_key_id,
+        payload_digest=normalized_digest,
+        request_id=request_id,
+        trace_id=trace_id,
+    )
+
+    with _ISSUANCE_REGISTRY_LOCK:
+        indexed = _read_registry(_ISSUANCE_REGISTRY_PATH)
+    record = indexed.get(issuance_record_id)
+    if not record:
+        raise LineageIssuanceRegistryError("lineage_issuance_missing")
+
+    expected_pairs = {
+        "artifact_type": artifact_type,
+        "artifact_id": artifact_id,
+        "issuer": issuer,
+        "key_id": normalized_key_id,
+        "payload_digest": normalized_digest,
+        "request_id": request_id,
+        "trace_id": trace_id,
+    }
+    for field, expected_value in expected_pairs.items():
+        if record.get(field) != expected_value:
+            raise LineageIssuanceRegistryError(f"lineage_issuance_mismatch:{field}")
+    return dict(record)
+
+
+def reset_lineage_issuance_registry_state(*, clear_persistent_registry: bool = False) -> None:
+    """Test helper to clear persisted issuance registry state."""
+    if clear_persistent_registry and _ISSUANCE_REGISTRY_PATH.exists():
+        _ISSUANCE_REGISTRY_PATH.unlink()

--- a/spectrum_systems/modules/runtime/repo_write_lineage_guard.py
+++ b/spectrum_systems/modules/runtime/repo_write_lineage_guard.py
@@ -10,6 +10,10 @@ from typing import Any
 from spectrum_systems.contracts import validate_artifact
 from spectrum_systems.modules.pqx_backbone import REPO_ROOT
 from spectrum_systems.modules.runtime.lineage_authenticity import LineageAuthenticityError, verify_authenticity
+from spectrum_systems.modules.runtime.lineage_issuance_registry import (
+    LineageIssuanceRegistryError,
+    verify_authoritative_lineage_issuance,
+)
 
 
 class RepoWriteLineageGuardError(ValueError):
@@ -111,6 +115,27 @@ def validate_repo_write_lineage(
         normalized_auth = verify_authenticity(artifact=normalized_execution_request, expected_issuer="AEX")
         handoff_auth = verify_authenticity(artifact=tlc_handoff_record, expected_issuer="TLC")
     except (ValueError, LineageAuthenticityError) as exc:
+        raise RepoWriteLineageGuardError(f"repo_write_lineage_rejected:{exc}") from exc
+    try:
+        verify_authoritative_lineage_issuance(
+            artifact=build_admission_record,
+            issuer="AEX",
+            key_id=admission_auth["key_id"],
+            payload_digest=admission_auth["payload_digest"],
+        )
+        verify_authoritative_lineage_issuance(
+            artifact=normalized_execution_request,
+            issuer="AEX",
+            key_id=normalized_auth["key_id"],
+            payload_digest=normalized_auth["payload_digest"],
+        )
+        verify_authoritative_lineage_issuance(
+            artifact=tlc_handoff_record,
+            issuer="TLC",
+            key_id=handoff_auth["key_id"],
+            payload_digest=handoff_auth["payload_digest"],
+        )
+    except LineageIssuanceRegistryError as exc:
         raise RepoWriteLineageGuardError(f"repo_write_lineage_rejected:{exc}") from exc
 
     admission_status = _require_non_empty_string(build_admission_record.get("admission_status"), field="admission_status")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import os
 import pytest
 
 from spectrum_systems.modules.runtime.repo_write_lineage_guard import reset_repo_write_lineage_replay_state
+from spectrum_systems.modules.runtime.lineage_issuance_registry import reset_lineage_issuance_registry_state
 
 
 os.environ.setdefault("SPECTRUM_LINEAGE_AUTH_SECRET_AEX", "test-lineage-auth-secret-aex")
@@ -18,3 +19,4 @@ os.environ.setdefault("SPECTRUM_LINEAGE_AUTH_MAX_AGE_SECONDS", "3600")
 @pytest.fixture(autouse=True)
 def _reset_lineage_replay_state() -> None:
     reset_repo_write_lineage_replay_state()
+    reset_lineage_issuance_registry_state(clear_persistent_registry=True)

--- a/tests/test_pqx_repo_write_lineage_guard.py
+++ b/tests/test_pqx_repo_write_lineage_guard.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+import json
 from pathlib import Path
 
 import pytest
@@ -12,6 +13,7 @@ from spectrum_systems.modules.runtime.repo_write_lineage_guard import (
     reset_repo_write_lineage_replay_state,
     validate_repo_write_lineage,
 )
+from spectrum_systems.modules.runtime.lineage_issuance_registry import _ISSUANCE_REGISTRY_PATH
 from tests.helpers_repo_write_lineage import build_valid_repo_write_lineage
 
 
@@ -273,10 +275,70 @@ def test_repo_write_lineage_accepts_valid_fresh_authentic_lineage() -> None:
     assert validated["request_id"] == "req-1"
 
 
+def test_repo_write_lineage_rejects_valid_signature_without_registry_issuance() -> None:
+    lineage = _lineage()
+    if _ISSUANCE_REGISTRY_PATH.exists():
+        _ISSUANCE_REGISTRY_PATH.unlink()
+    with pytest.raises(RepoWriteLineageGuardError, match="lineage_issuance_missing"):
+        validate_repo_write_lineage(
+            build_admission_record=lineage["build_admission_record"],
+            normalized_execution_request=lineage["normalized_execution_request"],
+            tlc_handoff_record=lineage["tlc_handoff_record"],
+            expected_trace_id="trace-repo-write",
+        )
+
+
+def test_repo_write_lineage_accepts_valid_signature_with_registry_issuance() -> None:
+    lineage = _lineage()
+    validated = validate_repo_write_lineage(
+        build_admission_record=lineage["build_admission_record"],
+        normalized_execution_request=lineage["normalized_execution_request"],
+        tlc_handoff_record=lineage["tlc_handoff_record"],
+        expected_trace_id="trace-repo-write",
+    )
+    assert validated["request_id"] == "req-1"
+
+
+def test_repo_write_lineage_rejects_forged_registry_mismatch() -> None:
+    lineage = _lineage()
+    payload = json.loads(_ISSUANCE_REGISTRY_PATH.read_text(encoding="utf-8"))
+    records = payload["issuance_records"]
+    admission_ref = f"build_admission_record:{lineage['build_admission_record']['admission_id']}"
+    for record in records:
+        if record.get("artifact_type") == "build_admission_record" and record.get("artifact_id") == admission_ref.split(":")[1]:
+            record["key_id"] = "forged-key-id"
+            break
+    _ISSUANCE_REGISTRY_PATH.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    with pytest.raises(RepoWriteLineageGuardError, match="lineage_issuance_mismatch:key_id"):
+        validate_repo_write_lineage(
+            build_admission_record=lineage["build_admission_record"],
+            normalized_execution_request=lineage["normalized_execution_request"],
+            tlc_handoff_record=lineage["tlc_handoff_record"],
+            expected_trace_id="trace-repo-write",
+        )
+
+
 def test_pqx_boundary_rejects_repo_write_with_forged_lineage(tmp_path: Path) -> None:
     lineage = _lineage()
     lineage["build_admission_record"]["authenticity"]["scope"] = "repo_write_lineage:build_admission_record:req-1:forged"
     with pytest.raises(PQXSequenceRunnerError, match="direct_pqx_repo_write_forbidden"):
+        execute_sequence_run(
+            slice_requests=_slice_requests(),
+            state_path=tmp_path / "state.json",
+            queue_run_id="queue-1",
+            run_id="run-1",
+            trace_id="trace-repo-write",
+            max_slices=1,
+            execution_class="repo_write",
+            repo_write_lineage=lineage,
+        )
+
+
+def test_run_pqx_slice_rejects_forged_lineage_even_if_signature_is_valid(tmp_path: Path) -> None:
+    lineage = _lineage()
+    if _ISSUANCE_REGISTRY_PATH.exists():
+        _ISSUANCE_REGISTRY_PATH.unlink()
+    with pytest.raises(PQXSequenceRunnerError, match="direct_pqx_repo_write_forbidden:repo_write_lineage_rejected:lineage_issuance_missing"):
         execute_sequence_run(
             slice_requests=_slice_requests(),
             state_path=tmp_path / "state.json",


### PR DESCRIPTION
### Motivation
- Close the remaining trust gap where PQX accepted repo-write lineage solely on cryptographic validity, allowing forged-but-valid artifacts to pass. 
- Implement a minimal, repo-native authoritative issuance proof so PQX can confirm artifacts were actually issued by AEX/TLC, not just signed by a key reachable at runtime. 
- Keep the change surgical: preserve AEX/TLC/TLC roles, reuse existing authenticity material, and avoid external KMS or broad platform additions.

### Description
- Add a narrow persisted issuance registry at `spectrum_systems/modules/runtime/lineage_issuance_registry.py` that records deterministic issuance records (artifact_type, artifact_id, issuer, key_id, payload_digest, trace_id, request_id, issued_at, issuance_record_id). 
- Make `issue_authenticity(...)` in `spectrum_systems/modules/runtime/lineage_authenticity.py` automatically record authoritative issuance via the new registry so AEX/TLC emission paths persist issuance proof without caller intervention. 
- Strengthen `validate_repo_write_lineage(...)` in `spectrum_systems/modules/runtime/repo_write_lineage_guard.py` to require both authenticity verification and registry-backed issuance confirmation for `build_admission_record`, `normalized_execution_request`, and `tlc_handoff_record`, rejecting when issuance is missing or mismatched. 
- Add deterministic test fixture cleanup in `tests/conftest.py`, extend `tests/test_pqx_repo_write_lineage_guard.py` with regression tests proving forged-but-valid lineage is rejected without registry proof and that mismatched registry entries fail, and update a concise architecture note in `docs/architecture/foundation_pqx_eval_control.md` plus a plan artifact `docs/review-actions/PLAN-BATCH-AEX-FIX-08-2026-04-09.md`.

### Testing
- Ran `pytest tests/test_pqx_repo_write_lineage_guard.py` and all tests in that file passed (17 passed). 
- Ran the related runtime path tests `pytest tests/test_aex_admission.py tests/test_tlc_handoff_flow.py tests/test_pqx_handoff_adapter.py tests/test_pqx_slice_runner.py tests/test_cycle_runner.py tests/test_tlc_requires_admission_for_repo_write.py` and they all passed (105 passed). 
- Ran contract validations with `pytest tests/test_contracts.py` and they all passed (79 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7d8611d008329ab471f9cfddbd497)