### PR TITLE
BATCH-RDX-REG-01: enforce canonical execution hierarchy and progression boundaries

### DIFF
--- a/docs/architecture/system_registry.md
+++ b/docs/architecture/system_registry.md
@@ -6,6 +6,76 @@
 
 These rules are hard boundaries for architecture, contracts, and validation.
 
+## Canonical Governed Execution Hierarchy
+
+The governed execution hierarchy is:
+
+**slice → batch → umbrella → roadmap**
+
+### Slice
+- Atomic unit of work.
+- Executed by PQX.
+- Reviewed by RQX.
+- Fixes gated by TPA.
+
+### Batch
+- Aggregation of slices representing one coherent system seam.
+- Must contain multiple slices.
+- Ends with:
+  - validation
+  - review
+  - `batch_decision_artifact`
+
+### Umbrella
+- Aggregation of batches representing a system phase.
+- Must contain multiple batches.
+- Ends with:
+  - `umbrella_decision_artifact`
+
+### Batch Constraint
+A batch **MUST** contain ≥2 slices.
+If a batch contains only one slice, it is invalid and must be collapsed into a slice.
+
+### Umbrella Constraint
+An umbrella **MUST** contain ≥2 batches.
+If an umbrella contains only one batch, it is invalid and must be collapsed into a batch.
+
+### Invariant
+All hierarchy levels must aggregate real work. No level may act as a pass-through wrapper.
+
+### BRF + Umbrella execution alignment
+- Batch execution flow:
+  - Slices → Test → Review → Decision → (Fix or Advance)
+- Umbrella execution flow:
+  - Batch → Decision
+  - Batch → Decision
+  - → Umbrella Decision
+- No batch advances without:
+  - validation
+  - review
+  - decision artifact
+- No umbrella advances without:
+  - all batches completed
+  - umbrella decision artifact
+
+### Execution Hierarchy Ownership Clarification
+- Slice execution → PQX
+- Review loop → RQX
+- Fix gating → TPA
+- Orchestration → TLC
+- Roadmap execution control → RDX
+- Closure / readiness / promotion → CDE
+
+Batch and umbrella decision artifacts:
+- control execution progression only
+- **MUST NOT** represent closure, readiness, or promotion authority
+- **MUST NOT** substitute for CDE decisions
+
+CDE is the only system allowed to emit:
+- `closure_decision_artifact`
+- `promotion_readiness_decision`
+- `readiness_to_close`
+
 ## System Map
 - **AEX** — admission and execution exchange boundary for repo-mutating Codex requests
 - **PQX** — bounded execution engine

--- a/docs/review-actions/PLAN-BATCH-RDX-REG-01-2026-04-10.md
+++ b/docs/review-actions/PLAN-BATCH-RDX-REG-01-2026-04-10.md
@@ -1,0 +1,29 @@
+# Plan — BATCH-RDX-REG-01 — 2026-04-10
+
+## Prompt type
+VALIDATE
+
+## Scope
+Formalize and enforce the canonical governed execution hierarchy (`slice → batch → umbrella → roadmap`) as a registry + contract/validation hardening change with fail-closed behavior and mandatory red-team review.
+
+## Files in scope
+| File | Action | Purpose |
+| --- | --- | --- |
+| `docs/architecture/system_registry.md` | MODIFY | Add canonical execution hierarchy, cardinality constraints, ownership clarifications, and progression-vs-closure authority boundaries. |
+| `spectrum_systems/modules/runtime/roadmap_selector.py` | MODIFY | Enforce fail-closed hierarchy cardinality checks for roadmap/system roadmap execution inputs. |
+| `spectrum_systems/modules/runtime/roadmap_executor.py` | MODIFY | Enforce hierarchy cardinality checks before batch execution progression. |
+| `spectrum_systems/modules/runtime/roadmap_execution_loop_validator.py` | MODIFY | Enforce hierarchy cardinality checks in roadmap loop validation path. |
+| `spectrum_systems/modules/runtime/execution_hierarchy.py` | ADD | Minimal shared validation layer for non-degenerate batch/umbrella hierarchy checks. |
+| `tests/test_execution_hierarchy.py` | ADD | Surgical tests for invalid/valid batch and umbrella cardinality behavior. |
+| `docs/reviews/RVW-RDX-REG-01.md` | ADD | Mandatory red-team review artifact with explicit risk questions and verdict. |
+
+## Constraints
+- Preserve existing PQX execution behavior, RQX semantics, TPA gating, and CDE closure authority logic.
+- No new systems introduced.
+- Fail closed on missing/invalid hierarchy definitions where required.
+- Keep changes minimal and deterministic.
+
+## Validation
+1. `pytest -q tests/test_execution_hierarchy.py`
+2. `pytest -q tests/test_roadmap_selection.py tests/test_roadmap_executor.py tests/test_roadmap_execution_loop_validator.py`
+3. `pytest -q tests/test_contracts.py`

--- a/docs/reviews/RVW-RDX-REG-01.md
+++ b/docs/reviews/RVW-RDX-REG-01.md
@@ -1,0 +1,37 @@
+# RVW-RDX-REG-01 — Red-Team Review
+
+## Scope
+Review of BATCH-RDX-REG-01 hierarchy and authority hardening:
+- canonical execution hierarchy registration
+- batch/umbrella cardinality enforcement
+- progression-only decision semantics
+- closure authority isolation
+
+## Questions
+
+1. **Can a single-slice batch still execute as a batch?**
+   - **Result:** No (for declared hierarchy manifests).
+   - **Evidence:** `validate_execution_hierarchy(...)` fails closed when a batch declares `slice_ids`/`slices` with length < 2.
+
+2. **Can a single-batch umbrella still execute as an umbrella?**
+   - **Result:** No.
+   - **Evidence:** `validate_execution_hierarchy(...)` fails closed when an umbrella declares fewer than 2 batches.
+
+3. **Can `batch_decision_artifact` be misused as closure authority?**
+   - **Result:** Registry now explicitly forbids this.
+   - **Evidence:** System registry states batch/umbrella decision artifacts are progression-only and cannot substitute for CDE closure authority.
+
+4. **Can TLC or RDX accidentally become closure authority?**
+   - **Result:** Registry now explicitly prevents this.
+   - **Evidence:** ownership clarification binds TLC to orchestration and RDX to roadmap execution control, while CDE is the sole emitter for closure/readiness/promotion decisions.
+
+5. **Can new callers bypass hierarchy enforcement?**
+   - **Result:** Partially mitigated.
+   - **Evidence:** hierarchy validation is now wired into roadmap selector, executor, and loop validator seams.
+   - **Residual risk:** a brand-new call path that avoids these seams could bypass checks unless it also imports the shared hierarchy validator.
+
+## Verdict
+**SAFE TO MOVE ON**
+
+## Follow-up hardening note
+Require all future roadmap execution entrypoints to call `validate_execution_hierarchy(...)` before any selection/execution transition.

--- a/spectrum_systems/modules/runtime/execution_hierarchy.py
+++ b/spectrum_systems/modules/runtime/execution_hierarchy.py
@@ -1,0 +1,78 @@
+"""Fail-closed validation for governed execution hierarchy cardinality."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class ExecutionHierarchyError(ValueError):
+    """Raised when execution hierarchy cardinality or authority rules are invalid."""
+
+
+def _non_empty_name(value: Any) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ExecutionHierarchyError("hierarchy entry id must be a non-empty string")
+    return value.strip()
+
+
+def _require_items(label: str, value: Any) -> list[Any]:
+    if not isinstance(value, list):
+        raise ExecutionHierarchyError(f"{label} must be a list")
+    return value
+
+
+def _find_batch_slice_collection(batch: dict[str, Any]) -> tuple[str, list[Any]] | None:
+    for key in ("slice_ids", "slices"):
+        if key in batch:
+            return key, _require_items(f"batch.{key}", batch[key])
+    return None
+
+
+def validate_execution_hierarchy(payload: dict[str, Any], *, label: str = "payload") -> None:
+    """Validate canonical hierarchy cardinality with fail-closed behavior.
+
+    Rules enforced:
+    - Declared batches with explicit slice collections must include >= 2 slices.
+    - Declared umbrellas must include >= 2 batches.
+    - Batch/umbrella wrappers must not be pass-through (single-member) wrappers.
+    """
+
+    if not isinstance(payload, dict):
+        raise ExecutionHierarchyError(f"{label} must be an object")
+
+    batches = payload.get("batches")
+    if batches is not None:
+        for index, batch in enumerate(_require_items(f"{label}.batches", batches), start=1):
+            if not isinstance(batch, dict):
+                raise ExecutionHierarchyError(f"{label}.batches[{index}] must be an object")
+            collection = _find_batch_slice_collection(batch)
+            if collection is None:
+                continue
+            key, slices = collection
+            if len(slices) < 2:
+                batch_id = _non_empty_name(batch.get("batch_id") or f"index-{index}")
+                raise ExecutionHierarchyError(
+                    f"invalid batch cardinality for {batch_id}: {key} must contain at least 2 slices"
+                )
+
+    umbrellas = payload.get("umbrellas")
+    if umbrellas is not None:
+        for index, umbrella in enumerate(_require_items(f"{label}.umbrellas", umbrellas), start=1):
+            if not isinstance(umbrella, dict):
+                raise ExecutionHierarchyError(f"{label}.umbrellas[{index}] must be an object")
+            umbrella_id = _non_empty_name(umbrella.get("umbrella_id") or f"index-{index}")
+            if "batch_ids" in umbrella:
+                batch_refs = _require_items(f"{label}.umbrellas[{index}].batch_ids", umbrella.get("batch_ids"))
+            elif "batches" in umbrella:
+                batch_refs = _require_items(f"{label}.umbrellas[{index}].batches", umbrella.get("batches"))
+            else:
+                raise ExecutionHierarchyError(
+                    f"invalid umbrella definition for {umbrella_id}: batch_ids or batches is required"
+                )
+            if len(batch_refs) < 2:
+                raise ExecutionHierarchyError(
+                    f"invalid umbrella cardinality for {umbrella_id}: umbrellas must contain at least 2 batches"
+                )
+
+
+__all__ = ["ExecutionHierarchyError", "validate_execution_hierarchy"]

--- a/spectrum_systems/modules/runtime/roadmap_execution_loop_validator.py
+++ b/spectrum_systems/modules/runtime/roadmap_execution_loop_validator.py
@@ -12,6 +12,7 @@ from typing import Any, Callable
 from jsonschema import Draft202012Validator, FormatChecker
 
 from spectrum_systems.contracts import load_schema
+from spectrum_systems.modules.runtime.execution_hierarchy import ExecutionHierarchyError, validate_execution_hierarchy
 from spectrum_systems.modules.runtime.roadmap_authorizer import authorize_selected_batch
 from spectrum_systems.modules.runtime.roadmap_executor import execute_authorized_batch
 from spectrum_systems.modules.runtime.roadmap_selector import build_roadmap_selection_result
@@ -123,6 +124,10 @@ def validate_single_batch_execution_loop(
     pqx_execute_fn: Callable[..., dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Validate one governed roadmap loop: selection -> authorization -> (optional) execution -> progress consistency."""
+    try:
+        validate_execution_hierarchy(roadmap_artifact, label="roadmap_artifact")
+    except ExecutionHierarchyError as exc:
+        raise RoadmapExecutionLoopValidationError(f"roadmap_artifact hierarchy invalid: {exc}") from exc
     _validate_schema(roadmap_artifact, "roadmap_artifact", label="roadmap_artifact")
 
     reason_codes: set[str] = set()

--- a/spectrum_systems/modules/runtime/roadmap_executor.py
+++ b/spectrum_systems/modules/runtime/roadmap_executor.py
@@ -12,6 +12,7 @@ from typing import Any, Callable
 from jsonschema import Draft202012Validator, FormatChecker
 
 from spectrum_systems.contracts import load_schema
+from spectrum_systems.modules.runtime.execution_hierarchy import ExecutionHierarchyError, validate_execution_hierarchy
 from spectrum_systems.modules.runtime.pqx_sequence_runner import execute_sequence_run
 from spectrum_systems.modules.runtime.roadmap_stop_reasons import (
     STOP_REASON_AUTHORIZATION_BLOCK,
@@ -181,6 +182,10 @@ def execute_authorized_batch(
     pqx_execute_fn: Callable[..., dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Execute one selected roadmap batch through PQX only when authorization permits it."""
+    try:
+        validate_execution_hierarchy(roadmap_artifact, label="roadmap_artifact")
+    except ExecutionHierarchyError as exc:
+        raise RoadmapExecutorError(f"roadmap_artifact hierarchy invalid: {exc}") from exc
     _validate_schema(roadmap_artifact, "roadmap_artifact", label="roadmap_artifact")
     _validate_schema(roadmap_selection_result, "roadmap_selection_result", label="roadmap_selection_result")
     _validate_schema(

--- a/spectrum_systems/modules/runtime/roadmap_selector.py
+++ b/spectrum_systems/modules/runtime/roadmap_selector.py
@@ -11,6 +11,7 @@ from typing import Any
 from jsonschema import Draft202012Validator, FormatChecker
 
 from spectrum_systems.contracts import load_schema
+from spectrum_systems.modules.runtime.execution_hierarchy import ExecutionHierarchyError, validate_execution_hierarchy
 from spectrum_systems.modules.runtime.program_layer import validate_roadmap_against_program as validate_program_alignment
 from spectrum_systems.modules.runtime.roadmap_signal_steering import (
     select_priority_batch,
@@ -67,6 +68,10 @@ def load_active_roadmap(path: Path | str) -> dict[str, Any]:
         raise RoadmapSelectionError(f"roadmap artifact is not valid JSON: {roadmap_path}") from exc
     if not isinstance(payload, dict):
         raise RoadmapSelectionError("roadmap artifact root must be an object")
+    try:
+        validate_execution_hierarchy(payload, label="system_roadmap")
+    except ExecutionHierarchyError as exc:
+        raise RoadmapSelectionError(f"system_roadmap hierarchy invalid: {exc}") from exc
     _validate_schema(payload, "system_roadmap", label="system_roadmap")
     return payload
 
@@ -317,6 +322,10 @@ def select_next_batch(
 ) -> str | None:
     """Select the next roadmap batch allowed to run, or ``None`` when no batch is eligible."""
     if "version" in roadmap_artifact and "created_at" in roadmap_artifact and "trace_id" in roadmap_artifact:
+        try:
+            validate_execution_hierarchy(roadmap_artifact, label="system_roadmap")
+        except ExecutionHierarchyError as exc:
+            raise RoadmapSelectionError(f"system_roadmap hierarchy invalid: {exc}") from exc
         normalized_roadmap = _normalize_system_roadmap_for_selection(roadmap_artifact)
         _validate_schema(normalized_roadmap, "system_roadmap", label="system_roadmap")
         return _select_next_batch_from_system_roadmap(
@@ -326,6 +335,10 @@ def select_next_batch(
         )
 
     _validate_schema(roadmap_artifact, "roadmap_artifact", label="roadmap_artifact")
+    try:
+        validate_execution_hierarchy(roadmap_artifact, label="roadmap_artifact")
+    except ExecutionHierarchyError as exc:
+        raise RoadmapSelectionError(f"roadmap_artifact hierarchy invalid: {exc}") from exc
     if not isinstance(system_signals, dict):
         raise RoadmapSelectionError("system_signals must be an object")
 

--- a/tests/test_execution_hierarchy.py
+++ b/tests/test_execution_hierarchy.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pytest
+
+from spectrum_systems.modules.runtime.execution_hierarchy import (
+    ExecutionHierarchyError,
+    validate_execution_hierarchy,
+)
+
+
+def test_invalid_single_slice_batch_fails() -> None:
+    payload = {
+        "batches": [
+            {
+                "batch_id": "BATCH-ONE",
+                "slice_ids": ["SLICE-1"],
+            }
+        ]
+    }
+    with pytest.raises(ExecutionHierarchyError, match="invalid batch cardinality"):
+        validate_execution_hierarchy(payload, label="batch_manifest")
+
+
+def test_invalid_single_batch_umbrella_fails() -> None:
+    payload = {
+        "umbrellas": [
+            {
+                "umbrella_id": "UMB-A",
+                "batch_ids": ["BATCH-A"],
+            }
+        ]
+    }
+    with pytest.raises(ExecutionHierarchyError, match="invalid umbrella cardinality"):
+        validate_execution_hierarchy(payload, label="roadmap_manifest")
+
+
+def test_valid_multi_slice_batch_passes() -> None:
+    payload = {
+        "batches": [
+            {
+                "batch_id": "BATCH-OK",
+                "slice_ids": ["SLICE-1", "SLICE-2"],
+            }
+        ]
+    }
+    validate_execution_hierarchy(payload, label="batch_manifest")
+
+
+def test_valid_multi_batch_umbrella_passes() -> None:
+    payload = {
+        "batches": [
+            {"batch_id": "BATCH-A", "slice_ids": ["SLICE-1", "SLICE-2"]},
+            {"batch_id": "BATCH-B", "slice_ids": ["SLICE-3", "SLICE-4"]},
+        ],
+        "umbrellas": [
+            {
+                "umbrella_id": "UMB-OK",
+                "batch_ids": ["BATCH-A", "BATCH-B"],
+            }
+        ],
+    }
+    validate_execution_hierarchy(payload, label="roadmap_manifest")


### PR DESCRIPTION
### Motivation
- Make the governed execution hierarchy explicit (`slice → batch → umbrella → roadmap`) and record progression vs closure semantics in the System Registry. 
- Fail-closed enforcement of non-degenerate hierarchy cardinality so wrappers are not used as pass-throughs. 
- Align BRF/umbrella semantics and preserve strict ownership boundaries so closure/promotion authority remains CDE-only.

### Description
- Added a new Canonical Governed Execution Hierarchy section to `docs/architecture/system_registry.md` with batch/umbrella cardinality rules, BRF/umbrella progression flow, and ownership clarifications. 
- Introduced a shared validator `spectrum_systems/modules/runtime/execution_hierarchy.py` that raises `ExecutionHierarchyError` on invalid hierarchy declarations. 
- Wired `validate_execution_hierarchy(...)` into roadmap runtime seams: `roadmap_selector` (load/selection), `roadmap_executor` (authorized execution), and `roadmap_execution_loop_validator` (loop validation) to fail closed on invalid manifests. 
- Added surgical unit tests `tests/test_execution_hierarchy.py` for the four required cases and included governance artifacts: `docs/review-actions/PLAN-BATCH-RDX-REG-01-2026-04-10.md` and the red-team review `docs/reviews/RVW-RDX-REG-01.md`.

### Testing
- Ran `pytest -q tests/test_execution_hierarchy.py` and it passed (`4 passed`).
- Ran `pytest -q tests/test_roadmap_selector.py tests/test_roadmap_executor.py tests/test_roadmap_execution_loop_validator.py` and they passed (`37 passed`).
- Ran `pytest -q tests/test_contracts.py` and it passed (`79 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8cbc9f1288329b69ba3c64b7697f4)