### PR TITLE
BATCH-GOV-B: Enforce CDE-only closure authority and harden TLC/SEL boundaries

### DIFF
--- a/docs/review-actions/BATCH-GOV-B-DELIVERY-REPORT-2026-04-09.md
+++ b/docs/review-actions/BATCH-GOV-B-DELIVERY-REPORT-2026-04-09.md
@@ -1,0 +1,43 @@
+# Delivery Report — BATCH-GOV-B
+
+## Intent
+Surgically enforce closure authority boundaries so TLC remains orchestration/routing only, CDE remains sole closure/promotion-readiness authority, and SEL fail-closes unauthorized closure behavior.
+
+## Files modified
+- `spectrum_systems/modules/runtime/top_level_conductor.py`
+- `spectrum_systems/modules/runtime/system_enforcement_layer.py`
+- `tests/test_top_level_conductor.py`
+- `tests/test_system_enforcement_layer.py`
+- `docs/review-actions/PLAN-BATCH-GOV-B-2026-04-09.md`
+
+## Authority changes
+- TLC hard-fails any non-CDE subsystem output that attempts to emit closure authority fields (`closure_decision_artifact`, `decision_type`, `next_step_class`).
+- TLC no longer self-promotes to `ready_for_merge` after repair validation; it routes back to CDE for final closure determination.
+- SEL now validates closure authority provenance (`closure_decision_source`, `promotion_readiness_decisioning`) as CDE-only.
+
+## Enforcement points
+- TLC handoff output validator now blocks closure-like signals from non-CDE systems.
+- TLC state lineage now carries explicit closure authority metadata (`closure_lock_state`, CDE-only decision source fields) to SEL.
+- SEL blocks execution when `closure_lock_state=locked` and records `closure_lock_violation`.
+
+## Tests added
+- `test_tlc_does_not_emit_closure_decisions`
+- `test_only_cde_can_emit_closure_decision` (TLC boundary)
+- `test_rqx_cannot_decide_closure`
+- `test_pqx_cannot_mark_done`
+- `test_tlc_routes_to_cde_for_closure`
+- `test_sel_enforces_closure_decision`
+- `test_only_cde_can_emit_closure_decision` (SEL authority check)
+
+## Remaining gaps
+- No dedicated runtime module named `RQX` is invoked by TLC in this slice; the boundary is enforced generically by rejecting non-CDE closure signals.
+- Promotion gate artifact policy remains unchanged in this batch (scope-limited as requested).
+
+## Next step
+Run targeted GOV-B review (same pattern as GOV-A), then proceed to PFG formalization.
+
+## Minimal boundary clarifications
+- TLC is non-authoritative and may only orchestrate/route/classify bounded handoffs.
+- CDE is sole closure authority (closure decision, promotion readiness, bounded next-step classification).
+- Merge-ready is not equivalent to done-state authority outside CDE decision outputs.
+- SEL enforces closure decisions and closure lock fail-closed without reinterpreting CDE logic.

--- a/docs/review-actions/PLAN-BATCH-GOV-B-2026-04-09.md
+++ b/docs/review-actions/PLAN-BATCH-GOV-B-2026-04-09.md
@@ -1,0 +1,35 @@
+# Plan — BATCH-GOV-B — 2026-04-09
+
+## Prompt type
+PLAN
+
+## Roadmap item
+BATCH-GOV-B — Harden TLC orchestration boundaries and enforce CDE as sole closure/promotion authority
+
+## Objective
+Ensure TLC only orchestrates/routes and that CDE is the sole authority for closure decisions, promotion readiness, and bounded next-step classification, with SEL enforcing closure decisions fail-closed.
+
+## Declared files
+| File | Change type | Reason |
+| --- | --- | --- |
+| spectrum_systems/modules/runtime/top_level_conductor.py | MODIFY | Remove any TLC-owned closure authority paths and require CDE authority routing. |
+| spectrum_systems/modules/runtime/system_enforcement_layer.py | MODIFY | Add SEL checks that enforce CDE closure authority and closure-lock behavior. |
+| tests/test_top_level_conductor.py | MODIFY | Add/adjust TLC boundary tests so TLC cannot emit closure decisions and routes closure through CDE. |
+| tests/test_system_enforcement_layer.py | MODIFY | Add SEL closure-lock and authority enforcement tests. |
+| docs/review-actions/BATCH-GOV-B-DELIVERY-REPORT-2026-04-09.md | CREATE | Minimal documentation/report clarifying authority boundaries and enforcement points. |
+
+## Contracts touched
+None.
+
+## Tests that must pass after execution
+1. `pytest tests/test_top_level_conductor.py`
+2. `pytest tests/test_system_enforcement_layer.py`
+
+## Scope exclusions
+- Do not add new systems, subsystems, or architecture surfaces.
+- Do not redesign closure schema contracts.
+- Do not rewrite architecture documents.
+- Do not refactor unrelated runtime modules.
+
+## Dependencies
+- `docs/architecture/system_registry.md` and `README.md` remain canonical role authority references.

--- a/spectrum_systems/modules/runtime/system_enforcement_layer.py
+++ b/spectrum_systems/modules/runtime/system_enforcement_layer.py
@@ -410,6 +410,51 @@ def _check_failure_learning_governance(normalized: dict[str, Any], violations: l
         )
 
 
+def _check_closure_authority_boundaries(normalized: dict[str, Any], violations: list[dict[str, Any]]) -> None:
+    request = normalized["execution_request"]
+    refs = normalized["artifact_references"]
+
+    closure_source = str(request.get("closure_decision_source") or "cde_only").strip().lower()
+    readiness_source = str(request.get("promotion_readiness_decisioning") or "cde_only").strip().lower()
+    if closure_source not in {"cde", "cde_only"}:
+        _add_violation(
+            violations,
+            code="repair_decision_violation",
+            boundary="CDE",
+            field="execution_request.closure_decision_source",
+            message="closure decision authority must remain CDE-only",
+        )
+    if readiness_source not in {"cde", "cde_only"}:
+        _add_violation(
+            violations,
+            code="repair_decision_violation",
+            boundary="CDE",
+            field="execution_request.promotion_readiness_decisioning",
+            message="promotion readiness decisioning must remain CDE-only",
+        )
+
+    closure_artifact = refs.get("closure_decision_artifact")
+    closure_ref = refs.get("closure_decision_artifact_ref")
+    if _is_present(closure_artifact) and not _is_present(closure_ref):
+        _add_violation(
+            violations,
+            code="lineage_violation",
+            boundary="CDE",
+            field="artifact_references.closure_decision_artifact_ref",
+            message="closure decision artifact must include deterministic CDE reference",
+        )
+
+    lock_state = str(request.get("closure_lock_state") or "open").strip().lower()
+    if lock_state == "locked":
+        _add_violation(
+            violations,
+            code="repair_budget_violation",
+            boundary="SEL",
+            field="execution_request.closure_lock_state",
+            message="execution after closure lock is forbidden",
+        )
+
+
 def enforce_system_boundaries(context: dict[str, Any]) -> dict[str, Any]:
     """Enforce SEL governed boundaries; fail closed when any boundary violation exists."""
 
@@ -428,6 +473,7 @@ def enforce_system_boundaries(context: dict[str, Any]) -> dict[str, Any]:
     _check_lineage(normalized, violations)
     _check_repair_boundaries(normalized, violations)
     _check_failure_learning_governance(normalized, violations)
+    _check_closure_authority_boundaries(normalized, violations)
 
     violated_boundaries = sorted({str(item["boundary"]) for item in violations})
     payload_for_id = {

--- a/spectrum_systems/modules/runtime/top_level_conductor.py
+++ b/spectrum_systems/modules/runtime/top_level_conductor.py
@@ -432,6 +432,14 @@ def _enforce_handoff(
 
 
 def _validate_handoff_output(subsystem: str, result: dict[str, Any]) -> None:
+    if subsystem != "CDE":
+        if isinstance(result.get("closure_decision_artifact"), dict):
+            raise TopLevelConductorError(f"{subsystem} must not emit closure_decision_artifact; route closure signals to CDE")
+        if isinstance(result.get("decision_type"), str) and result.get("decision_type"):
+            raise TopLevelConductorError(f"{subsystem} must not emit decision_type; closure authority is CDE-only")
+        if isinstance(result.get("next_step_class"), str) and result.get("next_step_class"):
+            raise TopLevelConductorError(f"{subsystem} must not emit next_step_class; bounded-next-step classification is CDE-only")
+
     if subsystem == "PQX":
         if not isinstance(result.get("request_artifact"), dict):
             raise TopLevelConductorError("PQX output must include request_artifact")
@@ -906,6 +914,9 @@ def _enforce_sel(
             "queue_id": queue_id,
             "work_item_id": work_item_id,
             "step_id": step_id,
+            "closure_lock_state": state["lineage"].get("closure_lock_state", "open"),
+            "closure_decision_source": state["lineage"].get("closure_decision_source", "cde_only"),
+            "promotion_readiness_decisioning": state["lineage"].get("promotion_readiness_decisioning", "cde_only"),
         },
         "artifact_references": {
             "execution_artifact": state["produced_artifact_refs"][0] if state["produced_artifact_refs"] else "request_artifact",
@@ -924,6 +935,13 @@ def _enforce_sel(
             "failure_learning_record_artifact": state["lineage"].get("latest_failure_learning_record_artifact"),
             "roadmap_signal_artifact": state["lineage"].get("latest_roadmap_signal_artifact"),
             "pqx_execution_authority_record": pqx_execution_authority_record,
+            "closure_decision_artifact": state["lineage"].get("closure_decision_artifact"),
+            "closure_decision_artifact_ref": (
+                f"closure_decision_artifact:{state['lineage']['closure_decision_artifact']['closure_decision_id']}"
+                if isinstance(state["lineage"].get("closure_decision_artifact"), dict)
+                and isinstance(state["lineage"]["closure_decision_artifact"].get("closure_decision_id"), str)
+                else None
+            ),
         },
         "downstream_consumption": {
             "consumed_artifact_types": consumed_artifact_types or ["review_projection_bundle_artifact"],
@@ -1015,6 +1033,10 @@ def run_top_level_conductor(run_request: dict[str, Any]) -> dict[str, Any]:
     lineage = deepcopy(run_request.get("lineage")) if isinstance(run_request.get("lineage"), dict) else {}
     lineage.setdefault("lineage_id", f"lineage-{run_id}")
     lineage.setdefault("parent_refs", [f"request:{run_id}"])
+    lineage.setdefault("closure_lock_state", "open")
+    lineage.setdefault("closure_decision_source", "cde_only")
+    lineage.setdefault("promotion_readiness_decisioning", "cde_only")
+    lineage.setdefault("repair_validation_passed", False)
     lineage.setdefault(
         "request_hash",
         _canonical_hash(
@@ -1300,8 +1322,10 @@ def run_top_level_conductor(run_request: dict[str, Any]) -> dict[str, Any]:
                 isinstance(repair_candidate, dict)
                 and repair_candidate.get("safe_to_repair")
                 and repair_candidate.get("bounded_scope")
+                and not bool(state["lineage"].get("repair_validation_passed", False))
                 and state["retry_budget_remaining"] > 0
             )
+            closure_complete = repair_packet is None or bool(state["lineage"].get("repair_validation_passed", False))
             cde_result = resolved["cde"](
                 {
                     "run_id": state["run_id"],
@@ -1320,9 +1344,9 @@ def run_top_level_conductor(run_request: dict[str, Any]) -> dict[str, Any]:
                             "unresolved_action_item_ids": [],
                         }
                     ],
-                    "closure_complete": repair_packet is None,
-                    "final_verification_passed": repair_packet is None,
-                    "hardening_completed": repair_packet is None,
+                    "closure_complete": closure_complete,
+                    "final_verification_passed": closure_complete,
+                    "hardening_completed": closure_complete,
                     "escalation_required": False,
                     "bounded_next_step_available": state["retry_budget_remaining"] > 0,
                     "repair_loop_eligible": repair_loop_eligible,
@@ -1358,6 +1382,9 @@ def run_top_level_conductor(run_request: dict[str, Any]) -> dict[str, Any]:
             )
             decision = cde_result.get("decision_type") if isinstance(cde_result, dict) else None
             state["closure_state"] = str(cde_result.get("closure_state", "pending")) if isinstance(cde_result, dict) else "pending"
+            state["lineage"]["closure_decision_source"] = "CDE"
+            state["lineage"]["promotion_readiness_decisioning"] = "CDE"
+            state["lineage"]["closure_lock_state"] = "locked" if decision in {"lock", "blocked", "escalate"} else "open"
 
             if decision == "lock":
                 _transition(state=state, to_state="ready_for_merge", reason="cde_lock")
@@ -1499,10 +1526,10 @@ def run_top_level_conductor(run_request: dict[str, Any]) -> dict[str, Any]:
                             _transition(state=state, to_state="blocked", reason="local_pre_pr_governance_block")
                             state["stop_reason"] = f"local_pre_pr_governance_block:{exc}"
                             break
-                    _transition(state=state, to_state="ready_for_merge", reason="repair_tests_green")
-                    state["ready_for_merge"] = True
-                    state["stop_reason"] = "ready_for_merge"
-                    break
+                    state["lineage"]["repair_validation_passed"] = True
+                    _transition(state=state, to_state="closure_decision_pending", reason="repair_validation_passed_route_to_cde")
+                    continue
+                state["lineage"]["repair_validation_passed"] = False
                 state["retry_budget_remaining"] -= 1
                 if state["retry_budget_remaining"] <= 0:
                     _transition(state=state, to_state="exhausted", reason="repair_attempts_exhausted")

--- a/tests/test_system_enforcement_layer.py
+++ b/tests/test_system_enforcement_layer.py
@@ -168,3 +168,28 @@ def test_traceability_violations_map_to_specific_input_fields() -> None:
     assert violations_by_code["governance_evidence_violation"]["field"] == "governance_evidence"
     assert "PQX" in result["violated_boundaries"]
     assert "GOVERNANCE_EVIDENCE" in result["violated_boundaries"]
+
+
+def test_sel_enforces_closure_decision() -> None:
+    context = _valid_context()
+    context["execution_request"]["closure_lock_state"] = "locked"
+    context["execution_request"]["closure_decision_source"] = "CDE"
+    context["execution_request"]["promotion_readiness_decisioning"] = "CDE"
+    context["artifact_references"]["closure_decision_artifact"] = {"artifact_type": "closure_decision_artifact"}
+    context["artifact_references"]["closure_decision_artifact_ref"] = "closure_decision_artifact:cda-001"
+
+    result = enforce_system_boundaries(context)
+
+    assert result["enforcement_status"] == "block"
+    assert "repair_budget_violation" in _violation_codes(result)
+
+
+def test_only_cde_can_emit_closure_decision() -> None:
+    context = _valid_context()
+    context["execution_request"]["closure_decision_source"] = "PQX"
+    context["execution_request"]["promotion_readiness_decisioning"] = "RQX"
+
+    result = enforce_system_boundaries(context)
+
+    assert result["enforcement_status"] == "block"
+    assert "repair_decision_violation" in _violation_codes(result)

--- a/tests/test_top_level_conductor.py
+++ b/tests/test_top_level_conductor.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from spectrum_systems.modules.runtime.system_enforcement_layer import enforce_system_boundaries
+from spectrum_systems.modules.runtime.closure_decision_engine import build_closure_decision_artifact
 from spectrum_systems.modules.runtime.top_level_conductor import (
     TopLevelConductorError,
     run_from_roadmap,
@@ -242,3 +243,153 @@ def test_run_from_roadmap_executes_bounded_steps(tmp_path: Path) -> None:
 
     assert result["execution_status"] == "completed"
     assert len(result["step_execution_artifacts"]) == 2
+
+
+def test_tlc_does_not_emit_closure_decisions(tmp_path: Path) -> None:
+    request = _base_request(tmp_path)
+
+    def _ril_with_closure_authority(_: dict) -> dict:
+        return {
+            "outputs_exist": True,
+            "artifact_refs": [],
+            "trace_refs": ["trace-illegal"],
+            "decision_type": "lock",
+            "review_signal_artifact": {"artifact_type": "review_signal_artifact"},
+            "review_projection_bundle_artifact": {"artifact_type": "review_projection_bundle_artifact"},
+            "review_consumer_output_bundle_artifact": {"artifact_type": "review_consumer_output_bundle_artifact"},
+        }
+
+    request["subsystems"] = {"ril": _ril_with_closure_authority}
+    with pytest.raises(TopLevelConductorError, match="CDE-only"):
+        run_top_level_conductor(request)
+
+
+def test_only_cde_can_emit_closure_decision(tmp_path: Path) -> None:
+    request = _base_request(tmp_path)
+
+    def _pqx_with_closure_artifact(_: dict) -> dict:
+        return {
+            "entry_valid": True,
+            "validation_passed": True,
+            "closure_decision_artifact": {"artifact_type": "closure_decision_artifact"},
+            "request_artifact": {
+                "schema_version": "1.1.0",
+                "run_id": "x",
+                "step_id": "s",
+                "step_name": "n",
+                "dependencies": [],
+                "requested_at": "2026-04-06T00:00:00Z",
+                "prompt": "p",
+            },
+            "execution_artifact": {
+                "schema_version": "1.1.0",
+                "run_id": "x",
+                "step_id": "s",
+                "execution_status": "success",
+                "started_at": "2026-04-06T00:00:00Z",
+                "completed_at": "2026-04-06T00:00:00Z",
+                "output_text": "",
+                "error": None,
+            },
+            "trace_refs": ["trace-x"],
+            "lineage": {"lineage_id": "lineage:x", "parent_refs": ["request:x"]},
+        }
+
+    request["subsystems"] = {"pqx": _pqx_with_closure_artifact}
+    with pytest.raises(TopLevelConductorError, match="must not emit closure_decision_artifact"):
+        run_top_level_conductor(request)
+
+
+def test_rqx_cannot_decide_closure(tmp_path: Path) -> None:
+    request = _base_request(tmp_path)
+
+    def _rqx_like_ril(_: dict) -> dict:
+        return {
+            "outputs_exist": True,
+            "artifact_refs": [],
+            "trace_refs": ["trace-rqx"],
+            "decision_type": "lock",
+            "next_step_class": "none",
+            "review_signal_artifact": {"artifact_type": "review_signal_artifact"},
+            "review_projection_bundle_artifact": {"artifact_type": "review_projection_bundle_artifact"},
+            "review_consumer_output_bundle_artifact": {"artifact_type": "review_consumer_output_bundle_artifact"},
+        }
+
+    request["subsystems"] = {"ril": _rqx_like_ril}
+    with pytest.raises(TopLevelConductorError, match="closure authority is CDE-only"):
+        run_top_level_conductor(request)
+
+
+def test_pqx_cannot_mark_done(tmp_path: Path) -> None:
+    request = _base_request(tmp_path)
+
+    def _blocking_cde(payload: dict) -> dict:
+        decision = build_closure_decision_artifact(
+            {
+                "subject_scope": "top_level_conductor",
+                "subsystem_acronym": "TLC",
+                "run_id": payload["run_id"],
+                "review_date": payload["review_date"],
+                "action_tracker_ref": payload["action_tracker_ref"],
+                "source_artifacts": payload["source_artifacts"],
+                "closure_complete": False,
+                "final_verification_passed": False,
+                "hardening_completed": False,
+                "escalation_required": False,
+                "bounded_next_step_available": False,
+                "emitted_at": payload["emitted_at"],
+                "trace_id": payload["trace_id"],
+            }
+        )
+        return {
+            "decision_type": decision["decision_type"],
+            "next_step_class": decision["next_step_class"],
+            "closure_state": "open",
+            "artifact_refs": [f"closure_decision_artifact:{decision['closure_decision_id']}"],
+            "trace_refs": [decision["trace_id"]],
+            "closure_decision_artifact": decision,
+        }
+
+    request["subsystems"] = {"cde": _blocking_cde}
+    result = run_top_level_conductor(request)
+    assert result["current_state"] == "blocked"
+    assert result["ready_for_merge"] is False
+
+
+def test_tlc_routes_to_cde_for_closure(tmp_path: Path) -> None:
+    request = _base_request(tmp_path)
+    cde_calls: list[dict] = []
+
+    def _tracking_cde(payload: dict) -> dict:
+        cde_calls.append({"source_artifacts": payload.get("source_artifacts", [])})
+        decision = build_closure_decision_artifact(
+            {
+                "subject_scope": "top_level_conductor",
+                "subsystem_acronym": "TLC",
+                "run_id": payload["run_id"],
+                "review_date": payload["review_date"],
+                "action_tracker_ref": payload["action_tracker_ref"],
+                "source_artifacts": payload["source_artifacts"],
+                "closure_complete": False,
+                "final_verification_passed": False,
+                "hardening_completed": False,
+                "escalation_required": payload.get("escalation_required", False),
+                "bounded_next_step_available": False,
+                "emitted_at": payload["emitted_at"],
+                "trace_id": payload["trace_id"],
+            }
+        )
+        return {
+            "decision_type": decision["decision_type"],
+            "next_step_class": decision["next_step_class"],
+            "closure_state": "closed" if decision["decision_type"] == "lock" else "open",
+            "artifact_refs": [f"closure_decision_artifact:{decision['closure_decision_id']}"],
+            "trace_refs": [decision["trace_id"]],
+            "closure_decision_artifact": decision,
+        }
+
+    request["subsystems"] = {"cde": _tracking_cde}
+    result = run_top_level_conductor(request)
+    assert len(cde_calls) >= 1
+    assert cde_calls[0]["source_artifacts"]
+    assert result["current_state"] == "blocked"


### PR DESCRIPTION
### Motivation
- Ensure role boundaries so `TLC` is orchestration/routing-only and `CDE` is the sole source of closure, promotion-readiness, and bounded next-step classification. 
- Eliminate implicit or accidental closure authority in orchestration or downstream subsystems and fail-closed on unauthorized closure signals. 

### Description
- Hardened `top_level_conductor` to reject closure-like outputs from non-CDE subsystems by blocking `closure_decision_artifact`, `decision_type`, and `next_step_class` when produced outside `CDE`. 
- Propagated explicit closure authority metadata through TLC → SEL inputs by adding `closure_lock_state`, `closure_decision_source`, `promotion_readiness_decisioning`, and closure artifact refs into SEL context and TLC lineage. 
- Changed TLC repair/validation flow so successful repair validation routes back to `CDE` for authoritative closure decision instead of TLC self-promoting to `ready_for_merge`. 
- Extended `system_enforcement_layer` with checks that fail-closed when closure authority provenance is not `CDE` or when execution is attempted while `closure_lock_state` indicates a locked/closed state. 
- Added tests and small test adjustments to validate boundary enforcement and deterministic behavior and included a PLAN plus a delivery report (docs) for the GOV-B change set. 

Files modified: `spectrum_systems/modules/runtime/top_level_conductor.py`, `spectrum_systems/modules/runtime/system_enforcement_layer.py`, `tests/test_top_level_conductor.py`, `tests/test_system_enforcement_layer.py`, `docs/review-actions/PLAN-BATCH-GOV-B-2026-04-09.md`, and `docs/review-actions/BATCH-GOV-B-DELIVERY-REPORT-2026-04-09.md`.

### Testing
- Ran `pytest tests/test_top_level_conductor.py tests/test_system_enforcement_layer.py` and all tests passed (`25 passed`).
- New/updated tests exercised: `test_tlc_does_not_emit_closure_decisions`, `test_only_cde_can_emit_closure_decision`, `test_rqx_cannot_decide_closure`, `test_pqx_cannot_mark_done`, `test_tlc_routes_to_cde_for_closure`, and `test_sel_enforces_closure_decision`, and they succeeded as part of the above test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d82798ba208329a1226524c64fc215)