### PR TITLE
BATCH-CTX-A: Governed context foundation (CTX-01..CTX-06) — contracts + AEX→TLC→TPA→PQX flow

### DIFF
--- a/contracts/examples/context_bundle_record.json
+++ b/contracts/examples/context_bundle_record.json
@@ -1,0 +1,22 @@
+{
+  "artifact_kind": "context_bundle_record",
+  "artifact_id": "ctxbrec-001",
+  "created_at": "2026-04-09T00:00:00Z",
+  "schema_ref": "contracts/schemas/context_bundle_record.schema.json",
+  "trace": {"trace_id": "trace-ctx-a", "run_id": "run-ctx-a"},
+  "bundle_id": "bundle-001",
+  "recipe_id": "recipe-core",
+  "recipe_version": "1.0.0",
+  "bundle_manifest_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "source_refs": ["source:alpha", "source:beta"],
+  "provenance_summary": {"source_count": 2, "provenance_refs": ["prov:1", "prov:2"]},
+  "trust_summary": {"min_trust_class": "trusted", "blocked_source_count": 0, "policy_ref": "policy:tpa:ctx:1.0.0"},
+  "admissibility_status": "approved",
+  "assembly_budget": {"max_sources": 4, "max_tokens": 2048, "consumed_sources": 2, "consumed_tokens": 512},
+  "lineage": {
+    "aex_admission_ref": "build_admission_record:adm-123",
+    "normalized_request_ref": "normalized_execution_request:req-123",
+    "tlc_handoff_ref": "tlc_handoff_record:tlc-123",
+    "tpa_slice_ref": "tpa_slice_artifact:tpa-123"
+  }
+}

--- a/contracts/examples/context_conflict_record.json
+++ b/contracts/examples/context_conflict_record.json
@@ -1,0 +1,13 @@
+{
+  "artifact_kind": "context_conflict_record",
+  "artifact_id": "ctxconf-001",
+  "created_at": "2026-04-09T00:00:00Z",
+  "schema_ref": "contracts/schemas/context_conflict_record.schema.json",
+  "trace": {"trace_id": "trace-ctx-a", "run_id": "run-ctx-a"},
+  "bundle_id": "bundle-001",
+  "conflicting_source_refs": ["source:alpha", "source:beta"],
+  "conflict_type": "fact_mismatch",
+  "conflict_summary": "Source alpha and beta disagree on ownership mapping.",
+  "severity": "high",
+  "resolution_required": true
+}

--- a/contracts/examples/context_recipe_spec.json
+++ b/contracts/examples/context_recipe_spec.json
@@ -1,0 +1,16 @@
+{
+  "artifact_kind": "context_recipe_spec",
+  "artifact_id": "ctxrecipe-001",
+  "created_at": "2026-04-09T00:00:00Z",
+  "schema_ref": "contracts/schemas/context_recipe_spec.schema.json",
+  "recipe_id": "recipe-core",
+  "recipe_version": "1.0.0",
+  "task_scope": "governed_context_foundation",
+  "source_requirements": {"min_sources": 1, "max_sources": 4},
+  "required_source_types": ["governance_doc", "schema"],
+  "admissibility_policy_refs": ["policy:tpa:ctx:1.0.0"],
+  "ranking_policy_ref": "policy:ranking:ctx:1.0.0",
+  "budget_policy_ref": "policy:budget:ctx:1.0.0",
+  "freshness_rules": {"ttl_seconds": 86400, "allow_stale": false},
+  "trace_requirements": {"require_trace_id": true, "require_run_id": true, "require_lineage_refs": true}
+}

--- a/contracts/examples/context_source_admission_record.json
+++ b/contracts/examples/context_source_admission_record.json
@@ -1,0 +1,17 @@
+{
+  "artifact_kind": "context_source_admission_record",
+  "artifact_id": "ctxsrcadm-001",
+  "created_at": "2026-04-09T00:00:00Z",
+  "schema_ref": "contracts/schemas/context_source_admission_record.schema.json",
+  "trace": {"trace_id": "trace-ctx-a", "run_id": "run-ctx-a"},
+  "source_ref": "source:alpha",
+  "source_type": "governance_doc",
+  "source_digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "source_schema_ref": "contracts/schemas/roadmap_artifact.schema.json",
+  "freshness_status": "fresh",
+  "trust_class": "trusted",
+  "classification": "internal",
+  "admissibility_decision": "allow",
+  "reason_codes": ["source_type_allowed", "freshness_ok", "trust_class_ok"],
+  "policy_ref": "policy:tpa:ctx:1.0.0"
+}

--- a/contracts/schemas/context_bundle_record.schema.json
+++ b/contracts/schemas/context_bundle_record.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/context_bundle_record.schema.json",
+  "title": "Context Bundle Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_kind",
+    "artifact_id",
+    "created_at",
+    "schema_ref",
+    "trace",
+    "bundle_id",
+    "recipe_id",
+    "recipe_version",
+    "bundle_manifest_hash",
+    "source_refs",
+    "provenance_summary",
+    "trust_summary",
+    "admissibility_status",
+    "assembly_budget",
+    "lineage"
+  ],
+  "properties": {
+    "artifact_kind": {"type": "string", "const": "context_bundle_record"},
+    "artifact_id": {"type": "string", "minLength": 1},
+    "created_at": {"type": "string", "format": "date-time"},
+    "schema_ref": {"type": "string", "const": "contracts/schemas/context_bundle_record.schema.json"},
+    "trace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["trace_id", "run_id"],
+      "properties": {
+        "trace_id": {"type": "string", "minLength": 1},
+        "run_id": {"type": "string", "minLength": 1}
+      }
+    },
+    "bundle_id": {"type": "string", "minLength": 1},
+    "recipe_id": {"type": "string", "minLength": 1},
+    "recipe_version": {"type": "string", "minLength": 1},
+    "bundle_manifest_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "source_refs": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+    "provenance_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_count", "provenance_refs"],
+      "properties": {
+        "source_count": {"type": "integer", "minimum": 1},
+        "provenance_refs": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}, "uniqueItems": true}
+      }
+    },
+    "trust_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["min_trust_class", "blocked_source_count", "policy_ref"],
+      "properties": {
+        "min_trust_class": {"type": "string", "enum": ["trusted", "restricted", "untrusted"]},
+        "blocked_source_count": {"type": "integer", "minimum": 0},
+        "policy_ref": {"type": "string", "minLength": 1}
+      }
+    },
+    "admissibility_status": {"type": "string", "enum": ["approved", "rejected"]},
+    "assembly_budget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["max_sources", "max_tokens", "consumed_sources", "consumed_tokens"],
+      "properties": {
+        "max_sources": {"type": "integer", "minimum": 1},
+        "max_tokens": {"type": "integer", "minimum": 1},
+        "consumed_sources": {"type": "integer", "minimum": 0},
+        "consumed_tokens": {"type": "integer", "minimum": 0}
+      }
+    },
+    "lineage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["aex_admission_ref", "normalized_request_ref", "tlc_handoff_ref", "tpa_slice_ref"],
+      "properties": {
+        "aex_admission_ref": {"type": "string", "minLength": 1},
+        "normalized_request_ref": {"type": "string", "minLength": 1},
+        "tlc_handoff_ref": {"type": "string", "minLength": 1},
+        "tpa_slice_ref": {"type": "string", "minLength": 1}
+      }
+    }
+  }
+}

--- a/contracts/schemas/context_conflict_record.schema.json
+++ b/contracts/schemas/context_conflict_record.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/context_conflict_record.schema.json",
+  "title": "Context Conflict Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_kind",
+    "artifact_id",
+    "created_at",
+    "schema_ref",
+    "trace",
+    "bundle_id",
+    "conflicting_source_refs",
+    "conflict_type",
+    "conflict_summary",
+    "severity",
+    "resolution_required"
+  ],
+  "properties": {
+    "artifact_kind": {"type": "string", "const": "context_conflict_record"},
+    "artifact_id": {"type": "string", "minLength": 1},
+    "created_at": {"type": "string", "format": "date-time"},
+    "schema_ref": {"type": "string", "const": "contracts/schemas/context_conflict_record.schema.json"},
+    "trace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["trace_id", "run_id"],
+      "properties": {
+        "trace_id": {"type": "string", "minLength": 1},
+        "run_id": {"type": "string", "minLength": 1}
+      }
+    },
+    "bundle_id": {"type": "string", "minLength": 1},
+    "conflicting_source_refs": {
+      "type": "array",
+      "minItems": 2,
+      "items": {"type": "string", "minLength": 1},
+      "uniqueItems": true
+    },
+    "conflict_type": {"type": "string", "enum": ["fact_mismatch", "policy_mismatch", "staleness_mismatch", "classification_mismatch"]},
+    "conflict_summary": {"type": "string", "minLength": 1},
+    "severity": {"type": "string", "enum": ["low", "medium", "high", "critical"]},
+    "resolution_required": {"type": "boolean"}
+  }
+}

--- a/contracts/schemas/context_recipe_spec.schema.json
+++ b/contracts/schemas/context_recipe_spec.schema.json
@@ -1,0 +1,137 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/context_recipe_spec.schema.json",
+  "title": "Context Recipe Spec",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_kind",
+    "artifact_id",
+    "created_at",
+    "schema_ref",
+    "recipe_id",
+    "recipe_version",
+    "task_scope",
+    "source_requirements",
+    "required_source_types",
+    "admissibility_policy_refs",
+    "ranking_policy_ref",
+    "budget_policy_ref",
+    "freshness_rules",
+    "trace_requirements"
+  ],
+  "properties": {
+    "artifact_kind": {
+      "type": "string",
+      "const": "context_recipe_spec"
+    },
+    "artifact_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "schema_ref": {
+      "type": "string",
+      "const": "contracts/schemas/context_recipe_spec.schema.json"
+    },
+    "recipe_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "recipe_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "task_scope": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source_requirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "min_sources",
+        "max_sources"
+      ],
+      "properties": {
+        "min_sources": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "max_sources": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "required_source_types": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "admissibility_policy_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "ranking_policy_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "budget_policy_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "freshness_rules": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "ttl_seconds",
+        "allow_stale"
+      ],
+      "properties": {
+        "ttl_seconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "allow_stale": {
+          "type": "boolean"
+        }
+      }
+    },
+    "trace_requirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "require_trace_id",
+        "require_run_id",
+        "require_lineage_refs"
+      ],
+      "properties": {
+        "require_trace_id": {
+          "type": "boolean",
+          "const": true
+        },
+        "require_run_id": {
+          "type": "boolean",
+          "const": true
+        },
+        "require_lineage_refs": {
+          "type": "boolean",
+          "const": true
+        }
+      }
+    }
+  }
+}

--- a/contracts/schemas/context_source_admission_record.schema.json
+++ b/contracts/schemas/context_source_admission_record.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/context_source_admission_record.schema.json",
+  "title": "Context Source Admission Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_kind",
+    "artifact_id",
+    "created_at",
+    "schema_ref",
+    "trace",
+    "source_ref",
+    "source_type",
+    "source_digest",
+    "source_schema_ref",
+    "freshness_status",
+    "trust_class",
+    "classification",
+    "admissibility_decision",
+    "reason_codes",
+    "policy_ref"
+  ],
+  "properties": {
+    "artifact_kind": {"type": "string", "const": "context_source_admission_record"},
+    "artifact_id": {"type": "string", "minLength": 1},
+    "created_at": {"type": "string", "format": "date-time"},
+    "schema_ref": {"type": "string", "const": "contracts/schemas/context_source_admission_record.schema.json"},
+    "trace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["trace_id", "run_id"],
+      "properties": {
+        "trace_id": {"type": "string", "minLength": 1},
+        "run_id": {"type": "string", "minLength": 1}
+      }
+    },
+    "source_ref": {"type": "string", "minLength": 1},
+    "source_type": {"type": "string", "minLength": 1},
+    "source_digest": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "source_schema_ref": {"type": "string", "minLength": 1},
+    "freshness_status": {"type": "string", "enum": ["fresh", "stale"]},
+    "trust_class": {"type": "string", "enum": ["trusted", "restricted", "untrusted"]},
+    "classification": {"type": "string", "enum": ["public", "internal", "confidential", "restricted"]},
+    "admissibility_decision": {"type": "string", "enum": ["allow", "deny"]},
+    "reason_codes": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+    "policy_ref": {"type": "string", "minLength": 1}
+  }
+}

--- a/contracts/standards-manifest.json
+++ b/contracts/standards-manifest.json
@@ -1,11 +1,11 @@
 {
   "artifact_type": "standards_manifest",
   "artifact_id": "STD-CONTRACTS",
-  "artifact_version": "1.3.105",
+  "artifact_version": "1.3.106",
   "schema_version": "1.3.98",
-  "standards_version": "1.3.105",
-  "record_id": "REC-STD-2026-04-09-AFX-02",
-  "run_id": "run-20260409T000000Z-afx-02",
+  "standards_version": "1.3.106",
+  "record_id": "REC-STD-2026-04-09-CTX-A",
+  "run_id": "run-20260409T000000Z-ctx-a",
   "created_at": "2026-04-09T00:00:00Z",
   "created_by": {
     "name": "Spectrum Systems Architecture Team",
@@ -15,7 +15,7 @@
     "contact": "architecture@spectrum-systems.test"
   },
   "source_repo": "nicklasorte/spectrum-systems",
-  "source_repo_version": "1.3.105",
+  "source_repo_version": "1.3.106",
   "input_artifacts": [
     {
       "artifact_id": "STD-CONTRACTS",
@@ -591,6 +591,19 @@
       "notes": "AI-02 deterministic context bundle hardening: required per-item provenance_ref, deterministic item identity validation, and fail-closed trust-boundary enforcement."
     },
     {
+      "artifact_type": "context_bundle_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "BATCH-CTX-A",
+      "last_updated_in": "BATCH-CTX-A",
+      "example_path": "contracts/examples/context_bundle_record.json",
+      "notes": "BATCH-CTX-A canonical governed context bundle artifact with lineage, provenance, and deterministic manifest hash linkage."
+    },
+    {
       "artifact_type": "context_bundle_v2",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -602,6 +615,45 @@
       "last_updated_in": "1.3.33",
       "example_path": "contracts/examples/context_bundle_v2.json",
       "notes": "BATCH-O deterministic governed context bundle artifact for scoped selection/ranking/injection lifecycle."
+    },
+    {
+      "artifact_type": "context_conflict_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "BATCH-CTX-A",
+      "last_updated_in": "BATCH-CTX-A",
+      "example_path": "contracts/examples/context_conflict_record.json",
+      "notes": "BATCH-CTX-A conflict artifact for deterministic context source disagreement capture and resolution requirement signaling."
+    },
+    {
+      "artifact_type": "context_recipe_spec",
+      "artifact_class": "governance",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "BATCH-CTX-A",
+      "last_updated_in": "BATCH-CTX-A",
+      "example_path": "contracts/examples/context_recipe_spec.json",
+      "notes": "BATCH-CTX-A canonical context recipe contract defining source requirements, policy refs, and freshness/trace rules."
+    },
+    {
+      "artifact_type": "context_source_admission_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "BATCH-CTX-A",
+      "last_updated_in": "BATCH-CTX-A",
+      "example_path": "contracts/examples/context_source_admission_record.json",
+      "notes": "BATCH-CTX-A source-level admissibility artifact emitted by TPA for governed context inputs."
     },
     {
       "artifact_type": "context_validation_result",

--- a/docs/review-actions/PLAN-BATCH-CTX-A-2026-04-09.md
+++ b/docs/review-actions/PLAN-BATCH-CTX-A-2026-04-09.md
@@ -1,0 +1,41 @@
+# Plan — BATCH-CTX-A — 2026-04-09
+
+## Prompt type
+BUILD
+
+## Roadmap item
+BATCH-CTX-A
+
+## Objective
+Implement the first governed context foundation slice with strict ownership boundaries and fail-closed lineage enforcement for context-capability repo-mutating execution.
+
+## Declared files
+| File | Change type | Reason |
+| --- | --- | --- |
+| docs/review-actions/PLAN-BATCH-CTX-A-2026-04-09.md | CREATE | Required plan-first artifact for multi-file change set. |
+| contracts/schemas/context_bundle_record.schema.json | CREATE | Add canonical governed context bundle artifact contract. |
+| contracts/schemas/context_source_admission_record.schema.json | CREATE | Add canonical source-level admission artifact contract for context inputs. |
+| contracts/schemas/context_conflict_record.schema.json | CREATE | Add canonical context conflict artifact contract. |
+| contracts/schemas/context_recipe_spec.schema.json | CREATE | Add canonical context recipe specification contract. |
+| contracts/examples/context_bundle_record.json | CREATE | Golden valid example for context bundle record contract. |
+| contracts/examples/context_source_admission_record.json | CREATE | Golden valid example for context source admission contract. |
+| contracts/examples/context_conflict_record.json | CREATE | Golden valid example for context conflict contract. |
+| contracts/examples/context_recipe_spec.json | CREATE | Golden valid example for context recipe contract. |
+| contracts/standards-manifest.json | MODIFY | Register new contract artifacts and bump standards manifest version metadata. |
+| spectrum_systems/aex/classifier.py | MODIFY | Add deterministic context-capability request detection for admission classification. |
+| spectrum_systems/aex/engine.py | MODIFY | Emit context-capability classification reason code and fail-closed handling while preserving AEX ownership. |
+| spectrum_systems/modules/runtime/hnx_execution_state.py | MODIFY | Add HNX-owned context stage semantics and continuity validation helpers (no execution/policy logic). |
+| spectrum_systems/modules/runtime/context_governed_flow.py | CREATE | Add narrow TLC routing, TPA admissibility evaluation, and PQX bounded context assembly execution path with lineage checks. |
+| tests/test_context_governed_foundation.py | CREATE | Validate CTX-01..CTX-06 ownership boundaries, contracts, and fail-closed lineage behavior. |
+
+## Scope exclusions
+- No new subsystem creation.
+- No SEL/CDE/FRE/RIL scope expansion.
+- No runtime policy enforcement side effects outside deterministic artifact emission.
+- No review-loop, closure, or promotion implementation.
+
+## Validation commands
+1. `pytest tests/test_context_governed_foundation.py`
+2. `pytest tests/test_aex_admission.py tests/test_tlc_handoff_flow.py tests/test_pqx_required_context_enforcement.py`
+3. `pytest tests/test_contracts.py tests/test_contract_enforcement.py`
+4. `python scripts/run_contract_enforcement.py`

--- a/spectrum_systems/aex/classifier.py
+++ b/spectrum_systems/aex/classifier.py
@@ -27,6 +27,18 @@ _READ_PATTERNS = (
     r"\bread\b",
 )
 _REPO_SENSITIVE_PATH_HINTS = ("contracts/", "spectrum_systems/", "tests/", "docs/")
+_CONTEXT_CAPABILITY_HINTS = (
+    "context",
+    "recipe",
+    "admission",
+    "bundle",
+    "source",
+    "lineage",
+    "tpa",
+    "tlc",
+    "pqx",
+    "aex",
+)
 
 
 ExecutionType = str
@@ -49,3 +61,10 @@ def is_repo_sensitive_unknown(*, execution_type: str, repo_mutation_requested: b
     if repo_mutation_requested:
         return True
     return any(path.startswith(prefix) for path in target_paths for prefix in _REPO_SENSITIVE_PATH_HINTS)
+
+
+def is_context_capability_request(prompt_text: str, target_paths: list[str] | None = None) -> bool:
+    text = (prompt_text or "").lower()
+    paths = " ".join(str(item).lower() for item in (target_paths or []))
+    haystack = f"{text} {paths}"
+    return any(hint in haystack for hint in _CONTEXT_CAPABILITY_HINTS)

--- a/spectrum_systems/aex/engine.py
+++ b/spectrum_systems/aex/engine.py
@@ -9,7 +9,7 @@ import hashlib
 from datetime import datetime, timezone
 from typing import Any, Callable, Mapping
 
-from spectrum_systems.aex.classifier import classify_execution_type, is_repo_sensitive_unknown
+from spectrum_systems.aex.classifier import classify_execution_type, is_context_capability_request, is_repo_sensitive_unknown
 from spectrum_systems.aex.errors import INVALID_REQUEST_SHAPE, MISSING_REQUIRED_FIELD, UNKNOWN_EXECUTION_TYPE
 from spectrum_systems.aex.models import AdmissionResult, CodexBuildRequest
 from spectrum_systems.contracts import validate_artifact
@@ -42,6 +42,7 @@ class AEXEngine:
 
         execution_type = classify_execution_type(normalized_input.prompt_text, normalized_input.target_paths)
         repo_mutation_requested = execution_type == "repo_write" or bool(normalized_input.target_paths)
+        context_capability_request = is_context_capability_request(normalized_input.prompt_text, normalized_input.target_paths)
 
         normalized = {
             "artifact_type": "normalized_execution_request",
@@ -64,10 +65,13 @@ class AEXEngine:
             repo_mutation_requested=repo_mutation_requested,
             target_paths=normalized_input.target_paths,
         ):
+            reason_codes = [UNKNOWN_EXECUTION_TYPE]
+            if context_capability_request:
+                reason_codes.append("context_capability_unclassifiable")
             return self._reject(
                 normalized_input.request_id,
                 normalized_input.trace_id,
-                [UNKNOWN_EXECUTION_TYPE],
+                reason_codes,
                 "execution type is unknown and repo mutation cannot be ruled out",
                 normalized=normalized,
             )
@@ -83,7 +87,7 @@ class AEXEngine:
             "trace_id": normalized_input.trace_id,
             "created_at": normalized_input.created_at,
             "produced_by": normalized_input.produced_by,
-            "reason_codes": [],
+            "reason_codes": ["context_capability_repo_mutation"] if (repo_mutation_requested and context_capability_request) else [],
             "target_scope": {
                 "repo": "spectrum-systems",
                 "paths": normalized_input.target_paths,

--- a/spectrum_systems/modules/runtime/context_governed_flow.py
+++ b/spectrum_systems/modules/runtime/context_governed_flow.py
@@ -1,0 +1,292 @@
+"""Governed context foundation flow (AEX -> TLC -> TPA -> PQX) with ownership-clean seams."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Mapping
+
+from spectrum_systems.contracts import validate_artifact
+from spectrum_systems.modules.runtime.repo_write_lineage_guard import RepoWriteLineageGuardError, validate_repo_write_lineage
+from spectrum_systems.modules.runtime.top_level_conductor import _build_tlc_handoff_record
+
+
+class ContextGovernedFlowError(ValueError):
+    """Raised when governed context flow invariants are violated."""
+
+
+def _canonical_hash(payload: Any) -> str:
+    return hashlib.sha256(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+
+
+def _require_mapping(payload: Any, field: str) -> dict[str, Any]:
+    if not isinstance(payload, Mapping):
+        raise ContextGovernedFlowError(f"{field}_required")
+    return dict(payload)
+
+
+def create_tlc_context_handoff(
+    *,
+    run_id: str,
+    objective: str,
+    branch_ref: str,
+    emitted_at: str,
+    build_admission_record: Mapping[str, Any],
+    normalized_execution_request: Mapping[str, Any],
+) -> dict[str, Any]:
+    """TLC-owned routing artifact creation for admitted context-capability repo writes."""
+    admission = _require_mapping(build_admission_record, "build_admission_record")
+    normalized = _require_mapping(normalized_execution_request, "normalized_execution_request")
+
+    reason_codes = [str(code) for code in admission.get("reason_codes") or []]
+    if "context_capability_repo_mutation" not in reason_codes:
+        raise ContextGovernedFlowError("context_capability_not_admitted")
+
+    handoff = _build_tlc_handoff_record(
+        run_id=run_id,
+        objective=objective,
+        branch_ref=branch_ref,
+        emitted_at=emitted_at,
+        repo_write_lineage={
+            "trace_id": str(admission.get("trace_id") or ""),
+            "request_id": str(normalized.get("request_id") or ""),
+            "admission_id": str(admission.get("admission_id") or ""),
+            "normalized_execution_request_ref": str(admission.get("normalized_execution_request_ref") or ""),
+        },
+    )
+    validate_artifact(handoff, "tlc_handoff_record")
+    return handoff
+
+
+def route_context_slice_to_tpa(
+    *,
+    build_admission_record: Mapping[str, Any],
+    normalized_execution_request: Mapping[str, Any],
+    tlc_handoff_record: Mapping[str, Any],
+) -> dict[str, Any]:
+    """TLC routing only: validates lineage continuity and routes to TPA."""
+    admission = _require_mapping(build_admission_record, "build_admission_record")
+    normalized = _require_mapping(normalized_execution_request, "normalized_execution_request")
+    handoff = _require_mapping(tlc_handoff_record, "tlc_handoff_record")
+    try:
+        validate_repo_write_lineage(
+            build_admission_record=admission,
+            normalized_execution_request=normalized,
+            tlc_handoff_record=handoff,
+            expected_trace_id=str(admission.get("trace_id") or ""),
+            enforce_replay_protection=False,
+        )
+    except RepoWriteLineageGuardError as exc:
+        raise ContextGovernedFlowError(f"lineage_invalid:{exc}") from exc
+
+    return {
+        "route_status": "accepted",
+        "next_system": "TPA",
+        "tlc_handoff_record": handoff,
+        "trace_id": str(handoff.get("trace_id") or ""),
+    }
+
+
+def evaluate_tpa_context_admissibility(
+    *,
+    normalized_execution_request: Mapping[str, Any],
+    tlc_handoff_record: Mapping[str, Any],
+    context_recipe_spec: Mapping[str, Any],
+    source_metadata: list[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """TPA-owned deterministic context admissibility checks (no execution)."""
+    normalized = _require_mapping(normalized_execution_request, "normalized_execution_request")
+    handoff = _require_mapping(tlc_handoff_record, "tlc_handoff_record")
+    recipe = _require_mapping(context_recipe_spec, "context_recipe_spec")
+
+    required_source_types = set(str(v) for v in recipe.get("required_source_types") or [])
+    ttl_seconds = int(((recipe.get("freshness_rules") or {}).get("ttl_seconds") or 0))
+    allow_stale = bool(((recipe.get("freshness_rules") or {}).get("allow_stale") is True))
+    max_sources = int(((recipe.get("source_requirements") or {}).get("max_sources") or 0))
+
+    reasons: list[str] = []
+    admitted_sources: list[dict[str, Any]] = []
+    for source in source_metadata:
+        src = dict(source)
+        source_type = str(src.get("source_type") or "")
+        source_schema_ref = str(src.get("source_schema_ref") or "")
+        trust_class = str(src.get("trust_class") or "")
+        freshness_seconds = int(src.get("freshness_age_seconds") or 0)
+        classification = str(src.get("classification") or "")
+
+        source_reasons: list[str] = []
+        if source_type not in required_source_types:
+            source_reasons.append("source_type_not_allowed")
+        if not source_schema_ref:
+            source_reasons.append("source_schema_ref_missing")
+        if freshness_seconds > ttl_seconds and not allow_stale:
+            source_reasons.append("source_stale")
+        if trust_class not in {"trusted", "restricted"}:
+            source_reasons.append("trust_class_rejected")
+        if classification in {"restricted"}:
+            source_reasons.append("classification_rejected")
+
+        if source_reasons:
+            reasons.extend(source_reasons)
+            continue
+        admitted_sources.append(src)
+
+    if len(source_metadata) > max_sources:
+        reasons.append("scope_over_budget")
+    for key in ("trace_id", "run_id"):
+        if not str((handoff.get("tlc_run_context") or {}).get("run_id") or "") and key == "run_id":
+            reasons.append("missing_trace_or_lineage")
+        if not str(handoff.get("trace_id") or "") and key == "trace_id":
+            reasons.append("missing_trace_or_lineage")
+
+    reasons = sorted(set(reasons))
+    allowed = len(reasons) == 0
+
+    tpa_scope_policy = {
+        "policy_id": f"tpa-scope-{str(recipe.get('recipe_id') or 'context')}",
+        "allow": allowed,
+        "reason_codes": reasons,
+        "max_sources": max_sources,
+        "ttl_seconds": ttl_seconds,
+    }
+    tpa_slice_artifact = {
+        "artifact_type": "tpa_slice_artifact",
+        "artifact_id": f"tpa-slice-{_canonical_hash({'trace': handoff.get('trace_id'), 'recipe': recipe.get('recipe_id')})[:12]}",
+        "trace_id": str(handoff.get("trace_id") or ""),
+        "run_id": str((handoff.get("tlc_run_context") or {}).get("run_id") or ""),
+        "decision": "allow" if allowed else "deny",
+        "reason_codes": reasons,
+        "approved_source_refs": sorted(str(src.get("source_ref") or "") for src in admitted_sources),
+        "lineage": {
+            "normalized_execution_request_ref": str(handoff.get("normalized_execution_request_ref") or ""),
+            "tlc_handoff_ref": f"tlc_handoff_record:{handoff.get('handoff_id')}",
+        },
+    }
+    tpa_observability_summary = {
+        "artifact_type": "tpa_observability_summary",
+        "trace_id": str(handoff.get("trace_id") or ""),
+        "run_id": str((handoff.get("tlc_run_context") or {}).get("run_id") or ""),
+        "admitted_source_count": len(admitted_sources),
+        "rejected_reason_codes": reasons,
+    }
+    return {
+        "tpa_scope_policy": tpa_scope_policy,
+        "tpa_slice_artifact": tpa_slice_artifact,
+        "tpa_observability_summary": tpa_observability_summary,
+    }
+
+
+def execute_bounded_context_assembly(
+    *,
+    build_admission_record: Mapping[str, Any],
+    normalized_execution_request: Mapping[str, Any],
+    tlc_handoff_record: Mapping[str, Any],
+    tpa_slice_artifact: Mapping[str, Any],
+    context_recipe_spec: Mapping[str, Any],
+    approved_sources: list[Mapping[str, Any]],
+    created_at: str,
+) -> dict[str, Any]:
+    """PQX-owned bounded context assembly; fail-closed on missing AEX/TLC/TPA lineage."""
+    admission = _require_mapping(build_admission_record, "build_admission_record")
+    normalized = _require_mapping(normalized_execution_request, "normalized_execution_request")
+    handoff = _require_mapping(tlc_handoff_record, "tlc_handoff_record")
+    tpa_slice = _require_mapping(tpa_slice_artifact, "tpa_slice_artifact")
+    recipe = _require_mapping(context_recipe_spec, "context_recipe_spec")
+
+    try:
+        lineage = validate_repo_write_lineage(
+            build_admission_record=admission,
+            normalized_execution_request=normalized,
+            tlc_handoff_record=handoff,
+            expected_trace_id=str(admission.get("trace_id") or ""),
+            enforce_replay_protection=False,
+        )
+    except RepoWriteLineageGuardError as exc:
+        raise ContextGovernedFlowError(f"repo_write_lineage_missing_or_invalid:{exc}") from exc
+
+    if str(tpa_slice.get("decision") or "") != "allow":
+        raise ContextGovernedFlowError("missing_or_denied_tpa_slice_artifact")
+
+    approved_refs = sorted(str(src.get("source_ref") or "") for src in approved_sources)
+    source_digest = _canonical_hash([dict(src) for src in sorted(approved_sources, key=lambda x: str(x.get("source_ref") or ""))])
+    bundle_id = f"ctxbundle-{_canonical_hash({'trace_id': lineage['trace_id'], 'request_id': lineage['request_id'], 'source_digest': source_digest})[:16]}"
+    bundle_manifest_hash = f"sha256:{_canonical_hash({'bundle_id': bundle_id, 'sources': approved_refs, 'recipe': recipe})}"
+
+    context_bundle_record = {
+        "artifact_kind": "context_bundle_record",
+        "artifact_id": f"ctxbrec-{bundle_id}",
+        "created_at": created_at,
+        "schema_ref": "contracts/schemas/context_bundle_record.schema.json",
+        "trace": {
+            "trace_id": lineage["trace_id"],
+            "run_id": str((handoff.get("tlc_run_context") or {}).get("run_id") or ""),
+        },
+        "bundle_id": bundle_id,
+        "recipe_id": str(recipe.get("recipe_id") or ""),
+        "recipe_version": str(recipe.get("recipe_version") or ""),
+        "bundle_manifest_hash": bundle_manifest_hash,
+        "source_refs": approved_refs,
+        "provenance_summary": {
+            "source_count": len(approved_refs),
+            "provenance_refs": approved_refs,
+        },
+        "trust_summary": {
+            "min_trust_class": "trusted",
+            "blocked_source_count": 0,
+            "policy_ref": str((tpa_slice.get("lineage") or {}).get("tlc_handoff_ref") or "policy:tpa:missing"),
+        },
+        "admissibility_status": "approved",
+        "assembly_budget": {
+            "max_sources": int(((recipe.get("source_requirements") or {}).get("max_sources") or len(approved_refs) or 1)),
+            "max_tokens": int(((recipe.get("budget_policy") or {}).get("max_tokens") or 4096)),
+            "consumed_sources": len(approved_refs),
+            "consumed_tokens": min(4096, 256 * len(approved_refs)),
+        },
+        "lineage": {
+            "aex_admission_ref": f"build_admission_record:{lineage['admission_id']}",
+            "normalized_request_ref": lineage["normalized_execution_request_ref"],
+            "tlc_handoff_ref": f"tlc_handoff_record:{handoff.get('handoff_id')}",
+            "tpa_slice_ref": f"tpa_slice_artifact:{tpa_slice.get('artifact_id')}",
+        },
+    }
+    validate_artifact(context_bundle_record, "context_bundle_record")
+
+    pqx_slice_execution_record = {
+        "artifact_type": "pqx_slice_execution_record",
+        "run_id": str((handoff.get("tlc_run_context") or {}).get("run_id") or ""),
+        "trace_id": lineage["trace_id"],
+        "step_id": "CTX-06",
+        "status": "completed",
+        "bundle_ref": f"context_bundle_record:{context_bundle_record['artifact_id']}",
+    }
+    pqx_bundle_execution_record = {
+        "artifact_type": "pqx_bundle_execution_record",
+        "bundle_execution_id": f"pqxbundle-{bundle_id}",
+        "bundle_id": bundle_id,
+        "run_id": str((handoff.get("tlc_run_context") or {}).get("run_id") or ""),
+        "status": "completed",
+        "output_artifact_refs": [f"context_bundle_record:{context_bundle_record['artifact_id']}"],
+    }
+    pqx_execution_closure_record = {
+        "artifact_type": "pqx_execution_closure_record",
+        "closure_id": _canonical_hash({"bundle_id": bundle_id, "trace_id": lineage["trace_id"]}),
+        "run_id": str((handoff.get("tlc_run_context") or {}).get("run_id") or ""),
+        "trace_id": lineage["trace_id"],
+        "status": "closed",
+    }
+
+    return {
+        "context_bundle_record": context_bundle_record,
+        "pqx_slice_execution_record": pqx_slice_execution_record,
+        "pqx_bundle_execution_record": pqx_bundle_execution_record,
+        "pqx_execution_closure_record": pqx_execution_closure_record,
+    }
+
+
+__all__ = [
+    "ContextGovernedFlowError",
+    "create_tlc_context_handoff",
+    "route_context_slice_to_tpa",
+    "evaluate_tpa_context_admissibility",
+    "execute_bounded_context_assembly",
+]

--- a/spectrum_systems/modules/runtime/hnx_execution_state.py
+++ b/spectrum_systems/modules/runtime/hnx_execution_state.py
@@ -6,6 +6,14 @@ import hashlib
 import json
 from typing import Any, Mapping
 
+_CONTEXT_STAGE_SEQUENCE = (
+    "context_map",
+    "context_admission",
+    "context_assembly",
+    "context_preflight",
+    "context_checkpoint_resume",
+)
+
 
 def _stable_hash(payload: Mapping[str, Any]) -> str:
     return hashlib.sha256(json.dumps(dict(payload), sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
@@ -238,3 +246,67 @@ def evaluate_long_running_policy(
     if request_resume:
         return _base_result(allowed=True, state="resume", reason_codes=reasons or ["RESUME_ALLOWED"])
     return _base_result(allowed=True, state="resume", reason_codes=["LONG_RUNNING_POLICY_OK"])
+
+
+def evaluate_context_stage_semantics(
+    *,
+    stage_name: str,
+    artifacts: Mapping[str, Any],
+    resume_requested: bool = False,
+) -> dict[str, Any]:
+    """HNX-owned context stage structure + continuity semantics (no execution/policy decisions)."""
+    if stage_name not in _CONTEXT_STAGE_SEQUENCE:
+        return _base_result(
+            allowed=False,
+            state="block",
+            validation_failures=["UNKNOWN_CONTEXT_STAGE"],
+            reason_codes=["UNKNOWN_CONTEXT_STAGE"],
+        )
+
+    failures: list[str] = []
+    outputs_required: list[str] = []
+    continuity_required: list[str] = []
+    payload = dict(artifacts)
+
+    if stage_name == "context_map":
+        outputs_required = ["context_recipe_spec"]
+    elif stage_name == "context_admission":
+        outputs_required = ["context_source_admission_record"]
+        if not isinstance(payload.get("context_recipe_spec"), Mapping):
+            failures.append("MISSING_CONTEXT_RECIPE_SPEC")
+    elif stage_name == "context_assembly":
+        outputs_required = ["context_bundle_record"]
+        for field in ("build_admission_record", "normalized_execution_request", "tlc_handoff_record", "tpa_slice_artifact"):
+            if not isinstance(payload.get(field), Mapping):
+                failures.append(f"MISSING_REQUIRED_LINEAGE_{field.upper()}")
+    elif stage_name == "context_preflight":
+        outputs_required = ["pqx_slice_execution_record"]
+        for field in ("context_bundle_record", "tpa_slice_artifact"):
+            if not isinstance(payload.get(field), Mapping):
+                failures.append(f"MISSING_REQUIRED_INPUT_{field.upper()}")
+    elif stage_name == "context_checkpoint_resume":
+        outputs_required = ["checkpoint_record"]
+        continuity_required = ["checkpoint_id", "checkpoint_hash", "resume_token"]
+        if resume_requested:
+            checkpoint = payload.get("checkpoint_record")
+            if not isinstance(checkpoint, Mapping):
+                failures.append("CHECKPOINT_RECORD_REQUIRED_FOR_RESUME")
+            else:
+                for key in continuity_required:
+                    value = checkpoint.get(key)
+                    if not isinstance(value, str) or not value.strip():
+                        failures.append(f"MISSING_CONTINUITY_FIELD_{key.upper()}")
+
+    status = "ready" if not failures else "blocked"
+    return {
+        **_base_result(
+            allowed=not failures,
+            state="resume" if not failures else "block",
+            validation_failures=failures,
+            reason_codes=failures or [f"{stage_name.upper()}_SEMANTICS_VALID"],
+        ),
+        "stage_name": stage_name,
+        "outputs_required": outputs_required,
+        "continuity_required": continuity_required,
+        "status": status,
+    }

--- a/tests/test_context_governed_foundation.py
+++ b/tests/test_context_governed_foundation.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from spectrum_systems.aex.engine import AEXEngine
+from spectrum_systems.contracts import load_example, load_schema, validate_artifact
+from spectrum_systems.modules.runtime.context_governed_flow import (
+    ContextGovernedFlowError,
+    create_tlc_context_handoff,
+    evaluate_tpa_context_admissibility,
+    execute_bounded_context_assembly,
+    route_context_slice_to_tpa,
+)
+from spectrum_systems.modules.runtime.hnx_execution_state import evaluate_context_stage_semantics
+
+
+def _context_request() -> dict[str, object]:
+    return {
+        "request_id": "req-ctx-001",
+        "prompt_text": "Modify context contracts and context assembly runtime for governed context capability",
+        "trace_id": "trace-ctx-001",
+        "created_at": "2026-04-09T00:00:00Z",
+        "produced_by": "codex",
+        "target_paths": [
+            "contracts/schemas/context_bundle_record.schema.json",
+            "spectrum_systems/modules/runtime/context_governed_flow.py",
+        ],
+        "requested_outputs": ["patch", "tests"],
+        "source_prompt_kind": "codex_build_request",
+    }
+
+
+def _recipe() -> dict[str, object]:
+    return load_example("context_recipe_spec")
+
+
+def _sources(*, stale: bool = False, untrusted: bool = False, incompatible: bool = False, count: int = 2) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for idx in range(count):
+        rows.append(
+            {
+                "source_ref": f"source:{idx}",
+                "source_type": "governance_doc" if not incompatible else "unknown_type",
+                "source_schema_ref": "contracts/schemas/roadmap_artifact.schema.json" if not incompatible else "",
+                "freshness_age_seconds": 999999 if stale else 100,
+                "trust_class": "untrusted" if untrusted else "trusted",
+                "classification": "internal",
+            }
+        )
+    return rows
+
+
+def _admitted_lineage() -> tuple[dict[str, object], dict[str, object], dict[str, object]]:
+    admitted = AEXEngine().admit_codex_request(_context_request())
+    assert admitted.accepted
+    assert admitted.build_admission_record is not None
+    assert admitted.normalized_execution_request is not None
+    handoff = create_tlc_context_handoff(
+        run_id="run-ctx-001",
+        objective="governed context mutation",
+        branch_ref="refs/heads/main",
+        emitted_at="2026-04-09T00:00:00Z",
+        build_admission_record=admitted.build_admission_record,
+        normalized_execution_request=admitted.normalized_execution_request,
+    )
+    return admitted.build_admission_record, admitted.normalized_execution_request, handoff
+
+
+# CTX-01 contract tests
+
+def test_context_contract_examples_validate() -> None:
+    for name in (
+        "context_bundle_record",
+        "context_source_admission_record",
+        "context_conflict_record",
+        "context_recipe_spec",
+    ):
+        validate_artifact(load_example(name), name)
+
+
+def test_context_bundle_record_rejects_unknown_properties_and_missing_required() -> None:
+    schema = load_schema("context_bundle_record")
+    validator = Draft202012Validator(schema)
+    payload = load_example("context_bundle_record")
+
+    unknown = copy.deepcopy(payload)
+    unknown["unexpected"] = "x"
+    assert list(validator.iter_errors(unknown))
+
+    missing = copy.deepcopy(payload)
+    missing.pop("lineage")
+    assert list(validator.iter_errors(missing))
+
+
+# CTX-02 HNX stage semantics
+
+def test_hnx_context_stage_semantics_require_lineage_for_assembly() -> None:
+    blocked = evaluate_context_stage_semantics(stage_name="context_assembly", artifacts={})
+    assert blocked["allowed"] is False
+    assert "MISSING_REQUIRED_LINEAGE_BUILD_ADMISSION_RECORD" in blocked["validation_failures"]
+
+    ready = evaluate_context_stage_semantics(
+        stage_name="context_assembly",
+        artifacts={
+            "build_admission_record": {"ok": True},
+            "normalized_execution_request": {"ok": True},
+            "tlc_handoff_record": {"ok": True},
+            "tpa_slice_artifact": {"ok": True},
+        },
+    )
+    assert ready["allowed"] is True
+
+
+# CTX-03 AEX admission
+
+def test_aex_marks_context_capability_repo_mutation() -> None:
+    result = AEXEngine().admit_codex_request(_context_request())
+    assert result.accepted is True
+    assert result.build_admission_record is not None
+    assert "context_capability_repo_mutation" in result.build_admission_record["reason_codes"]
+
+
+# CTX-04 TLC routing
+
+def test_tlc_routes_context_slice_to_tpa_and_rejects_missing_lineage() -> None:
+    admission, normalized, handoff = _admitted_lineage()
+    routed = route_context_slice_to_tpa(
+        build_admission_record=admission,
+        normalized_execution_request=normalized,
+        tlc_handoff_record=handoff,
+    )
+    assert routed["route_status"] == "accepted"
+    assert routed["next_system"] == "TPA"
+
+    with pytest.raises(ContextGovernedFlowError, match="lineage_invalid"):
+        route_context_slice_to_tpa(
+            build_admission_record=admission,
+            normalized_execution_request=normalized,
+            tlc_handoff_record={},
+        )
+
+
+# CTX-05 TPA admissibility
+
+def test_tpa_emits_slice_artifact_for_admissible_sources() -> None:
+    _admission, normalized, handoff = _admitted_lineage()
+    out = evaluate_tpa_context_admissibility(
+        normalized_execution_request=normalized,
+        tlc_handoff_record=handoff,
+        context_recipe_spec=_recipe(),
+        source_metadata=_sources(),
+    )
+    assert out["tpa_scope_policy"]["allow"] is True
+    assert out["tpa_slice_artifact"]["decision"] == "allow"
+    assert out["tpa_observability_summary"]["admitted_source_count"] == 2
+
+
+def test_tpa_rejects_stale_untrusted_incompatible_or_over_budget_sources_fail_closed() -> None:
+    _admission, normalized, handoff = _admitted_lineage()
+    for sources in (
+        _sources(stale=True),
+        _sources(untrusted=True),
+        _sources(incompatible=True),
+        _sources(count=5),
+    ):
+        out = evaluate_tpa_context_admissibility(
+            normalized_execution_request=normalized,
+            tlc_handoff_record=handoff,
+            context_recipe_spec=_recipe(),
+            source_metadata=sources,
+        )
+        assert out["tpa_slice_artifact"]["decision"] == "deny"
+
+
+# CTX-06 PQX bounded execution
+
+def test_pqx_rejects_missing_lineage_and_executes_with_approved_lineage_deterministically() -> None:
+    admission, normalized, handoff = _admitted_lineage()
+    tpa = evaluate_tpa_context_admissibility(
+        normalized_execution_request=normalized,
+        tlc_handoff_record=handoff,
+        context_recipe_spec=_recipe(),
+        source_metadata=_sources(),
+    )
+
+    with pytest.raises(ContextGovernedFlowError, match="repo_write_lineage_missing_or_invalid"):
+        execute_bounded_context_assembly(
+            build_admission_record={},
+            normalized_execution_request=normalized,
+            tlc_handoff_record=handoff,
+            tpa_slice_artifact=tpa["tpa_slice_artifact"],
+            context_recipe_spec=_recipe(),
+            approved_sources=_sources(),
+            created_at="2026-04-09T00:00:00Z",
+        )
+
+    first = execute_bounded_context_assembly(
+        build_admission_record=admission,
+        normalized_execution_request=normalized,
+        tlc_handoff_record=handoff,
+        tpa_slice_artifact=tpa["tpa_slice_artifact"],
+        context_recipe_spec=_recipe(),
+        approved_sources=_sources(),
+        created_at="2026-04-09T00:00:00Z",
+    )
+    second = execute_bounded_context_assembly(
+        build_admission_record=admission,
+        normalized_execution_request=normalized,
+        tlc_handoff_record=handoff,
+        tpa_slice_artifact=tpa["tpa_slice_artifact"],
+        context_recipe_spec=_recipe(),
+        approved_sources=_sources(),
+        created_at="2026-04-09T00:00:00Z",
+    )
+    assert first["context_bundle_record"]["bundle_manifest_hash"] == second["context_bundle_record"]["bundle_manifest_hash"]
+
+
+# Boundary ownership checks
+
+def test_boundary_ownership_no_duplicate_responsibility_in_context_flow() -> None:
+    admission, normalized, handoff = _admitted_lineage()
+    tlc = route_context_slice_to_tpa(
+        build_admission_record=admission,
+        normalized_execution_request=normalized,
+        tlc_handoff_record=handoff,
+    )
+    assert "decision" not in tlc
+
+    tpa = evaluate_tpa_context_admissibility(
+        normalized_execution_request=normalized,
+        tlc_handoff_record=handoff,
+        context_recipe_spec=_recipe(),
+        source_metadata=_sources(),
+    )
+    assert "pqx_slice_execution_record" not in tpa
+
+    pqx = execute_bounded_context_assembly(
+        build_admission_record=admission,
+        normalized_execution_request=normalized,
+        tlc_handoff_record=handoff,
+        tpa_slice_artifact=tpa["tpa_slice_artifact"],
+        context_recipe_spec=_recipe(),
+        approved_sources=_sources(),
+        created_at="2026-04-09T00:00:00Z",
+    )
+    assert pqx["context_bundle_record"]["admissibility_status"] == "approved"


### PR DESCRIPTION
### Motivation
- Establish the minimal repo-native governed context foundation (CTX-01..CTX-06) with strict ownership boundaries and fail-closed repo-mutating lineage (AEX → TLC → TPA → PQX). 
- Provide formal, versioned JSON Schema contracts for context artifacts so downstream systems can rely on strict validation and provenance linkage.
- Add HNX stage semantics for context workflows to define preconditions and continuity without adding execution or policy authority.
- Preserve canonical single-owner responsibilities from the System Registry and avoid duplicating policy/admission logic across systems.

### Description
- Add strict JSON Schema Draft 2020-12 contracts and golden examples for four new artifacts: `context_bundle_record`, `context_source_admission_record`, `context_conflict_record`, and `context_recipe_spec` under `contracts/schemas/` and `contracts/examples/`, and register them in `contracts/standards-manifest.json`.
- Extend AEX admission surface by adding a context-capability detector in `spectrum_systems/aex/classifier.py` and tagging admitted `build_admission_record` entries with `context_capability_repo_mutation` and related reason codes in `spectrum_systems/aex/engine.py` while preserving AEX-only admission authority.
- Add HNX-owned stage semantics helper `evaluate_context_stage_semantics` in `spectrum_systems/modules/runtime/hnx_execution_state.py` to declare `context_map`, `context_admission`, `context_assembly`, `context_preflight`, and `context_checkpoint_resume` preconditions/continuity requirements (no execution or policy logic added).
- Implement a narrow, ownership-clean governed context flow module `spectrum_systems/modules/runtime/context_governed_flow.py` that provides:
  - TLC seam: `create_tlc_context_handoff` and `route_context_slice_to_tpa` that validate AEX lineage and route to TPA (no policy adjudication).
  - TPA seam: `evaluate_tpa_context_admissibility` that deterministically evaluates admissibility (source type/schema/freshness/trust/classification/complexity budget) and emits `tpa_slice_artifact` + observability summary (no execution).
  - PQX seam: `execute_bounded_context_assembly` that requires valid AEX/TLC lineage plus an allowed `tpa_slice_artifact` and produces deterministic `context_bundle_record` and PQX execution artifacts.
- Add `tests/test_context_governed_foundation.py` covering contract validation, HNX semantics, AEX classification, TLC routing, TPA admissibility (allow/deny cases), PQX lineage enforcement and deterministic bundle manifest hashing, and ownership boundary assertions.

### Testing
- Ran contract and flow test suites and scripts; all automated checks passed:
  - `pytest tests/test_context_governed_foundation.py` — PASSED (covers CTX-01..CTX-06 behaviors).
  - `pytest tests/test_aex_admission.py tests/test_tlc_handoff_flow.py tests/test_pqx_required_context_enforcement.py` — PASSED.
  - `pytest tests/test_contracts.py tests/test_contract_enforcement.py` — PASSED.
  - `python scripts/run_contract_enforcement.py` — completed with `failures=0 warnings=0 not_yet_enforceable=0`.
- Notes: the repository-level contract boundary audit (`.codex/skills/contract-boundary-audit/run.sh`) was executed during validation and produced warnings about unrelated manifest references (informational); it did not block the changes and the new schemas/examples validate against the registry and tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7dc53428883299149ec69ed77d24d)