### PR TITLE
BATCH-GOV-A-FIX-02: Harden TPA gate authority with verified authenticity

### DIFF
--- a/.github/workflows/artifact-boundary.yml
+++ b/.github/workflows/artifact-boundary.yml
@@ -100,10 +100,33 @@ jobs:
           GITHUB_BEFORE_SHA: ${{ github.event.before || '' }}
           GITHUB_SHA: ${{ github.sha }}
         run: |
+          python - <<'PY'
+          import json
+          import subprocess
+          from pathlib import Path
+
+          base_ref = "${{ steps.preflight-refs.outputs.base_ref }}"
+          head_ref = "${{ steps.preflight-refs.outputs.head_ref }}"
+          changed = subprocess.check_output(
+              ["git", "diff", "--name-only", f"{base_ref}..{head_ref}"],
+              text=True,
+          ).splitlines()
+          changed = sorted({p.strip() for p in changed if p.strip()})
+
+          wrapper_path = Path("outputs/contract_preflight/preflight_pqx_task_wrapper.json")
+          wrapper_path.parent.mkdir(parents=True, exist_ok=True)
+          wrapper = json.loads(Path("contracts/examples/codex_pqx_task_wrapper.json").read_text(encoding="utf-8"))
+          wrapper["changed_paths"] = changed
+          Path(wrapper_path).write_text(json.dumps(wrapper, indent=2) + "\n", encoding="utf-8")
+          PY
+
           python scripts/run_contract_preflight.py \
             --base-ref "${{ steps.preflight-refs.outputs.base_ref }}" \
             --head-ref "${{ steps.preflight-refs.outputs.head_ref }}" \
-            --output-dir outputs/contract_preflight
+            --output-dir outputs/contract_preflight \
+            --execution-context pqx_governed \
+            --pqx-wrapper-path outputs/contract_preflight/preflight_pqx_task_wrapper.json \
+            --authority-evidence-ref artifacts/pqx_runs/preflight.pqx_slice_execution_record.json
 
       - name: Upload contract preflight outputs
         if: always()

--- a/contracts/examples/review_fix_execution_request_artifact.json
+++ b/contracts/examples/review_fix_execution_request_artifact.json
@@ -40,7 +40,7 @@
   ],
   "tpa_slice_artifact": {
     "artifact_type": "tpa_slice_artifact",
-    "schema_version": "1.2.0",
+    "schema_version": "1.3.0",
     "artifact_id": "run-001:AI-01:GATE",
     "run_id": "run-001",
     "trace_id": "trace-001",
@@ -119,12 +119,16 @@
       "promotion_ready": true,
       "fail_closed_reason": null,
       "context_bundle_ref": "context-bundle:rqx-b2",
-      "review_signal_refs": ["review_result_artifact:rqx-02-review-001"],
+      "review_signal_refs": [
+        "review_result_artifact:rqx-02-review-001"
+      ],
       "eval_signal_refs": [],
       "addressed_failure_pattern_refs": [],
       "unaddressed_failure_pattern_refs": [],
       "high_risk_unmitigated": false,
-      "risk_mitigation_refs": ["mitigation:bounded-scope"],
+      "risk_mitigation_refs": [
+        "mitigation:bounded-scope"
+      ],
       "simplicity_review": {
         "decision": "allow",
         "overall_severity": "low",
@@ -139,6 +143,18 @@
         "historical_baseline_ref": "baseline:run-000",
         "exception_justified": false
       }
+    },
+    "request_id": "rfer-001",
+    "authenticity": {
+      "issuer": "TPA",
+      "key_id": "tpa-hs256-v1",
+      "payload_digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      "audience": "pqx_repo_write_boundary",
+      "scope": "repo_write_lineage:tpa_slice_artifact:rfer-001:trace-001",
+      "issued_at": "2026-04-08T01:01:00Z",
+      "expires_at": "2026-04-08T01:16:00Z",
+      "lineage_token_id": "lin-000000000000000000000000",
+      "attestation": "0000000000000000000000000000000000000000000000000000000000000000"
     }
   },
   "pqx_task_wrapper": {
@@ -205,9 +221,15 @@
     "scope": "Post-fix bounded re-review.",
     "run_id": "run-001",
     "batch_id": "batch-rqx-02",
-    "changed_files": ["spectrum_systems/modules/review_queue_executor.py"],
-    "produced_artifact_refs": ["artifacts/pqx_runs/run-001/output.json"],
-    "validation_result_refs": ["artifacts/pqx_runs/run-001/test_results.json"],
+    "changed_files": [
+      "spectrum_systems/modules/review_queue_executor.py"
+    ],
+    "produced_artifact_refs": [
+      "artifacts/pqx_runs/run-001/output.json"
+    ],
+    "validation_result_refs": [
+      "artifacts/pqx_runs/run-001/test_results.json"
+    ],
     "requested_at": "2026-04-08T01:02:00Z"
   },
   "loop_cycle_count": 1,

--- a/contracts/examples/tpa_slice_artifact.json
+++ b/contracts/examples/tpa_slice_artifact.json
@@ -1,6 +1,6 @@
 {
   "artifact_type": "tpa_slice_artifact",
-  "schema_version": "1.2.0",
+  "schema_version": "1.3.0",
   "artifact_id": "tpa:run-001:AI-01-P",
   "run_id": "run-001",
   "trace_id": "trace-001",
@@ -35,5 +35,17 @@
       "build_small": true,
       "no_redesign": true
     }
+  },
+  "request_id": "rfer-001",
+  "authenticity": {
+    "issuer": "TPA",
+    "key_id": "tpa-hs256-v1",
+    "payload_digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    "audience": "pqx_repo_write_boundary",
+    "scope": "repo_write_lineage:tpa_slice_artifact:rfer-001:trace-001",
+    "issued_at": "2026-04-08T01:01:00Z",
+    "expires_at": "2026-04-08T01:16:00Z",
+    "lineage_token_id": "lin-000000000000000000000000",
+    "attestation": "0000000000000000000000000000000000000000000000000000000000000000"
   }
 }

--- a/contracts/schemas/tpa_slice_artifact.schema.json
+++ b/contracts/schemas/tpa_slice_artifact.schema.json
@@ -10,35 +10,143 @@
     "schema_version",
     "artifact_id",
     "run_id",
+    "request_id",
     "trace_id",
     "slice_id",
     "step_id",
     "phase",
     "produced_at",
-    "artifact"
+    "artifact",
+    "authenticity"
   ],
   "properties": {
-    "artifact_type": {"type": "string", "const": "tpa_slice_artifact"},
-    "schema_version": {"type": "string", "const": "1.2.0"},
-    "artifact_id": {"type": "string", "minLength": 1},
-    "run_id": {"type": "string", "minLength": 1},
-    "trace_id": {"type": "string", "minLength": 1},
-    "slice_id": {"type": "string", "minLength": 1},
-    "step_id": {"type": "string", "pattern": "^AI-[0-9]+$"},
-    "phase": {"type": "string", "enum": ["plan", "build", "simplify", "gate"]},
-    "tpa_mode": {"type": "string", "enum": ["full", "lightweight"]},
-    "produced_at": {"type": "string", "format": "date-time"},
+    "artifact_type": {
+      "type": "string",
+      "const": "tpa_slice_artifact"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.3.0"
+    },
+    "artifact_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "run_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "slice_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "step_id": {
+      "type": "string",
+      "pattern": "^AI-[0-9]+$"
+    },
+    "phase": {
+      "type": "string",
+      "enum": [
+        "plan",
+        "build",
+        "simplify",
+        "gate"
+      ]
+    },
+    "tpa_mode": {
+      "type": "string",
+      "enum": [
+        "full",
+        "lightweight"
+      ]
+    },
+    "produced_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "artifact": {
       "oneOf": [
-        {"$ref": "#/$defs/plan_artifact"},
-        {"$ref": "#/$defs/build_artifact"},
-        {"$ref": "#/$defs/simplify_artifact"},
-        {"$ref": "#/$defs/gate_artifact"}
+        {
+          "$ref": "#/$defs/plan_artifact"
+        },
+        {
+          "$ref": "#/$defs/build_artifact"
+        },
+        {
+          "$ref": "#/$defs/simplify_artifact"
+        },
+        {
+          "$ref": "#/$defs/gate_artifact"
+        }
       ]
+    },
+    "request_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "authenticity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "issuer",
+        "key_id",
+        "payload_digest",
+        "audience",
+        "scope",
+        "issued_at",
+        "expires_at",
+        "lineage_token_id",
+        "attestation"
+      ],
+      "properties": {
+        "issuer": {
+          "type": "string",
+          "const": "TPA"
+        },
+        "key_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "payload_digest": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        },
+        "attestation": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "audience": {
+          "type": "string",
+          "const": "pqx_repo_write_boundary"
+        },
+        "scope": {
+          "type": "string",
+          "minLength": 1
+        },
+        "issued_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "expires_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "lineage_token_id": {
+          "type": "string",
+          "pattern": "^lin-[0-9a-f]{24}$"
+        }
+      }
     }
   },
   "$defs": {
-    "non_empty": {"type": "string", "minLength": 1},
+    "non_empty": {
+      "type": "string",
+      "minLength": 1
+    },
     "complexity_signals": {
       "type": "object",
       "additionalProperties": false,
@@ -60,21 +168,62 @@
         "abstraction_removed_count"
       ],
       "properties": {
-        "files_changed_count": {"type": "integer", "minimum": 0},
-        "lines_added": {"type": "integer", "minimum": 0},
-        "lines_removed": {"type": "integer", "minimum": 0},
-        "net_line_delta": {"type": "integer"},
-        "functions_added_count": {"type": "integer", "minimum": 0},
-        "functions_removed_count": {"type": "integer", "minimum": 0},
-        "helpers_added_count": {"type": "integer", "minimum": 0},
-        "helpers_removed_count": {"type": "integer", "minimum": 0},
-        "wrappers_collapsed_count": {"type": "integer", "minimum": 0},
-        "deletions_count": {"type": "integer", "minimum": 0},
-        "public_surface_delta_count": {"type": "integer"},
-        "approximate_max_nesting_delta": {"type": "integer"},
-        "approximate_branching_delta": {"type": "integer"},
-        "abstraction_added_count": {"type": "integer", "minimum": 0},
-        "abstraction_removed_count": {"type": "integer", "minimum": 0}
+        "files_changed_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "lines_added": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "lines_removed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "net_line_delta": {
+          "type": "integer"
+        },
+        "functions_added_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "functions_removed_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "helpers_added_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "helpers_removed_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "wrappers_collapsed_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "deletions_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "public_surface_delta_count": {
+          "type": "integer"
+        },
+        "approximate_max_nesting_delta": {
+          "type": "integer"
+        },
+        "approximate_branching_delta": {
+          "type": "integer"
+        },
+        "abstraction_added_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "abstraction_removed_count": {
+          "type": "integer",
+          "minimum": 0
+        }
       }
     },
     "complexity_signal_delta": {
@@ -98,21 +247,51 @@
         "abstraction_removed_count"
       ],
       "properties": {
-        "files_changed_count": {"type": "integer"},
-        "lines_added": {"type": "integer"},
-        "lines_removed": {"type": "integer"},
-        "net_line_delta": {"type": "integer"},
-        "functions_added_count": {"type": "integer"},
-        "functions_removed_count": {"type": "integer"},
-        "helpers_added_count": {"type": "integer"},
-        "helpers_removed_count": {"type": "integer"},
-        "wrappers_collapsed_count": {"type": "integer"},
-        "deletions_count": {"type": "integer"},
-        "public_surface_delta_count": {"type": "integer"},
-        "approximate_max_nesting_delta": {"type": "integer"},
-        "approximate_branching_delta": {"type": "integer"},
-        "abstraction_added_count": {"type": "integer"},
-        "abstraction_removed_count": {"type": "integer"}
+        "files_changed_count": {
+          "type": "integer"
+        },
+        "lines_added": {
+          "type": "integer"
+        },
+        "lines_removed": {
+          "type": "integer"
+        },
+        "net_line_delta": {
+          "type": "integer"
+        },
+        "functions_added_count": {
+          "type": "integer"
+        },
+        "functions_removed_count": {
+          "type": "integer"
+        },
+        "helpers_added_count": {
+          "type": "integer"
+        },
+        "helpers_removed_count": {
+          "type": "integer"
+        },
+        "wrappers_collapsed_count": {
+          "type": "integer"
+        },
+        "deletions_count": {
+          "type": "integer"
+        },
+        "public_surface_delta_count": {
+          "type": "integer"
+        },
+        "approximate_max_nesting_delta": {
+          "type": "integer"
+        },
+        "approximate_branching_delta": {
+          "type": "integer"
+        },
+        "abstraction_added_count": {
+          "type": "integer"
+        },
+        "abstraction_removed_count": {
+          "type": "integer"
+        }
       }
     },
     "plan_artifact": {
@@ -133,41 +312,129 @@
         "context_rationale"
       ],
       "properties": {
-        "artifact_kind": {"type": "string", "const": "plan"},
-        "execution_mode": {"type": "string", "enum": ["feature_build", "cleanup_only"]},
+        "artifact_kind": {
+          "type": "string",
+          "const": "plan"
+        },
+        "execution_mode": {
+          "type": "string",
+          "enum": [
+            "feature_build",
+            "cleanup_only"
+          ]
+        },
         "cleanup_scope": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["bounded_files", "reason"],
+          "required": [
+            "bounded_files",
+            "reason"
+          ],
           "properties": {
-            "bounded_files": {"type": "array", "items": {"$ref": "#/$defs/non_empty"}, "minItems": 1, "uniqueItems": true},
-            "reason": {"$ref": "#/$defs/non_empty"}
+            "bounded_files": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/non_empty"
+              },
+              "minItems": 1,
+              "uniqueItems": true
+            },
+            "reason": {
+              "$ref": "#/$defs/non_empty"
+            }
           }
         },
-        "files_touched": {"type": "array", "items": {"$ref": "#/$defs/non_empty"}, "uniqueItems": true},
-        "seams_reused": {"type": "array", "items": {"$ref": "#/$defs/non_empty"}, "uniqueItems": true},
-        "abstraction_intent": {"type": "string", "enum": ["reuse_existing", "minimal_extension"]},
-        "context_bundle_ref": {"$ref": "#/$defs/non_empty"},
-        "known_risk_refs": {"type": "array", "items": {"$ref": "#/$defs/non_empty"}, "uniqueItems": true},
-        "prior_failure_pattern_refs": {"type": "array", "items": {"$ref": "#/$defs/non_empty"}, "uniqueItems": true},
-        "modules_affected": {"type": "array", "items": {"$ref": "#/$defs/non_empty"}, "uniqueItems": true},
-        "improvement_objective": {"$ref": "#/$defs/non_empty"},
-        "context_rationale": {"$ref": "#/$defs/non_empty"},
-        "tpa_mode": {"type": "string", "enum": ["full", "lightweight"]},
+        "files_touched": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/non_empty"
+          },
+          "uniqueItems": true
+        },
+        "seams_reused": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/non_empty"
+          },
+          "uniqueItems": true
+        },
+        "abstraction_intent": {
+          "type": "string",
+          "enum": [
+            "reuse_existing",
+            "minimal_extension"
+          ]
+        },
+        "context_bundle_ref": {
+          "$ref": "#/$defs/non_empty"
+        },
+        "known_risk_refs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/non_empty"
+          },
+          "uniqueItems": true
+        },
+        "prior_failure_pattern_refs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/non_empty"
+          },
+          "uniqueItems": true
+        },
+        "modules_affected": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/non_empty"
+          },
+          "uniqueItems": true
+        },
+        "improvement_objective": {
+          "$ref": "#/$defs/non_empty"
+        },
+        "context_rationale": {
+          "$ref": "#/$defs/non_empty"
+        },
+        "tpa_mode": {
+          "type": "string",
+          "enum": [
+            "full",
+            "lightweight"
+          ]
+        },
         "constraints_acknowledged": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["build_small", "no_redesign"],
+          "required": [
+            "build_small",
+            "no_redesign"
+          ],
           "properties": {
-            "build_small": {"type": "boolean", "const": true},
-            "no_redesign": {"type": "boolean", "const": true}
+            "build_small": {
+              "type": "boolean",
+              "const": true
+            },
+            "no_redesign": {
+              "type": "boolean",
+              "const": true
+            }
           }
         }
       },
       "allOf": [
         {
-          "if": {"properties": {"execution_mode": {"const": "cleanup_only"}}},
-          "then": {"required": ["cleanup_scope"]}
+          "if": {
+            "properties": {
+              "execution_mode": {
+                "const": "cleanup_only"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "cleanup_scope"
+            ]
+          }
         }
       ]
     },
@@ -190,30 +457,83 @@
         "complexity_signals"
       ],
       "properties": {
-        "artifact_kind": {"type": "string", "const": "build"},
-        "files_touched": {"type": "array", "items": {"$ref": "#/$defs/non_empty"}, "uniqueItems": true},
-        "new_layers": {"type": "integer", "minimum": 0},
-        "unused_helpers": {"type": "array", "items": {"$ref": "#/$defs/non_empty"}, "uniqueItems": true},
-        "unnecessary_indirection": {"type": "array", "items": {"$ref": "#/$defs/non_empty"}, "uniqueItems": true},
-        "plan_scope_match": {"type": "boolean"},
+        "artifact_kind": {
+          "type": "string",
+          "const": "build"
+        },
+        "files_touched": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/non_empty"
+          },
+          "uniqueItems": true
+        },
+        "new_layers": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "unused_helpers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/non_empty"
+          },
+          "uniqueItems": true
+        },
+        "unnecessary_indirection": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/non_empty"
+          },
+          "uniqueItems": true
+        },
+        "plan_scope_match": {
+          "type": "boolean"
+        },
         "abstraction_justifications": {
           "type": "array",
           "items": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["abstraction", "justification"],
+            "required": [
+              "abstraction",
+              "justification"
+            ],
             "properties": {
-              "abstraction": {"$ref": "#/$defs/non_empty"},
-              "justification": {"$ref": "#/$defs/non_empty"}
+              "abstraction": {
+                "$ref": "#/$defs/non_empty"
+              },
+              "justification": {
+                "$ref": "#/$defs/non_empty"
+              }
             }
           }
         },
-        "context_bundle_ref": {"$ref": "#/$defs/non_empty"},
-        "known_failure_patterns_avoided": {"type": "array", "items": {"$ref": "#/$defs/non_empty"}, "uniqueItems": true},
-        "existing_abstractions_satisfied": {"type": "boolean"},
-        "speculative_expansion_detected": {"type": "boolean"},
-        "reused_module_refs": {"type": "array", "items": {"$ref": "#/$defs/non_empty"}, "uniqueItems": true},
-        "complexity_signals": {"$ref": "#/$defs/complexity_signals"}
+        "context_bundle_ref": {
+          "$ref": "#/$defs/non_empty"
+        },
+        "known_failure_patterns_avoided": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/non_empty"
+          },
+          "uniqueItems": true
+        },
+        "existing_abstractions_satisfied": {
+          "type": "boolean"
+        },
+        "speculative_expansion_detected": {
+          "type": "boolean"
+        },
+        "reused_module_refs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/non_empty"
+          },
+          "uniqueItems": true
+        },
+        "complexity_signals": {
+          "$ref": "#/$defs/complexity_signals"
+        }
       }
     },
     "simplify_artifact": {
@@ -233,19 +553,56 @@
         "delete_pass"
       ],
       "properties": {
-        "artifact_kind": {"type": "string", "const": "simplify"},
-        "source_build_artifact_id": {"$ref": "#/$defs/non_empty"},
+        "artifact_kind": {
+          "type": "string",
+          "const": "simplify"
+        },
+        "source_build_artifact_id": {
+          "$ref": "#/$defs/non_empty"
+        },
         "actions": {
           "type": "array",
-          "items": {"type": "string", "enum": ["dedupe_logic", "reduce_nesting", "rename_for_clarity", "delete_unnecessary_code"]}
+          "items": {
+            "type": "string",
+            "enum": [
+              "dedupe_logic",
+              "reduce_nesting",
+              "rename_for_clarity",
+              "delete_unnecessary_code"
+            ]
+          }
         },
-        "behavior_changed": {"type": "boolean"},
-        "new_layers_introduced": {"type": "integer", "minimum": 0},
-        "context_bundle_ref": {"$ref": "#/$defs/non_empty"},
-        "redundant_code_paths_removed": {"type": "integer", "minimum": 0},
-        "duplicate_logic_collapsed": {"type": "array", "items": {"$ref": "#/$defs/non_empty"}, "uniqueItems": true},
-        "pattern_consistency_refs": {"type": "array", "items": {"$ref": "#/$defs/non_empty"}, "uniqueItems": true},
-        "complexity_signals": {"$ref": "#/$defs/complexity_signals"},
+        "behavior_changed": {
+          "type": "boolean"
+        },
+        "new_layers_introduced": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "context_bundle_ref": {
+          "$ref": "#/$defs/non_empty"
+        },
+        "redundant_code_paths_removed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "duplicate_logic_collapsed": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/non_empty"
+          },
+          "uniqueItems": true
+        },
+        "pattern_consistency_refs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/non_empty"
+          },
+          "uniqueItems": true
+        },
+        "complexity_signals": {
+          "$ref": "#/$defs/complexity_signals"
+        },
         "delete_pass": {
           "type": "object",
           "additionalProperties": false,
@@ -260,14 +617,53 @@
             "indirection_avoided"
           ],
           "properties": {
-            "deletion_considered": {"type": "boolean"},
-            "deletion_performed": {"type": "boolean"},
-            "deletion_rejected_reason": {"type": ["string", "null"]},
-            "deleted_items": {"type": "array", "items": {"$ref": "#/$defs/non_empty"}, "uniqueItems": true},
-            "collapsed_abstractions": {"type": "array", "items": {"$ref": "#/$defs/non_empty"}, "uniqueItems": true},
-            "removed_helpers": {"type": "array", "items": {"$ref": "#/$defs/non_empty"}, "uniqueItems": true},
-            "removed_wrappers": {"type": "array", "items": {"$ref": "#/$defs/non_empty"}, "uniqueItems": true},
-            "indirection_avoided": {"type": "array", "items": {"$ref": "#/$defs/non_empty"}, "uniqueItems": true}
+            "deletion_considered": {
+              "type": "boolean"
+            },
+            "deletion_performed": {
+              "type": "boolean"
+            },
+            "deletion_rejected_reason": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "deleted_items": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/non_empty"
+              },
+              "uniqueItems": true
+            },
+            "collapsed_abstractions": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/non_empty"
+              },
+              "uniqueItems": true
+            },
+            "removed_helpers": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/non_empty"
+              },
+              "uniqueItems": true
+            },
+            "removed_wrappers": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/non_empty"
+              },
+              "uniqueItems": true
+            },
+            "indirection_avoided": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/non_empty"
+              },
+              "uniqueItems": true
+            }
           }
         }
       }
@@ -300,57 +696,170 @@
         "complexity_regression_gate"
       ],
       "properties": {
-        "artifact_kind": {"type": "string", "const": "gate"},
-        "build_artifact_id": {"$ref": "#/$defs/non_empty"},
-        "simplify_artifact_id": {"$ref": "#/$defs/non_empty"},
-        "behavioral_equivalence": {"type": "boolean"},
-        "contract_valid": {"type": "boolean"},
-        "tests_valid": {"type": "boolean"},
-        "selected_pass": {"type": "string", "enum": ["pass_1_build", "pass_2_simplify"]},
-        "rejected_pass": {"type": "string", "enum": ["pass_1_build", "pass_2_simplify"]},
+        "artifact_kind": {
+          "type": "string",
+          "const": "gate"
+        },
+        "build_artifact_id": {
+          "$ref": "#/$defs/non_empty"
+        },
+        "simplify_artifact_id": {
+          "$ref": "#/$defs/non_empty"
+        },
+        "behavioral_equivalence": {
+          "type": "boolean"
+        },
+        "contract_valid": {
+          "type": "boolean"
+        },
+        "tests_valid": {
+          "type": "boolean"
+        },
+        "selected_pass": {
+          "type": "string",
+          "enum": [
+            "pass_1_build",
+            "pass_2_simplify"
+          ]
+        },
+        "rejected_pass": {
+          "type": "string",
+          "enum": [
+            "pass_1_build",
+            "pass_2_simplify"
+          ]
+        },
         "selection_inputs": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["build_artifact_id", "simplify_artifact_id", "comparison_inputs_present"],
+          "required": [
+            "build_artifact_id",
+            "simplify_artifact_id",
+            "comparison_inputs_present"
+          ],
           "properties": {
-            "build_artifact_id": {"$ref": "#/$defs/non_empty"},
-            "simplify_artifact_id": {"$ref": "#/$defs/non_empty"},
-            "comparison_inputs_present": {"type": "boolean"}
+            "build_artifact_id": {
+              "$ref": "#/$defs/non_empty"
+            },
+            "simplify_artifact_id": {
+              "$ref": "#/$defs/non_empty"
+            },
+            "comparison_inputs_present": {
+              "type": "boolean"
+            }
           }
         },
         "selection_metrics": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["build", "simplify", "simplify_delta"],
+          "required": [
+            "build",
+            "simplify",
+            "simplify_delta"
+          ],
           "properties": {
-            "build": {"$ref": "#/$defs/complexity_signals"},
-            "simplify": {"$ref": "#/$defs/complexity_signals"},
-            "simplify_delta": {"$ref": "#/$defs/complexity_signal_delta"}
+            "build": {
+              "$ref": "#/$defs/complexity_signals"
+            },
+            "simplify": {
+              "$ref": "#/$defs/complexity_signals"
+            },
+            "simplify_delta": {
+              "$ref": "#/$defs/complexity_signal_delta"
+            }
           }
         },
-        "selection_rationale": {"$ref": "#/$defs/non_empty"},
-        "promotion_ready": {"type": "boolean"},
-        "fail_closed_reason": {"type": ["string", "null"]},
-        "context_bundle_ref": {"$ref": "#/$defs/non_empty"},
-        "review_signal_refs": {"type": "array", "items": {"$ref": "#/$defs/non_empty"}, "uniqueItems": true},
-        "eval_signal_refs": {"type": "array", "items": {"$ref": "#/$defs/non_empty"}, "uniqueItems": true},
-        "addressed_failure_pattern_refs": {"type": "array", "items": {"$ref": "#/$defs/non_empty"}, "uniqueItems": true},
-        "unaddressed_failure_pattern_refs": {"type": "array", "items": {"$ref": "#/$defs/non_empty"}, "uniqueItems": true},
-        "high_risk_unmitigated": {"type": "boolean"},
-        "risk_mitigation_refs": {"type": "array", "items": {"$ref": "#/$defs/non_empty"}, "uniqueItems": true},
+        "selection_rationale": {
+          "$ref": "#/$defs/non_empty"
+        },
+        "promotion_ready": {
+          "type": "boolean"
+        },
+        "fail_closed_reason": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "context_bundle_ref": {
+          "$ref": "#/$defs/non_empty"
+        },
+        "review_signal_refs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/non_empty"
+          },
+          "uniqueItems": true
+        },
+        "eval_signal_refs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/non_empty"
+          },
+          "uniqueItems": true
+        },
+        "addressed_failure_pattern_refs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/non_empty"
+          },
+          "uniqueItems": true
+        },
+        "unaddressed_failure_pattern_refs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/non_empty"
+          },
+          "uniqueItems": true
+        },
+        "high_risk_unmitigated": {
+          "type": "boolean"
+        },
+        "risk_mitigation_refs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/non_empty"
+          },
+          "uniqueItems": true
+        },
         "simplicity_review": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["decision", "overall_severity", "findings", "report_ref"],
+          "required": [
+            "decision",
+            "overall_severity",
+            "findings",
+            "report_ref"
+          ],
           "properties": {
-            "decision": {"type": "string", "enum": ["allow", "warn", "freeze", "block"]},
-            "overall_severity": {"type": "string", "enum": ["low", "medium", "high", "critical"]},
+            "decision": {
+              "type": "string",
+              "enum": [
+                "allow",
+                "warn",
+                "freeze",
+                "block"
+              ]
+            },
+            "overall_severity": {
+              "type": "string",
+              "enum": [
+                "low",
+                "medium",
+                "high",
+                "critical"
+              ]
+            },
             "findings": {
               "type": "array",
               "items": {
                 "type": "object",
                 "additionalProperties": false,
-                "required": ["category", "severity", "message"],
+                "required": [
+                  "category",
+                  "severity",
+                  "message"
+                ],
                 "properties": {
                   "category": {
                     "type": "string",
@@ -364,12 +873,24 @@
                       "delete_instead_of_abstract"
                     ]
                   },
-                  "severity": {"type": "string", "enum": ["low", "medium", "high", "critical"]},
-                  "message": {"$ref": "#/$defs/non_empty"}
+                  "severity": {
+                    "type": "string",
+                    "enum": [
+                      "low",
+                      "medium",
+                      "high",
+                      "critical"
+                    ]
+                  },
+                  "message": {
+                    "$ref": "#/$defs/non_empty"
+                  }
                 }
               }
             },
-            "report_ref": {"$ref": "#/$defs/non_empty"}
+            "report_ref": {
+              "$ref": "#/$defs/non_empty"
+            }
           }
         },
         "complexity_regression_gate": {
@@ -384,22 +905,56 @@
             "exception_justified"
           ],
           "properties": {
-            "decision": {"type": "string", "enum": ["allow", "warn", "freeze", "block"]},
-            "policy_ref": {"$ref": "#/$defs/non_empty"},
-            "regression_detected": {"type": "boolean"},
-            "historical_baseline_available": {"type": "boolean"},
-            "historical_baseline_ref": {"type": ["string", "null"]},
-            "exception_justified": {"type": "boolean"}
+            "decision": {
+              "type": "string",
+              "enum": [
+                "allow",
+                "warn",
+                "freeze",
+                "block"
+              ]
+            },
+            "policy_ref": {
+              "$ref": "#/$defs/non_empty"
+            },
+            "regression_detected": {
+              "type": "boolean"
+            },
+            "historical_baseline_available": {
+              "type": "boolean"
+            },
+            "historical_baseline_ref": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "exception_justified": {
+              "type": "boolean"
+            }
           }
         },
         "cleanup_only_validation": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["mode_enabled", "equivalence_proven", "replay_ref"],
+          "required": [
+            "mode_enabled",
+            "equivalence_proven",
+            "replay_ref"
+          ],
           "properties": {
-            "mode_enabled": {"type": "boolean"},
-            "equivalence_proven": {"type": "boolean"},
-            "replay_ref": {"type": ["string", "null"]}
+            "mode_enabled": {
+              "type": "boolean"
+            },
+            "equivalence_proven": {
+              "type": "boolean"
+            },
+            "replay_ref": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
           }
         }
       }

--- a/contracts/standards-manifest.json
+++ b/contracts/standards-manifest.json
@@ -1,9 +1,9 @@
 {
   "artifact_type": "standards_manifest",
   "artifact_id": "STD-CONTRACTS",
-  "artifact_version": "1.3.106",
+  "artifact_version": "1.3.107",
   "schema_version": "1.3.98",
-  "standards_version": "1.3.106",
+  "standards_version": "1.3.107",
   "record_id": "REC-STD-2026-04-09-CTX-A",
   "run_id": "run-20260409T000000Z-ctx-a",
   "created_at": "2026-04-09T00:00:00Z",
@@ -15,7 +15,7 @@
     "contact": "architecture@spectrum-systems.test"
   },
   "source_repo": "nicklasorte/spectrum-systems",
-  "source_repo_version": "1.3.106",
+  "source_repo_version": "1.3.107",
   "input_artifacts": [
     {
       "artifact_id": "STD-CONTRACTS",
@@ -4486,15 +4486,15 @@
     {
       "artifact_type": "tpa_slice_artifact",
       "artifact_class": "coordination",
-      "schema_version": "1.2.0",
+      "schema_version": "1.3.0",
       "status": "stable",
       "intended_consumers": [
         "spectrum-systems"
       ],
       "introduced_in": "1.3.25",
-      "last_updated_in": "1.3.68",
+      "last_updated_in": "1.3.107",
       "example_path": "contracts/examples/tpa_slice_artifact.json",
-      "notes": "TPA-001..018 governed Plan\u2192Build\u2192Simplify\u2192Gate artifact with explicit tpa_mode support and required-scope bypass fail-closed enforcement."
+      "notes": "TPA gate artifacts now require verified TPA authenticity issuance binding; local file/token artifacts are audit-only and non-authoritative."
     },
     {
       "artifact_type": "transcript_intelligence_pack",

--- a/docs/governance-reports/contract-enforcement-report.md
+++ b/docs/governance-reports/contract-enforcement-report.md
@@ -1,6 +1,6 @@
 # Cross-Repo Contract Enforcement Report
 
-Generated: 2026-04-08T21:56:46Z
+Generated: 2026-04-09T20:43:40Z
 Source: `contracts/standards-manifest.json`
 
 ## Summary

--- a/docs/governance/tpa_gate_authority_note.md
+++ b/docs/governance/tpa_gate_authority_note.md
@@ -1,0 +1,5 @@
+# TPA gate authority note
+
+TPA gate authority for fix execution now requires verified `tpa_slice_artifact.authenticity` issuance (`issuer=TPA`) bound to payload and request context.
+
+`artifacts/tpa_authority/<id>.json` and deterministic integrity tokens may still be emitted for audit/debug retrieve paths, but they are not authoritative for execution admission.

--- a/docs/review-actions/PLAN-BATCH-GOV-A-FIX-02-2026-04-09.md
+++ b/docs/review-actions/PLAN-BATCH-GOV-A-FIX-02-2026-04-09.md
@@ -1,0 +1,37 @@
+# Plan — BATCH-GOV-A-FIX-02 — 2026-04-09
+
+## Prompt type
+BUILD
+
+## Scope
+Surgical trust-boundary correction so TPA gate authority is derived only from verified TPA issuance authenticity and request binding, with fail-closed PQX boundary enforcement.
+
+## Files in scope
+| File | Action | Purpose |
+| --- | --- | --- |
+| `spectrum_systems/modules/runtime/lineage_authenticity.py` | MODIFY | Add TPA issuer support and issuance authority binding for `tpa_slice_artifact`. |
+| `spectrum_systems/modules/runtime/pqx_sequence_runner.py` | MODIFY | Emit `authenticity` on canonical TPA slice artifacts. |
+| `spectrum_systems/modules/review_fix_execution_loop.py` | MODIFY | Replace forgeable local-file/token authority check with authenticity + payload/request binding validation. |
+| `contracts/schemas/tpa_slice_artifact.schema.json` | MODIFY | Require authenticity object on TPA slice artifact contract. |
+| `contracts/examples/tpa_slice_artifact.json` | MODIFY | Update golden example to include authenticity. |
+| `contracts/examples/review_fix_execution_request_artifact.json` | MODIFY | Update embedded TPA gate artifact to include authenticity. |
+| `contracts/standards-manifest.json` | MODIFY | Version bump for additive schema change. |
+| `tests/test_review_fix_execution_loop.py` | MODIFY | Add adversarial tests for forged/fake/valid TPA authority at gate boundary. |
+| `tests/test_pqx_fix_execution.py` | MODIFY | Update fixtures/helpers to provide authentic TPA artifact issuance instead of token file authority. |
+| `tests/test_pqx_bundle_orchestrator.py` | MODIFY | Update boundary test setup for authentic TPA gate artifacts and forged rejection behavior. |
+| `tests/test_contracts.py` | MODIFY (if needed) | Keep contract/example expectations aligned with schema updates. |
+| `docs/governance/*` (single minimal note file) | ADD | Minimal governance note that file/token are audit-only and non-authoritative. |
+
+## Constraints
+- No redesign of GOV-A flow.
+- No new subsystem introduction.
+- Fail-closed preserved for all mismatches.
+- No duplicate validation paths.
+
+## Validation
+1. `pytest -q tests/test_review_fix_execution_loop.py`
+2. `pytest -q tests/test_pqx_fix_execution.py`
+3. `pytest -q tests/test_pqx_bundle_orchestrator.py`
+4. `pytest -q tests/test_contracts.py`
+5. `pytest -q tests/test_contract_enforcement.py`
+6. `python scripts/run_contract_enforcement.py`

--- a/governance/reports/contract-dependency-graph.json
+++ b/governance/reports/contract-dependency-graph.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0.0",
-  "generated_at": "2026-04-08T21:56:46Z",
+  "generated_at": "2026-04-09T20:43:40Z",
   "source_manifest": "contracts/standards-manifest.json",
   "repos": [
     {

--- a/spectrum_systems/modules/review_fix_execution_loop.py
+++ b/spectrum_systems/modules/review_fix_execution_loop.py
@@ -15,6 +15,7 @@ from spectrum_systems.contracts import load_schema, validate_artifact
 from spectrum_systems.modules.review_handoff_disposition import emit_review_handoff_disposition
 from spectrum_systems.modules.review_queue_executor import run_review_queue_executor
 from spectrum_systems.modules.runtime.codex_to_pqx_task_wrapper import run_wrapped_pqx_task
+from spectrum_systems.modules.runtime.lineage_authenticity import LineageAuthenticityError, verify_authenticity
 
 REQUEST_FILE_SUFFIX = "_review_fix_execution_request_artifact.json"
 RESULT_FILE_SUFFIX = "_review_fix_execution_result_artifact.json"
@@ -52,27 +53,43 @@ def compute_tpa_gate_provenance_token(tpa_slice_artifact: Mapping[str, Any]) -> 
     return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
 
 
-def validate_tpa_gate_authoritative_provenance(
-    *,
-    request_artifact: Mapping[str, Any],
-    repo_root: Path,
-) -> dict[str, Any]:
+def validate_tpa_slice_authority(*, request_artifact: Mapping[str, Any], repo_root: Path) -> dict[str, Any]:
     tpa_slice_artifact = request_artifact["tpa_slice_artifact"]
     artifact_id = str(tpa_slice_artifact.get("artifact_id") or "").strip()
     if not artifact_id:
         raise ReviewFixExecutionLoopError("authoritative TPA provenance requires tpa_slice_artifact.artifact_id")
+
+    try:
+        authenticity = verify_authenticity(artifact=dict(tpa_slice_artifact), expected_issuer="TPA")
+    except LineageAuthenticityError as exc:
+        raise ReviewFixExecutionLoopError(f"authoritative TPA provenance authenticity invalid:{exc}") from exc
+
+    expected_trace_id = str(request_artifact.get("trace_id") or tpa_slice_artifact.get("trace_id") or "").strip()
+    if not expected_trace_id or str(tpa_slice_artifact.get("trace_id") or "").strip() != expected_trace_id:
+        raise ReviewFixExecutionLoopError("authoritative TPA provenance trace_id mismatch")
+
+    expected_step_id = str((((request_artifact.get("pqx_task_wrapper") or {}).get("task_identity") or {}).get("step_id") or "")).strip()
+    if expected_step_id and str(tpa_slice_artifact.get("step_id") or "").strip() != expected_step_id:
+        raise ReviewFixExecutionLoopError("authoritative TPA provenance step_id mismatch")
+
+    request_id = str(request_artifact.get("request_id") or "").strip()
+    scope = str(authenticity.get("scope") or "")
+    if request_id and f":{request_id}:" not in scope:
+        raise ReviewFixExecutionLoopError("authoritative TPA provenance request binding mismatch")
+
+    # Local authority files remain optional audit/debug artifacts and are non-authoritative.
     path = repo_root / "artifacts" / "tpa_authority" / f"{artifact_id}.json"
-    if not path.is_file():
-        raise ReviewFixExecutionLoopError("authoritative TPA provenance artifact_ref is missing")
-    recorded_artifact = json.loads(path.read_text(encoding="utf-8"))
-    recorded_payload = dict(recorded_artifact)
-    token = str(recorded_payload.pop("authoritative_integrity_token", "")).strip()
-    if recorded_payload != dict(tpa_slice_artifact):
-        raise ReviewFixExecutionLoopError("authoritative TPA provenance artifact mismatch")
-    expected = compute_tpa_gate_provenance_token(tpa_slice_artifact)
-    if token != expected:
-        raise ReviewFixExecutionLoopError("authoritative TPA provenance integrity_token mismatch")
-    return {"artifact_ref": str(path), "integrity_token": token, "issued_by_system": "TPA"}
+    artifact_ref = str(path) if path.is_file() else None
+    return {
+        "artifact_ref": artifact_ref,
+        "issued_by_system": "TPA",
+        "authenticity": authenticity,
+    }
+
+
+def validate_tpa_gate_authoritative_provenance(*, request_artifact: Mapping[str, Any], repo_root: Path) -> dict[str, Any]:
+    """Backward-compatible wrapper; authority is enforced by authenticity verification only."""
+    return validate_tpa_slice_authority(request_artifact=request_artifact, repo_root=repo_root)
 
 
 def _validate(instance: dict[str, Any], schema_name: str) -> None:
@@ -287,7 +304,7 @@ def _assert_tpa_gated_fix_flow(request_artifact: Mapping[str, Any], *, repo_root
         raise ReviewFixExecutionLoopError(
             "tpa gate must bind to source_review_result_ref before PQX execution"
         )
-    validate_tpa_gate_authoritative_provenance(
+    validate_tpa_slice_authority(
         request_artifact=request_artifact,
         repo_root=repo_root,
     )

--- a/spectrum_systems/modules/runtime/github_pr_autofix_review_artifact_validation.py
+++ b/spectrum_systems/modules/runtime/github_pr_autofix_review_artifact_validation.py
@@ -127,7 +127,7 @@ def _minimal_complexity() -> dict[str, int]:
 def _build_tpa_gate_artifact(*, request_id: str, trace_id: str, emitted_at: str) -> dict[str, Any]:
     artifact = {
         "artifact_type": "tpa_slice_artifact",
-        "schema_version": "1.2.0",
+        "schema_version": "1.3.0",
         "artifact_id": f"tpa:{request_id}:AI-01-G",
         "run_id": f"autofix-{request_id}",
         "trace_id": trace_id,
@@ -181,6 +181,7 @@ def _build_tpa_gate_artifact(*, request_id: str, trace_id: str, emitted_at: str)
             },
         },
     }
+    artifact["authenticity"] = issue_authenticity(artifact=artifact, issuer="TPA")
     validate_artifact(artifact, "tpa_slice_artifact")
     return artifact
 

--- a/spectrum_systems/modules/runtime/github_pr_autofix_review_artifact_validation.py
+++ b/spectrum_systems/modules/runtime/github_pr_autofix_review_artifact_validation.py
@@ -129,6 +129,7 @@ def _build_tpa_gate_artifact(*, request_id: str, trace_id: str, emitted_at: str)
         "artifact_type": "tpa_slice_artifact",
         "schema_version": "1.3.0",
         "artifact_id": f"tpa:{request_id}:AI-01-G",
+        "request_id": request_id,
         "run_id": f"autofix-{request_id}",
         "trace_id": trace_id,
         "slice_id": "AI-01-G",

--- a/spectrum_systems/modules/runtime/lineage_authenticity.py
+++ b/spectrum_systems/modules/runtime/lineage_authenticity.py
@@ -17,14 +17,17 @@ AUDIENCE_REPO_WRITE_BOUNDARY = "pqx_repo_write_boundary"
 ISSUER_DEFAULT_KEY_IDS = {
     "AEX": "aex-hs256-v1",
     "TLC": "tlc-hs256-v1",
+    "TPA": "tpa-hs256-v1",
 }
 _ISSUER_SECRET_ENV = {
     "AEX": "SPECTRUM_LINEAGE_AUTH_SECRET_AEX",
     "TLC": "SPECTRUM_LINEAGE_AUTH_SECRET_TLC",
+    "TPA": "SPECTRUM_LINEAGE_AUTH_SECRET_TPA",
 }
 _ISSUER_KEY_ENV = {
     "AEX": "SPECTRUM_LINEAGE_AUTH_KEY_ID_AEX",
     "TLC": "SPECTRUM_LINEAGE_AUTH_KEY_ID_TLC",
+    "TPA": "SPECTRUM_LINEAGE_AUTH_KEY_ID_TPA",
 }
 
 
@@ -87,6 +90,10 @@ _AUTHORIZED_ISSUANCE_CALLERS: dict[tuple[str, str], set[str]] = {
     ("TLC", "tlc_handoff_record"): {
         "spectrum_systems.modules.runtime.top_level_conductor:_build_tlc_handoff_record",
         "spectrum_systems.modules.runtime.github_pr_autofix_review_artifact_validation:_build_tlc_handoff",
+    },
+    ("TPA", "tpa_slice_artifact"): {
+        "spectrum_systems.modules.runtime.pqx_sequence_runner:_build_tpa_slice_artifact",
+        "spectrum_systems.modules.runtime.github_pr_autofix_review_artifact_validation:_build_tpa_gate_artifact",
     },
 }
 

--- a/spectrum_systems/modules/runtime/lineage_issuance_registry.py
+++ b/spectrum_systems/modules/runtime/lineage_issuance_registry.py
@@ -22,12 +22,14 @@ _EXPECTED_ISSUER_BY_ARTIFACT = {
     "build_admission_record": "AEX",
     "normalized_execution_request": "AEX",
     "tlc_handoff_record": "TLC",
+    "tpa_slice_artifact": "TPA",
 }
 
 _ARTIFACT_ID_FIELD_BY_TYPE = {
     "build_admission_record": "admission_id",
     "normalized_execution_request": "request_id",
     "tlc_handoff_record": "handoff_id",
+    "tpa_slice_artifact": "artifact_id",
 }
 
 

--- a/spectrum_systems/modules/runtime/pqx_sequence_runner.py
+++ b/spectrum_systems/modules/runtime/pqx_sequence_runner.py
@@ -21,6 +21,7 @@ from spectrum_systems.modules.runtime.pqx_slice_runner import (
     run_pqx_slice,
 )
 from spectrum_systems.modules.runtime.repo_write_lineage_guard import RepoWriteLineageGuardError, validate_repo_write_lineage
+from spectrum_systems.modules.runtime.lineage_authenticity import LineageAuthenticityError, issue_authenticity
 from spectrum_systems.modules.runtime.tpa_complexity_governance import (
     build_complexity_budget,
     build_complexity_trend,
@@ -440,6 +441,7 @@ def _build_batch_result(state: dict) -> dict:
 
 def _build_tpa_slice_artifact(
     *,
+    request_id: str,
     run_id: str,
     trace_id: str,
     slice_id: str,
@@ -452,8 +454,9 @@ def _build_tpa_slice_artifact(
         raise PQXSequenceRunnerError("TPA artifact requested for non-TPA slice id")
     artifact = {
         "artifact_type": "tpa_slice_artifact",
-        "schema_version": "1.2.0",
+        "schema_version": "1.3.0",
         "artifact_id": f"tpa:{run_id}:{slice_id}",
+        "request_id": request_id,
         "run_id": run_id,
         "trace_id": trace_id,
         "slice_id": slice_id,
@@ -463,6 +466,10 @@ def _build_tpa_slice_artifact(
         "produced_at": produced_at,
         "artifact": artifact_payload,
     }
+    try:
+        artifact["authenticity"] = issue_authenticity(artifact=artifact, issuer="TPA")
+    except LineageAuthenticityError as exc:
+        raise PQXSequenceRunnerError(f"invalid TPA {phase} artifact for {slice_id}: {exc}") from exc
     try:
         validate_artifact(artifact, "tpa_slice_artifact")
     except Exception as exc:
@@ -1580,6 +1587,7 @@ def execute_sequence_run(
                     raise PQXSequenceRunnerError("tpa_bypass_detected: lightweight mode not eligible for this scope")
                 tpa_mode = requested_mode
                 artifacts["plan"] = _build_tpa_slice_artifact(
+                    request_id=str(request.get("request_id") or f"{run_id}:{next_slice_id}"),
                     run_id=run_id,
                     trace_id=request["trace_id"],
                     slice_id=next_slice_id,
@@ -1623,6 +1631,7 @@ def execute_sequence_run(
                 if planned_modules and not planned_modules.intersection(reused_modules):
                     raise PQXSequenceRunnerError("TPA build must reuse modules surfaced by plan context")
                 artifacts["build"] = _build_tpa_slice_artifact(
+                    request_id=str(request.get("request_id") or f"{run_id}:{next_slice_id}"),
                     run_id=run_id,
                     trace_id=request["trace_id"],
                     slice_id=next_slice_id,
@@ -1685,6 +1694,7 @@ def execute_sequence_run(
                 if not simplify_payload.get("pattern_consistency_refs"):
                     raise PQXSequenceRunnerError("TPA simplify must declare pattern consistency references")
                 artifacts["simplify"] = _build_tpa_slice_artifact(
+                    request_id=str(request.get("request_id") or f"{run_id}:{next_slice_id}"),
                     run_id=run_id,
                     trace_id=request["trace_id"],
                     slice_id=next_slice_id,
@@ -1879,6 +1889,7 @@ def execute_sequence_run(
                         "TPA gate cannot mark promotion_ready when contract-backed policy composition resolves freeze/block"
                     )
                 artifacts["gate"] = _build_tpa_slice_artifact(
+                    request_id=str(request.get("request_id") or f"{run_id}:{next_slice_id}"),
                     run_id=run_id,
                     trace_id=request["trace_id"],
                     slice_id=next_slice_id,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,8 +10,10 @@ from spectrum_systems.modules.runtime.lineage_issuance_registry import reset_lin
 
 os.environ.setdefault("SPECTRUM_LINEAGE_AUTH_SECRET_AEX", "test-lineage-auth-secret-aex")
 os.environ.setdefault("SPECTRUM_LINEAGE_AUTH_SECRET_TLC", "test-lineage-auth-secret-tlc")
+os.environ.setdefault("SPECTRUM_LINEAGE_AUTH_SECRET_TPA", "test-lineage-auth-secret-tpa")
 os.environ.setdefault("SPECTRUM_LINEAGE_AUTH_KEY_ID_AEX", "aex-hs256-v1")
 os.environ.setdefault("SPECTRUM_LINEAGE_AUTH_KEY_ID_TLC", "tlc-hs256-v1")
+os.environ.setdefault("SPECTRUM_LINEAGE_AUTH_KEY_ID_TPA", "tpa-hs256-v1")
 os.environ.setdefault("SPECTRUM_LINEAGE_AUTH_TTL_SECONDS", "900")
 os.environ.setdefault("SPECTRUM_LINEAGE_AUTH_MAX_AGE_SECONDS", "3600")
 

--- a/tests/test_done_certification.py
+++ b/tests/test_done_certification.py
@@ -343,8 +343,9 @@ def _attach_valid_tpa_refs(refs: Dict[str, str], tmp_path: Path, *, step_id: str
     for phase, payload in phase_payloads.items():
         artifact = {
             "artifact_type": "tpa_slice_artifact",
-            "schema_version": "1.2.0",
+            "schema_version": "1.3.0",
             "artifact_id": f"tpa:run-001:{step_id}-{phase_suffix[phase]}",
+            "request_id": f"req:{step_id}:{phase}",
             "run_id": "run-001",
             "trace_id": "trace-001",
             "slice_id": f"{step_id}-{phase_suffix[phase]}",
@@ -352,6 +353,17 @@ def _attach_valid_tpa_refs(refs: Dict[str, str], tmp_path: Path, *, step_id: str
             "phase": phase,
             "produced_at": "2026-04-04T00:00:00Z",
             "artifact": payload,
+            "authenticity": {
+                "issuer": "TPA",
+                "key_id": "tpa-hs256-v1",
+                "payload_digest": f"sha256:{'0'*64}",
+                "audience": "pqx_repo_write_boundary",
+                "scope": f"repo_write_lineage:tpa_slice_artifact:req:{step_id}:{phase}:trace-001",
+                "issued_at": "2026-04-04T00:00:00Z",
+                "expires_at": "2026-04-04T00:15:00Z",
+                "lineage_token_id": "lin-1234567890abcdef12345678",
+                "attestation": "0" * 64,
+            },
         }
         refs[f"tpa_{phase}_artifact"] = _write_json(tmp_path / f"tpa_{phase}.json", artifact)
 

--- a/tests/test_evaluation_enforcement_bridge.py
+++ b/tests/test_evaluation_enforcement_bridge.py
@@ -213,10 +213,22 @@ def _write_tpa_artifacts(tmp_path: Path, *, step_id: str = "AI-01") -> Dict[str,
     refs: Dict[str, str] = {}
     for phase, payload in phase_payloads.items():
         artifact = {
-            "artifact_type": "tpa_slice_artifact", "schema_version": "1.2.0",
+            "artifact_type": "tpa_slice_artifact", "schema_version": "1.3.0",
             "artifact_id": f"tpa:run-001:{step_id}-{suffix[phase]}", "run_id": "run-001", "trace_id": "trace-001",
+            "request_id": f"req:{step_id}:{phase}",
             "slice_id": f"{step_id}-{suffix[phase]}", "step_id": step_id, "phase": phase,
             "produced_at": "2026-04-04T00:00:00Z", "artifact": payload,
+            "authenticity": {
+                "issuer": "TPA",
+                "key_id": "tpa-hs256-v1",
+                "payload_digest": f"sha256:{'0'*64}",
+                "audience": "pqx_repo_write_boundary",
+                "scope": f"repo_write_lineage:tpa_slice_artifact:req:{step_id}:{phase}:trace-001",
+                "issued_at": "2026-04-04T00:00:00Z",
+                "expires_at": "2026-04-04T00:15:00Z",
+                "lineage_token_id": "lin-1234567890abcdef12345678",
+                "attestation": "0" * 64,
+            },
         }
         out = tmp_path / f"{phase}.json"
         out.write_text(json.dumps(artifact), encoding="utf-8")

--- a/tests/test_pqx_bundle_orchestrator.py
+++ b/tests/test_pqx_bundle_orchestrator.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+import hashlib
+import hmac
+import os
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -16,7 +19,7 @@ from spectrum_systems.modules.runtime.pqx_bundle_orchestrator import (
     resolve_bundle_definition,
     validate_bundle_definition,
 )
-from spectrum_systems.modules.review_fix_execution_loop import compute_tpa_gate_provenance_token
+from spectrum_systems.modules.runtime.lineage_authenticity import compute_payload_digest
 
 
 class FixedClock:
@@ -260,8 +263,9 @@ def test_execute_fixes_records_fix_gate_before_step_progression(tmp_path: Path) 
 
     tpa_artifact = {
         "artifact_type": "tpa_slice_artifact",
-        "schema_version": "1.2.0",
+        "schema_version": "1.3.0",
         "artifact_id": "tpa:fix:rev-block:f-001:gate",
+        "request_id": "rfer:fix:rev-block:f-001",
         "run_id": "run-gate-block-001",
         "trace_id": "trace-gate-block-001",
         "slice_id": "AI-01-G",
@@ -279,11 +283,29 @@ def test_execute_fixes_records_fix_gate_before_step_progression(tmp_path: Path) 
             "simplicity_review": {"decision": "allow"},
         },
     }
-    authority_path = tmp_path / "artifacts/tpa_authority" / f"{tpa_artifact['artifact_id']}.json"
-    authority_path.parent.mkdir(parents=True, exist_ok=True)
-    stored = dict(tpa_artifact)
-    stored["authoritative_integrity_token"] = compute_tpa_gate_provenance_token(tpa_artifact)
-    authority_path.write_text(json.dumps(stored, indent=2) + "\n", encoding="utf-8")
+    payload_digest = compute_payload_digest(dict(tpa_artifact))
+    scope = f"repo_write_lineage:tpa_slice_artifact:{tpa_artifact['request_id']}:{tpa_artifact['trace_id']}"
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+    issued_at = now.isoformat().replace("+00:00", "Z")
+    expires_at = (now + timedelta(minutes=15)).isoformat().replace("+00:00", "Z")
+    tpa_artifact["authenticity"] = {
+        "issuer": "TPA",
+        "key_id": "tpa-hs256-v1",
+        "payload_digest": payload_digest,
+        "audience": "pqx_repo_write_boundary",
+        "scope": scope,
+        "issued_at": issued_at,
+        "expires_at": expires_at,
+        "lineage_token_id": "lin-1234567890abcdef12345678",
+        "attestation": hmac.new(
+            os.environ["SPECTRUM_LINEAGE_AUTH_SECRET_TPA"].encode("utf-8"),
+            (
+                f"TPA|tpa-hs256-v1|{payload_digest}|pqx_repo_write_boundary|{scope}|"
+                f"{issued_at}|{expires_at}|lin-1234567890abcdef12345678"
+            ).encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest(),
+    }
 
     result = execute_bundle_run(
         bundle_id="BUNDLE-T1",

--- a/tests/test_pqx_fix_execution.py
+++ b/tests/test_pqx_fix_execution.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 import json
+import hashlib
+import hmac
+import os
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
 
 from spectrum_systems.modules.runtime.pqx_bundle_orchestrator import execute_bundle_run
-from spectrum_systems.modules.review_fix_execution_loop import compute_tpa_gate_provenance_token
+from spectrum_systems.modules.runtime.lineage_authenticity import compute_payload_digest
 from spectrum_systems.modules.runtime.pqx_bundle_state import (
     initialize_bundle_state,
     ingest_review_result,
@@ -102,8 +106,9 @@ def _state_with_pending_fix(tmp_path: Path, execution_plan_ref: str) -> tuple[di
 def _tpa_gate_bundle_for_fix(tmp_path: Path, *, fix_id: str, review_result_ref: str) -> dict:
     tpa_artifact = {
         "artifact_type": "tpa_slice_artifact",
-        "schema_version": "1.2.0",
+        "schema_version": "1.3.0",
         "artifact_id": f"tpa:{fix_id}:gate",
+        "request_id": f"rfer:{fix_id}",
         "run_id": "run-fix-001",
         "trace_id": "trace-fix-001",
         "slice_id": "AI-02-G",
@@ -121,11 +126,30 @@ def _tpa_gate_bundle_for_fix(tmp_path: Path, *, fix_id: str, review_result_ref: 
             "simplicity_review": {"decision": "allow"},
         },
     }
-    tpa_file = tmp_path / "artifacts/tpa_authority" / f"{tpa_artifact['artifact_id']}.json"
-    tpa_file.parent.mkdir(parents=True, exist_ok=True)
-    stored = dict(tpa_artifact)
-    stored["authoritative_integrity_token"] = compute_tpa_gate_provenance_token(tpa_artifact)
-    tpa_file.write_text(json.dumps(stored, indent=2) + "\n", encoding="utf-8")
+    payload_digest = compute_payload_digest(dict(tpa_artifact))
+    secret = os.environ["SPECTRUM_LINEAGE_AUTH_SECRET_TPA"]
+    scope = f"repo_write_lineage:tpa_slice_artifact:{tpa_artifact['request_id']}:{tpa_artifact['trace_id']}"
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+    issued_at = now.isoformat().replace("+00:00", "Z")
+    expires_at = (now + timedelta(minutes=15)).isoformat().replace("+00:00", "Z")
+    tpa_artifact["authenticity"] = {
+        "issuer": "TPA",
+        "key_id": "tpa-hs256-v1",
+        "payload_digest": payload_digest,
+        "audience": "pqx_repo_write_boundary",
+        "scope": scope,
+        "issued_at": issued_at,
+        "expires_at": expires_at,
+        "lineage_token_id": "lin-1234567890abcdef12345678",
+        "attestation": hmac.new(
+            secret.encode("utf-8"),
+            (
+                f"TPA|tpa-hs256-v1|{payload_digest}|pqx_repo_write_boundary|{scope}|"
+                f"{issued_at}|{expires_at}|lin-1234567890abcdef12345678"
+            ).encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest(),
+    }
     return {
         fix_id: {
             "request_artifact": {

--- a/tests/test_review_fix_execution_loop.py
+++ b/tests/test_review_fix_execution_loop.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 import copy
+import hashlib
+import hmac
 import json
+import os
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -9,9 +13,9 @@ import pytest
 from spectrum_systems.contracts import load_example, validate_artifact
 from spectrum_systems.modules.review_fix_execution_loop import (
     ReviewFixExecutionLoopError,
-    compute_tpa_gate_provenance_token,
     run_review_fix_execution_cycle,
 )
+from spectrum_systems.modules.runtime.lineage_authenticity import compute_payload_digest
 from spectrum_systems.modules.runtime.pqx_execution_policy import evaluate_pqx_execution_policy
 from spectrum_systems.modules.runtime.pqx_required_context_enforcement import enforce_pqx_required_context
 
@@ -29,12 +33,35 @@ def _prepare_post_fix_review_inputs(repo_root: Path, *, validation_status: str =
     validation.write_text(json.dumps({"status": validation_status}), encoding="utf-8")
 
 
-def _write_authoritative_tpa_gate(repo_root: Path, request: dict) -> None:
-    artifact = copy.deepcopy(request["tpa_slice_artifact"])
-    artifact["authoritative_integrity_token"] = compute_tpa_gate_provenance_token(artifact)
-    authority_path = repo_root / "artifacts/tpa_authority" / f"{artifact['artifact_id']}.json"
-    authority_path.parent.mkdir(parents=True, exist_ok=True)
-    authority_path.write_text(json.dumps(artifact, indent=2) + "\n", encoding="utf-8")
+def _attach_tpa_authenticity(request: dict, *, attestation: str | None = None) -> None:
+    artifact = request["tpa_slice_artifact"]
+    artifact["request_id"] = request["request_id"]
+    payload_digest = compute_payload_digest(dict(artifact))
+    issuer = "TPA"
+    key_id = "tpa-hs256-v1"
+    audience = "pqx_repo_write_boundary"
+    scope = f"repo_write_lineage:tpa_slice_artifact:{request['request_id']}:{artifact['trace_id']}"
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+    issued_at = now.isoformat().replace("+00:00", "Z")
+    expires_at = (now + timedelta(minutes=15)).isoformat().replace("+00:00", "Z")
+    lineage_token_id = "lin-1234567890abcdef12345678"
+    secret = os.environ["SPECTRUM_LINEAGE_AUTH_SECRET_TPA"]
+    computed_attestation = hmac.new(
+        secret.encode("utf-8"),
+        f"{issuer}|{key_id}|{payload_digest}|{audience}|{scope}|{issued_at}|{expires_at}|{lineage_token_id}".encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    artifact["authenticity"] = {
+        "issuer": "TPA",
+        "key_id": key_id,
+        "payload_digest": payload_digest,
+        "audience": audience,
+        "scope": scope,
+        "issued_at": issued_at,
+        "expires_at": expires_at,
+        "lineage_token_id": lineage_token_id,
+        "attestation": attestation or computed_attestation,
+    }
 
 
 def test_review_fix_execution_contract_examples_validate() -> None:
@@ -51,7 +78,7 @@ def test_happy_path_executes_once_and_reruns_review_once(tmp_path: Path) -> None
     _prepare_post_fix_review_inputs(repo_root, validation_status="passed")
 
     request = copy.deepcopy(load_example("review_fix_execution_request_artifact"))
-    _write_authoritative_tpa_gate(repo_root, request)
+    _attach_tpa_authenticity(request)
     pqx_calls: list[str] = []
 
     def _pqx_executor(_: dict) -> dict:
@@ -76,6 +103,67 @@ def test_happy_path_executes_once_and_reruns_review_once(tmp_path: Path) -> None
     assert "review_operator_handoff_artifact" not in result
 
 
+def test_tpa_gate_rejects_forged_artifact(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    _prepare_post_fix_review_inputs(repo_root, validation_status="passed")
+    request = copy.deepcopy(load_example("review_fix_execution_request_artifact"))
+    request["tpa_slice_artifact"].pop("authenticity", None)
+    with pytest.raises(ReviewFixExecutionLoopError, match="authenticity invalid"):
+        run_review_fix_execution_cycle(
+            request,
+            output_dir=repo_root / "artifacts/reviews",
+            repo_root=repo_root,
+            review_docs_dir=repo_root / "docs/reviews",
+            pqx_executor=lambda _: {"status": "complete"},
+        )
+
+
+def test_tpa_gate_rejects_fake_signature(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    _prepare_post_fix_review_inputs(repo_root, validation_status="passed")
+    request = copy.deepcopy(load_example("review_fix_execution_request_artifact"))
+    _attach_tpa_authenticity(request, attestation="0" * 64)
+    with pytest.raises(ReviewFixExecutionLoopError, match="authenticity invalid"):
+        run_review_fix_execution_cycle(
+            request,
+            output_dir=repo_root / "artifacts/reviews",
+            repo_root=repo_root,
+            review_docs_dir=repo_root / "docs/reviews",
+            pqx_executor=lambda _: {"status": "complete"},
+        )
+
+
+def test_tpa_gate_accepts_valid_tpa_artifact(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    _prepare_post_fix_review_inputs(repo_root, validation_status="passed")
+    request = copy.deepcopy(load_example("review_fix_execution_request_artifact"))
+    _attach_tpa_authenticity(request)
+    result = run_review_fix_execution_cycle(
+        request,
+        output_dir=repo_root / "artifacts/reviews",
+        repo_root=repo_root,
+        review_docs_dir=repo_root / "docs/reviews",
+        pqx_executor=lambda _: {"status": "complete", "execution_ref": "exec:run-001:AI-01:1"},
+    )
+    assert result["review_fix_execution_result_artifact"]["status"] == "completed_safe_to_merge"
+
+
+def test_pqx_fix_execution_rejects_forged_tpa_gate(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    _prepare_post_fix_review_inputs(repo_root, validation_status="passed")
+    request = copy.deepcopy(load_example("review_fix_execution_request_artifact"))
+    _attach_tpa_authenticity(request)
+    request["request_id"] = "forged-request-id"
+    with pytest.raises(ReviewFixExecutionLoopError, match="request binding mismatch"):
+        run_review_fix_execution_cycle(
+            request,
+            output_dir=repo_root / "artifacts/reviews",
+            repo_root=repo_root,
+            review_docs_dir=repo_root / "docs/reviews",
+            pqx_executor=lambda _: {"status": "complete"},
+        )
+
+
 def test_fix_reentry_triggers_review(tmp_path: Path) -> None:
     test_happy_path_executes_once_and_reruns_review_once(tmp_path)
 
@@ -85,7 +173,7 @@ def test_tpa_block_prevents_pqx_execution(tmp_path: Path) -> None:
     _prepare_post_fix_review_inputs(repo_root)
     request = copy.deepcopy(load_example("review_fix_execution_request_artifact"))
     request["tpa_slice_artifact"]["artifact"]["promotion_ready"] = False
-    _write_authoritative_tpa_gate(repo_root, request)
+    _attach_tpa_authenticity(request)
 
     pqx_called = False
 
@@ -118,7 +206,7 @@ def test_tpa_missing_or_malformed_fails_closed(tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
     _prepare_post_fix_review_inputs(repo_root)
     request = copy.deepcopy(load_example("review_fix_execution_request_artifact"))
-    _write_authoritative_tpa_gate(repo_root, request)
+    _attach_tpa_authenticity(request)
     request["tpa_slice_artifact"].pop("phase")
 
     with pytest.raises(ReviewFixExecutionLoopError):
@@ -136,7 +224,7 @@ def test_rqx_never_calls_pqx_directly(tmp_path: Path) -> None:
     _prepare_post_fix_review_inputs(repo_root)
     request = copy.deepcopy(load_example("review_fix_execution_request_artifact"))
     request["tpa_slice_artifact"]["artifact"]["promotion_ready"] = False
-    _write_authoritative_tpa_gate(repo_root, request)
+    _attach_tpa_authenticity(request)
     called = False
 
     def _pqx_executor(_: dict) -> dict:
@@ -163,7 +251,7 @@ def test_pqx_rejects_non_tpa_fix_execution(tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
     _prepare_post_fix_review_inputs(repo_root)
     request = copy.deepcopy(load_example("review_fix_execution_request_artifact"))
-    _write_authoritative_tpa_gate(repo_root, request)
+    _attach_tpa_authenticity(request)
     request["tpa_slice_artifact"]["artifact"]["review_signal_refs"] = []
 
     with pytest.raises(ReviewFixExecutionLoopError, match="tpa gate must bind"):
@@ -184,7 +272,7 @@ def test_rqx_routes_fix_slice_to_tpa(tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
     _prepare_post_fix_review_inputs(repo_root)
     request = copy.deepcopy(load_example("review_fix_execution_request_artifact"))
-    _write_authoritative_tpa_gate(repo_root, request)
+    _attach_tpa_authenticity(request)
     request["fix_slices"][0]["review_result_ref"] = "review_result_artifact:different-review"
 
     with pytest.raises(ReviewFixExecutionLoopError, match="must match source_review_result_ref"):
@@ -205,7 +293,7 @@ def test_raw_prompt_bypass_is_rejected(tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
     _prepare_post_fix_review_inputs(repo_root)
     request = copy.deepcopy(load_example("review_fix_execution_request_artifact"))
-    _write_authoritative_tpa_gate(repo_root, request)
+    _attach_tpa_authenticity(request)
     request["raw_prompt_text"] = "execute this markdown"
 
     with pytest.raises(ReviewFixExecutionLoopError, match="raw prompt text"):
@@ -222,7 +310,7 @@ def test_one_cycle_bound_stops_without_recursive_rerun(tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
     _prepare_post_fix_review_inputs(repo_root, validation_status="failed")
     request = copy.deepcopy(load_example("review_fix_execution_request_artifact"))
-    _write_authoritative_tpa_gate(repo_root, request)
+    _attach_tpa_authenticity(request)
 
     pqx_count = 0
 
@@ -261,7 +349,7 @@ def test_not_safe_to_merge_emits_operator_handoff(tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
     _prepare_post_fix_review_inputs(repo_root, validation_status="passed")
     request = copy.deepcopy(load_example("review_fix_execution_request_artifact"))
-    _write_authoritative_tpa_gate(repo_root, request)
+    _attach_tpa_authenticity(request)
     request["post_fix_review_request_artifact"]["changed_files"].append("missing/file.py")
 
     result = run_review_fix_execution_cycle(
@@ -284,7 +372,7 @@ def test_checkpoint_missing_emits_operator_handoff(tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
     _prepare_post_fix_review_inputs(repo_root, validation_status="passed")
     request = copy.deepcopy(load_example("review_fix_execution_request_artifact"))
-    _write_authoritative_tpa_gate(repo_root, request)
+    _attach_tpa_authenticity(request)
     request["checkpoint_required"] = True
     request["checkpoint_ref"] = None
 
@@ -307,7 +395,7 @@ def test_handoff_emission_does_not_trigger_additional_execution(tmp_path: Path) 
     repo_root = tmp_path / "repo"
     _prepare_post_fix_review_inputs(repo_root, validation_status="failed")
     request = copy.deepcopy(load_example("review_fix_execution_request_artifact"))
-    _write_authoritative_tpa_gate(repo_root, request)
+    _attach_tpa_authenticity(request)
     pqx_count = 0
 
     def _pqx_executor(_: dict) -> dict:
@@ -338,7 +426,7 @@ def test_safe_or_not_safe_paths_do_not_execute_when_no_fix_slice(tmp_path: Path)
     repo_root = tmp_path / "repo"
     _prepare_post_fix_review_inputs(repo_root)
     request = copy.deepcopy(load_example("review_fix_execution_request_artifact"))
-    _write_authoritative_tpa_gate(repo_root, request)
+    _attach_tpa_authenticity(request)
     request["fix_slices"] = []
 
     with pytest.raises(ReviewFixExecutionLoopError):
@@ -355,10 +443,10 @@ def test_run_review_fix_execution_cycle_rejects_forged_tpa_gate(tmp_path: Path) 
     repo_root = tmp_path / "repo"
     _prepare_post_fix_review_inputs(repo_root)
     request = copy.deepcopy(load_example("review_fix_execution_request_artifact"))
-    _write_authoritative_tpa_gate(repo_root, request)
+    _attach_tpa_authenticity(request)
     request["tpa_slice_artifact"]["artifact"]["promotion_ready"] = False
 
-    with pytest.raises(ReviewFixExecutionLoopError, match="authoritative TPA provenance artifact mismatch"):
+    with pytest.raises(ReviewFixExecutionLoopError, match="authenticity invalid"):
         run_review_fix_execution_cycle(
             request,
             output_dir=repo_root / "artifacts/reviews",


### PR DESCRIPTION
### Motivation
- Close a GOV-A trust boundary vulnerability by ensuring a TPA gate can be considered authoritative only when cryptographically issued and bound to the specific execution request. 
- Maintain the existing GOV-A flow and keep the change surgical: no new subsystems, no redesign, and fail-closed on any mismatch.
- Prevent attackers from fabricating `artifacts/tpa_authority/<id>.json` or replaying deterministic tokens to authorize PQX execution.

### Description
- Require `authenticity` on `tpa_slice_artifact` (schema bump to `1.3.0`) and add `request_id` binding in the artifact contract and examples, and update `contracts/standards-manifest.json` accordingly. 
- Emit cryptographic authenticity for TPA artifacts at source by calling `issue_authenticity(..., issuer="TPA")` in the TPA emission paths (`_build_tpa_slice_artifact` in `pqx_sequence_runner.py` and `_build_tpa_gate_artifact` in `github_pr_autofix_review_artifact_validation.py`).
- Replace file/token-based authority validation with `validate_tpa_slice_authority(...)` (backward-compatible wrapper `validate_tpa_gate_authoritative_provenance`) which: verifies `authenticity` (attestation, issuer/key binding), checks `payload_digest`, and enforces request/trace/step binding and freshness, failing closed on any mismatch (`spectrum_systems/modules/review_fix_execution_loop.py`).
- Add `TPA` support in runtime authenticity primitives and issuance registry (`lineage_authenticity.py`, `lineage_issuance_registry.py`) and authorize the TPA emission call sites for issuance recording.
- Keep `artifacts/tpa_authority/<id>.json` optionally for audit/debug but explicitly non-authoritative for execution admission.
- Add adversarial tests that exercise missing authenticity, bad signatures, valid TPA issuance, and PQX boundary rejects; update test fixtures and environment defaults to support deterministic test signing (`tests/*`, `tests/conftest.py`).
- Add a short governance note documenting the model change (`docs/governance/tpa_gate_authority_note.md`) and a small PLAN file recording scope and validation steps.

### Testing
- Ran `pytest -q tests/test_review_fix_execution_loop.py` and all `25` tests passed. 
- Ran `pytest -q tests/test_pqx_fix_execution.py tests/test_pqx_bundle_orchestrator.py tests/test_contracts.py tests/test_contract_enforcement.py` and the suite passed (`139` tests passed across those modules). 
- Ran `pytest -q tests/test_tpa_sequence_runner.py` and `15` tests passed. 
- Ran `pytest -q tests/test_done_certification.py tests/test_evaluation_enforcement_bridge.py` and those tests passed (`117` tests passed combined). 
- Ran contract enforcement with `python scripts/run_contract_enforcement.py` and it completed with zero failures or warnings. 
All executed automated tests passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d80d851b34832981e551178282d7a8)