### PR TITLE
Add GOV-A governed repair loop red-team assessment report

### DIFF
--- a/docs/reviews/gov_a_repair_loop_redteam.md
+++ b/docs/reviews/gov_a_repair_loop_redteam.md
@@ -1,0 +1,79 @@
+# GOV-A Repair Loop Red-Team — 2026-04-09
+
+Primary Type: REVIEW
+
+## 1. Executive Verdict
+- Is the loop enforceable?
+- NO
+
+## 2. Attack Results
+
+### Attack 1 — Review bypass
+- result: **SUCCEEDED (BLOCKER)**
+- explanation:
+  - `execute_sequence_run(...)` is a public execution path that does not require or trigger RQX review by default. Review enforcement is only activated when `review_results_by_slice` is explicitly passed (`enforce_review_policy = review_results_by_slice is not None`).
+  - A caller can execute successful PQX slices with `execute_slice` and receive successful state progression while never invoking `run_review_queue_executor(...)`.
+  - Exploit path:
+    1. Call `execute_sequence_run(...)` directly with valid `slice_requests`.
+    2. Provide a slice executor that returns `{"execution_status": "success"}` and required refs.
+    3. Omit `review_results_by_slice`.
+    4. Execution completes without mandatory RQX review.
+
+### Attack 2 — Fix bypass
+- result: **SUCCEEDED (BLOCKER)**
+- explanation:
+  - In bundle fix handling, `_execute_pending_fix_loop(...)` executes fixes through `execute_fix_step(...)` and `execute_sequence_run(...)` without any TPA gate artifact requirement and without routing through the RQX→TPA→PQX bounded loop.
+  - The only gating there is `pqx_fix_gate` (mapping/validation consistency), not TPA policy gate approval.
+  - Exploit path:
+    1. Seed `bundle_state.pending_fix_ids` with an `open` fix.
+    2. Run `execute_bundle_run(..., execute_fixes=True)`.
+    3. Fix executes and can be marked resolved/passed via fix gate.
+    4. No mandatory TPA gate artifact is required before fix execution.
+
+### Attack 3 — Fake TPA linkage
+- result: **SUCCEEDED (BLOCKER)**
+- explanation:
+  - `run_review_fix_execution_cycle(...)` checks TPA linkage structurally (schema + field checks + string reference containment), but there is no authenticity binding to an actual TPA run/output lineage.
+  - A forged but schema-valid `tpa_slice_artifact` with `phase="gate"`, `artifact_kind="gate"`, `promotion_ready=true`, allowed decisions, and `review_signal_refs` containing `source_review_result_ref` is accepted.
+  - Exploit path:
+    1. Craft synthetic `review_fix_execution_request_artifact` with fake `tpa_slice_artifact` fields set to pass `_tpa_gate_decision(...)`.
+    2. Include matching `source_review_result_ref` string in `review_signal_refs`.
+    3. Run `run_review_fix_execution_cycle(...)`.
+    4. PQX execution is allowed although TPA provenance can be fabricated.
+
+### Attack 4 — RQX role drift
+- result: **FAILED (no exploit)**
+- explanation:
+  - `run_review_queue_executor(...)` does bounded review artifact production and emits findings/merge readiness/fix slice/handoff only.
+  - It explicitly marks bounded behavior (`bounded_review=True`) and `automatic_fix_execution="disabled"`.
+  - RQX does not execute PQX slices, does not auto-run fixes, and does not claim closure authority.
+
+### Attack 5 — Unresolved recursion
+- result: **FAILED (no exploit)**
+- explanation:
+  - In `run_review_fix_execution_cycle(...)`, unresolved outcomes set terminal statuses and emit operator handoff artifacts. The cycle is hard-bounded to one pass (`loop_cycle_count=1`, `stopped=True`).
+  - TLC disposition classification keeps execution disabled (`execution_triggered=False`, `rqx_cycle_reentry_triggered=False`) and requires human action for follow-on scheduling.
+  - No hidden auto-recursive execution was found in this seam.
+
+### Attack 6 — Bundle inconsistency
+- result: **SUCCEEDED (BLOCKER)**
+- explanation:
+  - Bundle-level execution and fix-level execution are not consistently forced through the same governed repair loop contract.
+  - `execute_bundle_run(...)` does execute post-run RQX review emission, but fix execution inside `_execute_pending_fix_loop(...)` can run independently of TPA policy gating.
+  - This creates split governance semantics:
+    - bundle path: post-execution review present;
+    - fix path: direct execution path possible with no mandatory TPA gate artifact.
+  - Result: bundle/fix mixing can bypass required fix-gating semantics.
+
+### Attack 7 — Drift scenario
+- result: **SUCCEEDED (HIGH)**
+- explanation:
+  - Multiple callable seams (`execute_sequence_run`, bundle fix loop helpers, direct executor wrappers) can be invoked by future wrappers/callers without forcing the strict RQX→TPA→PQX contract.
+  - Existing behavior already relies on caller discipline for some gates (especially review policy activation and fix-gate source quality).
+  - A realistic future wrapper that “just calls sequence runner” can silently reintroduce direct execution with missing review/TPA linkage.
+
+## 3. Weakest Point
+- `spectrum_systems/modules/runtime/pqx_bundle_orchestrator.py` fix execution path (`_execute_pending_fix_loop`) is the single most fragile component because it enables direct fix execution and state advancement without mandatory TPA gate artifact lineage.
+
+## 4. Final Recommendation
+- **DO NOT MOVE ON**


### PR DESCRIPTION
### Motivation
- Add an adversarial red-team assessment artifact that focuses solely on the governed repair loop seam `PQX → RQX → TPA → PQX` to enumerate ways the repair loop can be bypassed and produce a clear enforceability verdict.

### Description
- Create `docs/reviews/gov_a_repair_loop_redteam.md` containing the required structured report (executive verdict, Attack 1–7 results with exploit paths or failure reasoning, weakest point identification, and a single final recommendation `DO NOT MOVE ON`).

### Testing
- Ran targeted unit tests: `pytest -q tests/test_review_fix_execution_loop.py tests/test_review_queue_executor.py tests/test_review_handoff_disposition.py tests/test_pqx_bundle_orchestrator.py` and all tests passed (`46 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7ee1487648329aed5d79b852107f7)