### PR TITLE
BATCH-AUT-REG-01: add canonical slice registry, roadmap structure, and fail-closed loader

### DIFF
--- a/contracts/roadmap/roadmap_structure.json
+++ b/contracts/roadmap/roadmap_structure.json
@@ -1,0 +1,186 @@
+{
+  "artifact_type": "roadmap_structure",
+  "version": "1.0.0",
+  "umbrellas": [
+    {
+      "umbrella_id": "AUTONOMY_EXECUTION",
+      "batches": [
+        {
+          "batch_id": "BATCH-AEX",
+          "slice_ids": [
+            "AEX-01",
+            "AEX-02",
+            "AUT-01",
+            "AUT-02",
+            "AUT-03"
+          ]
+        },
+        {
+          "batch_id": "BATCH-AUT",
+          "slice_ids": [
+            "AUT-04",
+            "AUT-05",
+            "AUT-06",
+            "AUT-07",
+            "AUT-08",
+            "AUT-09",
+            "AUT-10"
+          ]
+        }
+      ]
+    },
+    {
+      "umbrella_id": "GOVERNANCE_HARDENING",
+      "batches": [
+        {
+          "batch_id": "BATCH-GOV-A",
+          "slice_ids": [
+            "GOV-A-01",
+            "GOV-A-02"
+          ]
+        },
+        {
+          "batch_id": "BATCH-GOV-B",
+          "slice_ids": [
+            "GOV-B-01",
+            "GOV-B-02"
+          ]
+        },
+        {
+          "batch_id": "BATCH-GOV-C",
+          "slice_ids": [
+            "GOV-C-01",
+            "GOV-C-02"
+          ]
+        },
+        {
+          "batch_id": "BATCH-GOV-D",
+          "slice_ids": [
+            "GOV-D-01",
+            "GOV-D-02"
+          ]
+        },
+        {
+          "batch_id": "BATCH-GOV-E",
+          "slice_ids": [
+            "GOV-E-01",
+            "GOV-E-02"
+          ]
+        }
+      ]
+    },
+    {
+      "umbrella_id": "PREFLIGHT_AND_REPAIR",
+      "batches": [
+        {
+          "batch_id": "BATCH-PFG",
+          "slice_ids": [
+            "PFG-01",
+            "PFG-02"
+          ]
+        },
+        {
+          "batch_id": "BATCH-AFX",
+          "slice_ids": [
+            "AFX-01",
+            "AFX-02",
+            "AFX-03",
+            "AFX-04",
+            "AFX-05"
+          ]
+        },
+        {
+          "batch_id": "BATCH-AFX-GATES",
+          "slice_ids": [
+            "AFX-GATE-01",
+            "AFX-RT-01"
+          ]
+        },
+        {
+          "batch_id": "BATCH-PRG-RGM",
+          "slice_ids": [
+            "PRG-RGM-01",
+            "PRG-RGM-02"
+          ]
+        },
+        {
+          "batch_id": "BATCH-MBRF",
+          "slice_ids": [
+            "MBRF-01",
+            "BRF-01"
+          ]
+        }
+      ]
+    },
+    {
+      "umbrella_id": "RDX_EXECUTION_CONTROL",
+      "batches": [
+        {
+          "batch_id": "BATCH-RDX-REG",
+          "slice_ids": [
+            "RDX-REG-01",
+            "RDX-REG-02"
+          ]
+        },
+        {
+          "batch_id": "BATCH-RDX-EXEC",
+          "slice_ids": [
+            "RDX-EXEC-01",
+            "RDX-EXEC-02",
+            "RDX-EXEC-03",
+            "RDX-EXEC-04"
+          ]
+        },
+        {
+          "batch_id": "BATCH-UMB-DEC",
+          "slice_ids": [
+            "UMB-DEC-01",
+            "BRF-ENFORCE-01"
+          ]
+        }
+      ]
+    },
+    {
+      "umbrella_id": "STRESS_VALIDATION",
+      "batches": [
+        {
+          "batch_id": "BATCH-SVA-ADV",
+          "slice_ids": [
+            "SVA-ADV-01",
+            "SVA-ADV-02",
+            "SVA-ADV-03",
+            "SVA-ADV-04"
+          ]
+        },
+        {
+          "batch_id": "BATCH-SVA-LOAD",
+          "slice_ids": [
+            "SVA-LOAD-01",
+            "SVA-LOAD-02",
+            "SVA-LOAD-03",
+            "SVA-LOAD-04"
+          ]
+        },
+        {
+          "batch_id": "BATCH-SVA-DRIFT",
+          "slice_ids": [
+            "SVA-DRIFT-01",
+            "SVA-DRIFT-02",
+            "SVA-DRIFT-03",
+            "SVA-DRIFT-04"
+          ]
+        },
+        {
+          "batch_id": "BATCH-SVA-REC",
+          "slice_ids": [
+            "SVA-REC-01",
+            "SVA-REC-02",
+            "SVA-REC-03",
+            "SVA-REC-04"
+          ]
+        }
+      ]
+    }
+  ],
+  "reserved_slice_ids": []
+}

--- a/contracts/roadmap/slice_registry.json
+++ b/contracts/roadmap/slice_registry.json
@@ -1,0 +1,1497 @@
+{
+  "artifact_type": "slice_registry",
+  "version": "1.0.0",
+  "slices": [
+    {
+      "slice_id": "AEX-01",
+      "what_it_does": "Implements governed AEX control behavior for execution slice AEX-01.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for AEX-01; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "partial",
+      "source_basis": [
+        "roadmap",
+        "repo",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "AEX-02",
+      "what_it_does": "Implements governed AEX control behavior for execution slice AEX-02.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for AEX-02; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "AFX-01",
+      "what_it_does": "Implements governed AFX control behavior for execution slice AFX-01.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for AFX-01; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "AFX-02",
+      "what_it_does": "Implements governed AFX control behavior for execution slice AFX-02.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for AFX-02; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "repo",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "AFX-03",
+      "what_it_does": "Implements governed AFX control behavior for execution slice AFX-03.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for AFX-03; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "AFX-04",
+      "what_it_does": "Implements governed AFX control behavior for execution slice AFX-04.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for AFX-04; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "AFX-05",
+      "what_it_does": "Implements governed AFX control behavior for execution slice AFX-05.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for AFX-05; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "AFX-GATE-01",
+      "what_it_does": "Implements governed AFX control behavior for execution slice AFX-GATE-01.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for AFX-GATE-01; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "AFX-RT-01",
+      "what_it_does": "Implements governed AFX control behavior for execution slice AFX-RT-01.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for AFX-RT-01; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "AUT-01",
+      "what_it_does": "Implements governed AUT control behavior for execution slice AUT-01.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for AUT-01; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "AUT-02",
+      "what_it_does": "Implements governed AUT control behavior for execution slice AUT-02.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for AUT-02; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "AUT-03",
+      "what_it_does": "Implements governed AUT control behavior for execution slice AUT-03.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for AUT-03; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "AUT-04",
+      "what_it_does": "Implements governed AUT control behavior for execution slice AUT-04.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for AUT-04; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "AUT-05",
+      "what_it_does": "Implements governed AUT control behavior for execution slice AUT-05.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for AUT-05; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "AUT-06",
+      "what_it_does": "Implements governed AUT control behavior for execution slice AUT-06.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for AUT-06; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "AUT-07",
+      "what_it_does": "Implements governed AUT control behavior for execution slice AUT-07.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for AUT-07; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "AUT-08",
+      "what_it_does": "Implements governed AUT control behavior for execution slice AUT-08.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for AUT-08; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "AUT-09",
+      "what_it_does": "Implements governed AUT control behavior for execution slice AUT-09.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for AUT-09; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "AUT-10",
+      "what_it_does": "Implements governed AUT control behavior for execution slice AUT-10.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for AUT-10; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "BRF-01",
+      "what_it_does": "Implements governed BRF control behavior for execution slice BRF-01.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for BRF-01; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "BRF-ENFORCE-01",
+      "what_it_does": "Implements governed BRF control behavior for execution slice BRF-ENFORCE-01.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for BRF-ENFORCE-01; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "partial",
+      "source_basis": [
+        "roadmap",
+        "repo",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "GOV-A-01",
+      "what_it_does": "Implements governed GOV control behavior for execution slice GOV-A-01.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for GOV-A-01; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "GOV-A-02",
+      "what_it_does": "Implements governed GOV control behavior for execution slice GOV-A-02.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for GOV-A-02; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "GOV-B-01",
+      "what_it_does": "Implements governed GOV control behavior for execution slice GOV-B-01.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for GOV-B-01; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "GOV-B-02",
+      "what_it_does": "Implements governed GOV control behavior for execution slice GOV-B-02.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for GOV-B-02; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "GOV-C-01",
+      "what_it_does": "Implements governed GOV control behavior for execution slice GOV-C-01.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for GOV-C-01; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "GOV-C-02",
+      "what_it_does": "Implements governed GOV control behavior for execution slice GOV-C-02.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for GOV-C-02; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "GOV-D-01",
+      "what_it_does": "Implements governed GOV control behavior for execution slice GOV-D-01.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for GOV-D-01; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "GOV-D-02",
+      "what_it_does": "Implements governed GOV control behavior for execution slice GOV-D-02.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for GOV-D-02; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "GOV-E-01",
+      "what_it_does": "Implements governed GOV control behavior for execution slice GOV-E-01.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for GOV-E-01; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "GOV-E-02",
+      "what_it_does": "Implements governed GOV control behavior for execution slice GOV-E-02.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for GOV-E-02; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "MBRF-01",
+      "what_it_does": "Implements governed MBRF control behavior for execution slice MBRF-01.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for MBRF-01; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "PFG-01",
+      "what_it_does": "Implements governed PFG control behavior for execution slice PFG-01.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for PFG-01; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "repo",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "PFG-02",
+      "what_it_does": "Implements governed PFG control behavior for execution slice PFG-02.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for PFG-02; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "PRG-RGM-01",
+      "what_it_does": "Implements governed PRG control behavior for execution slice PRG-RGM-01.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for PRG-RGM-01; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "repo",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "PRG-RGM-02",
+      "what_it_does": "Implements governed PRG control behavior for execution slice PRG-RGM-02.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for PRG-RGM-02; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "RDX-EXEC-01",
+      "what_it_does": "Implements governed RDX control behavior for execution slice RDX-EXEC-01.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for RDX-EXEC-01; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "RDX-EXEC-02",
+      "what_it_does": "Implements governed RDX control behavior for execution slice RDX-EXEC-02.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for RDX-EXEC-02; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "partial",
+      "source_basis": [
+        "roadmap",
+        "repo",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "RDX-EXEC-03",
+      "what_it_does": "Implements governed RDX control behavior for execution slice RDX-EXEC-03.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for RDX-EXEC-03; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "partial",
+      "source_basis": [
+        "roadmap",
+        "repo",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "RDX-EXEC-04",
+      "what_it_does": "Implements governed RDX control behavior for execution slice RDX-EXEC-04.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for RDX-EXEC-04; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "RDX-REG-01",
+      "what_it_does": "Implements governed RDX control behavior for execution slice RDX-REG-01.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for RDX-REG-01; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "partial",
+      "source_basis": [
+        "roadmap",
+        "repo",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "RDX-REG-02",
+      "what_it_does": "Implements governed RDX control behavior for execution slice RDX-REG-02.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for RDX-REG-02; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "SVA-ADV-01",
+      "what_it_does": "Implements governed SVA control behavior for execution slice SVA-ADV-01.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for SVA-ADV-01; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "partial",
+      "source_basis": [
+        "roadmap",
+        "repo",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "SVA-ADV-02",
+      "what_it_does": "Implements governed SVA control behavior for execution slice SVA-ADV-02.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for SVA-ADV-02; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "repo",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "SVA-ADV-03",
+      "what_it_does": "Implements governed SVA control behavior for execution slice SVA-ADV-03.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for SVA-ADV-03; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "repo",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "SVA-ADV-04",
+      "what_it_does": "Implements governed SVA control behavior for execution slice SVA-ADV-04.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for SVA-ADV-04; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "repo",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "SVA-DRIFT-01",
+      "what_it_does": "Implements governed SVA control behavior for execution slice SVA-DRIFT-01.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for SVA-DRIFT-01; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "SVA-DRIFT-02",
+      "what_it_does": "Implements governed SVA control behavior for execution slice SVA-DRIFT-02.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for SVA-DRIFT-02; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "SVA-DRIFT-03",
+      "what_it_does": "Implements governed SVA control behavior for execution slice SVA-DRIFT-03.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for SVA-DRIFT-03; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "SVA-DRIFT-04",
+      "what_it_does": "Implements governed SVA control behavior for execution slice SVA-DRIFT-04.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for SVA-DRIFT-04; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "SVA-LOAD-01",
+      "what_it_does": "Implements governed SVA control behavior for execution slice SVA-LOAD-01.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for SVA-LOAD-01; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "partial",
+      "source_basis": [
+        "roadmap",
+        "repo",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "SVA-LOAD-02",
+      "what_it_does": "Implements governed SVA control behavior for execution slice SVA-LOAD-02.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for SVA-LOAD-02; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "repo",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "SVA-LOAD-03",
+      "what_it_does": "Implements governed SVA control behavior for execution slice SVA-LOAD-03.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for SVA-LOAD-03; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "repo",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "SVA-LOAD-04",
+      "what_it_does": "Implements governed SVA control behavior for execution slice SVA-LOAD-04.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for SVA-LOAD-04; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "repo",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "SVA-REC-01",
+      "what_it_does": "Implements governed SVA control behavior for execution slice SVA-REC-01.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for SVA-REC-01; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "SVA-REC-02",
+      "what_it_does": "Implements governed SVA control behavior for execution slice SVA-REC-02.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for SVA-REC-02; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "SVA-REC-03",
+      "what_it_does": "Implements governed SVA control behavior for execution slice SVA-REC-03.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for SVA-REC-03; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "SVA-REC-04",
+      "what_it_does": "Implements governed SVA control behavior for execution slice SVA-REC-04.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for SVA-REC-04; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    },
+    {
+      "slice_id": "UMB-DEC-01",
+      "what_it_does": "Implements governed UMB control behavior for execution slice UMB-DEC-01.",
+      "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
+      "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "implementation_notes": "Inferred from canonical roadmap batch intent for UMB-DEC-01; keep behavior artifact-first and fail-closed.",
+      "likely_entrypoints": [
+        "spectrum_systems/modules/runtime",
+        "scripts"
+      ],
+      "likely_tests": [
+        "tests/test_execution_hierarchy.py",
+        "tests/test_prompt_queue_execution_loop.py"
+      ],
+      "invariants": [
+        "fail_closed_on_missing_artifacts",
+        "deterministic_execution_order",
+        "cde_closure_authority_preserved"
+      ],
+      "status": "planned",
+      "source_basis": [
+        "roadmap",
+        "inferred"
+      ]
+    }
+  ]
+}

--- a/docs/review-actions/PLAN-BATCH-AUT-REG-01-2026-04-10.md
+++ b/docs/review-actions/PLAN-BATCH-AUT-REG-01-2026-04-10.md
@@ -1,0 +1,30 @@
+# PLAN-BATCH-AUT-REG-01-2026-04-10
+
+- **Primary prompt type:** PLAN
+- **Date:** 2026-04-10
+- **Batch ID:** BATCH-AUT-REG-01
+- **Scope:** Build canonical machine-readable slice registry + execution structure artifacts, fail-closed validator seam, loader seam, targeted tests, and review/delivery artifacts.
+
+## Execution Plan
+1. Inspect authoritative roadmap surfaces and adjacent runtime validator/loader patterns to derive canonical slice IDs and execution structure shape.
+2. Add governed roadmap artifacts under `contracts/roadmap/`:
+   - `slice_registry.json` (canonical Table 1 machine form)
+   - `roadmap_structure.json` (Table 2 machine form)
+3. Implement a thin runtime seam for loading + validating the two artifacts with fail-closed checks:
+   - missing slice definitions
+   - duplicate slice IDs
+   - orphan structure references
+   - malformed implementation metadata
+   - invalid batch/umbrella cardinality
+4. Add focused deterministic tests for valid loads/order and all required fail-closed conditions.
+5. Add required review artifacts:
+   - `docs/reviews/RVW-BATCH-AUT-REG-01.md`
+   - `docs/reviews/BATCH-AUT-REG-01-DELIVERY-REPORT.md`
+6. Execute required command set and targeted tests for changed seams.
+7. Commit, then open PR message via `make_pr`.
+
+## Constraints and Guardrails
+- No new systems or ownership changes.
+- Preserve authority boundaries (RDX sequencing, PQX execution, RQX review, TPA gating, SEL enforcement, CDE closure authority).
+- Deterministic ordering by `slice_id`.
+- Artifact-first + fail-closed behavior.

--- a/docs/reviews/BATCH-AUT-REG-01-DELIVERY-REPORT.md
+++ b/docs/reviews/BATCH-AUT-REG-01-DELIVERY-REPORT.md
@@ -1,0 +1,54 @@
+# BATCH-AUT-REG-01 — DELIVERY REPORT
+
+- **Date:** 2026-04-10
+- **Primary prompt type:** VALIDATE
+
+## Intent
+Deliver the missing canonical, machine-readable Table 1 (slice registry) and Table 2 (execution structure), wire a thin runtime loader/validator seam, and fail closed on structural/metadata errors.
+
+## Files Added/Changed
+- `contracts/roadmap/slice_registry.json` (new canonical slice registry artifact)
+- `contracts/roadmap/roadmap_structure.json` (new canonical execution hierarchy artifact)
+- `spectrum_systems/modules/runtime/roadmap_slice_registry.py` (loader + fail-closed validator seam)
+- `tests/test_roadmap_slice_registry.py` (targeted deterministic validation tests)
+- `docs/review-actions/PLAN-BATCH-AUT-REG-01-2026-04-10.md` (plan-first artifact)
+- `docs/reviews/RVW-BATCH-AUT-REG-01.md` (review artifact)
+- `docs/reviews/BATCH-AUT-REG-01-DELIVERY-REPORT.md` (this report)
+
+## Registry Structure Created
+- `slice_registry.json`
+  - `artifact_type`, `version`, `slices[]`
+  - per-slice required semantic + implementation fields
+  - deterministic `slice_id` ordering
+  - explicit `source_basis` including inferred coverage where exact repo seams are unresolved
+- `roadmap_structure.json`
+  - `artifact_type`, `version`, `umbrellas[]`, `reserved_slice_ids[]`
+  - machine-usable `umbrella -> batches -> slice_ids` structure
+
+## Validation Behavior Added
+Fail-closed checks now enforce:
+1. referenced slices must exist in registry
+2. duplicate `slice_id` in registry is rejected
+3. duplicate cross-batch placement rejected unless explicit allowance exists
+4. batch cardinality >= 2 slices
+5. umbrella cardinality >= 2 batches
+6. registry slices must be mapped or explicitly reserved
+7. implementation metadata must be present and well-formed
+
+## Tests Added
+- valid registry + structure load
+- deterministic loader ordering/content
+- orphan slice reference failure
+- duplicate slice_id failure
+- single-slice batch failure
+- single-batch umbrella failure
+- implementation metadata enforcement
+
+## Review Summary
+Review result: **SAFE TO MOVE ON**. Canonical artifacts are machine-readable, fail-closed, and maintain existing authority boundaries.
+
+## Remaining Gaps
+- Several slices remain intentionally marked inferred because source intent is spread across multiple governed docs and execution traces.
+
+## Next-Step Recommendation
+Wire this loader seam into next RDX selection/sequencing adapters so execution can source canonical slice metadata directly from artifact contracts rather than prompt text.

--- a/docs/reviews/RVW-BATCH-AUT-REG-01.md
+++ b/docs/reviews/RVW-BATCH-AUT-REG-01.md
@@ -1,0 +1,26 @@
+# RVW-BATCH-AUT-REG-01
+
+- **Primary prompt type:** REVIEW
+- **Date:** 2026-04-10
+- **Scope:** Canonical slice registry + execution structure artifacts + fail-closed loader/validator seam.
+
+## 1) Is the slice registry actually machine-readable and canonical?
+Yes. `contracts/roadmap/slice_registry.json` is JSON with deterministic `slice_id` ordering and required implementation metadata fields per slice. Runtime loading is fail-closed and enforces metadata presence and uniqueness.
+
+## 2) Can roadmap_structure reference a non-existent slice?
+No. Loader validation rejects any structure reference whose `slice_id` is absent from the canonical registry.
+
+## 3) Can degenerate batch/umbrella structures slip through?
+No. Batch cardinality (<2 slices) and umbrella cardinality (<2 batches) fail closed through the shared runtime hierarchy validator.
+
+## 4) Is implementation guidance sufficient for future minimal prompt mode?
+Sufficient for next-step execution wiring. Every slice carries implementation guidance (`implementation_notes`, likely entrypoints/tests, invariants, source basis), and unresolved details are explicitly marked inferred.
+
+## 5) Did this add any new authority owner by accident?
+No. Authority boundaries remain unchanged: RDX sequencing, PQX execution, RQX review, TPA fix gating, SEL enforcement, CDE closure/readiness/promotion authority.
+
+## 6) Weakest point?
+Some slice-level implementation details are inferred because authoritative roadmap intent for all 59 slices is currently distributed across batch plans/reviews instead of one canonical table source. This is surfaced explicitly via `source_basis` and can be tightened as canonical source depth increases.
+
+## Verdict
+**SAFE TO MOVE ON**

--- a/spectrum_systems/modules/runtime/roadmap_slice_registry.py
+++ b/spectrum_systems/modules/runtime/roadmap_slice_registry.py
@@ -1,0 +1,219 @@
+"""Canonical roadmap slice registry loader + fail-closed consistency validation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from spectrum_systems.modules.runtime.execution_hierarchy import (
+    ExecutionHierarchyError,
+    validate_execution_hierarchy,
+)
+
+
+class RoadmapSliceRegistryError(ValueError):
+    """Raised when canonical roadmap registry artifacts are invalid."""
+
+
+_REQUIRED_SLICE_FIELDS = (
+    "slice_id",
+    "what_it_does",
+    "purpose",
+    "why_it_matters",
+    "implementation_notes",
+    "likely_entrypoints",
+    "likely_tests",
+    "invariants",
+)
+
+
+def _load_json_object(path: Path | str, *, label: str) -> dict[str, Any]:
+    file_path = Path(path)
+    try:
+        payload = json.loads(file_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise RoadmapSliceRegistryError(f"{label} artifact not found: {file_path}") from exc
+    except json.JSONDecodeError as exc:
+        raise RoadmapSliceRegistryError(f"{label} artifact is not valid JSON: {file_path}") from exc
+
+    if not isinstance(payload, dict):
+        raise RoadmapSliceRegistryError(f"{label} artifact root must be an object")
+    return payload
+
+
+def _as_non_empty_string(value: Any, *, field: str, slice_id: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise RoadmapSliceRegistryError(f"slice {slice_id} has invalid {field}: expected non-empty string")
+    return value.strip()
+
+
+def _as_string_list(value: Any, *, field: str, slice_id: str) -> list[str]:
+    if not isinstance(value, list) or not value:
+        raise RoadmapSliceRegistryError(f"slice {slice_id} has invalid {field}: expected non-empty list")
+    cleaned: list[str] = []
+    for item in value:
+        if not isinstance(item, str) or not item.strip():
+            raise RoadmapSliceRegistryError(f"slice {slice_id} has invalid {field}: entries must be non-empty strings")
+        cleaned.append(item.strip())
+    return cleaned
+
+
+def validate_slice_registry(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    if payload.get("artifact_type") != "slice_registry":
+        raise RoadmapSliceRegistryError("slice registry artifact_type must be 'slice_registry'")
+
+    raw_slices = payload.get("slices")
+    if not isinstance(raw_slices, list) or not raw_slices:
+        raise RoadmapSliceRegistryError("slice registry must include a non-empty slices list")
+
+    normalized: list[dict[str, Any]] = []
+    seen_slice_ids: set[str] = set()
+    for row in raw_slices:
+        if not isinstance(row, dict):
+            raise RoadmapSliceRegistryError("slice registry entries must be objects")
+
+        slice_id = _as_non_empty_string(row.get("slice_id"), field="slice_id", slice_id="<unknown>")
+        if slice_id in seen_slice_ids:
+            raise RoadmapSliceRegistryError(f"duplicate slice_id in registry: {slice_id}")
+        seen_slice_ids.add(slice_id)
+
+        for field in _REQUIRED_SLICE_FIELDS:
+            if field not in row:
+                raise RoadmapSliceRegistryError(f"slice {slice_id} missing required field: {field}")
+
+        normalized.append(
+            {
+                "slice_id": slice_id,
+                "what_it_does": _as_non_empty_string(row.get("what_it_does"), field="what_it_does", slice_id=slice_id),
+                "purpose": _as_non_empty_string(row.get("purpose"), field="purpose", slice_id=slice_id),
+                "why_it_matters": _as_non_empty_string(
+                    row.get("why_it_matters"), field="why_it_matters", slice_id=slice_id
+                ),
+                "implementation_notes": _as_non_empty_string(
+                    row.get("implementation_notes"), field="implementation_notes", slice_id=slice_id
+                ),
+                "likely_entrypoints": _as_string_list(
+                    row.get("likely_entrypoints"), field="likely_entrypoints", slice_id=slice_id
+                ),
+                "likely_tests": _as_string_list(row.get("likely_tests"), field="likely_tests", slice_id=slice_id),
+                "invariants": _as_string_list(row.get("invariants"), field="invariants", slice_id=slice_id),
+                "status": _as_non_empty_string(row.get("status", "planned"), field="status", slice_id=slice_id),
+                "source_basis": _as_string_list(row.get("source_basis", ["inferred"]), field="source_basis", slice_id=slice_id),
+            }
+        )
+
+    return sorted(normalized, key=lambda item: item["slice_id"])
+
+
+def validate_roadmap_structure(payload: dict[str, Any]) -> dict[str, Any]:
+    if payload.get("artifact_type") != "roadmap_structure":
+        raise RoadmapSliceRegistryError("roadmap structure artifact_type must be 'roadmap_structure'")
+
+    umbrellas = payload.get("umbrellas")
+    if not isinstance(umbrellas, list) or not umbrellas:
+        raise RoadmapSliceRegistryError("roadmap structure must include a non-empty umbrellas list")
+
+    try:
+        validate_execution_hierarchy(payload, label="roadmap_structure")
+    except ExecutionHierarchyError as exc:
+        raise RoadmapSliceRegistryError(str(exc)) from exc
+
+    normalized_umbrellas: list[dict[str, Any]] = []
+    for umbrella in umbrellas:
+        if not isinstance(umbrella, dict):
+            raise RoadmapSliceRegistryError("umbrella entries must be objects")
+        umbrella_id = _as_non_empty_string(umbrella.get("umbrella_id"), field="umbrella_id", slice_id="<umbrella>")
+        batches = umbrella.get("batches")
+        if not isinstance(batches, list) or not batches:
+            raise RoadmapSliceRegistryError(f"umbrella {umbrella_id} must include non-empty batches")
+        normalized_batches: list[dict[str, Any]] = []
+        for batch in batches:
+            if not isinstance(batch, dict):
+                raise RoadmapSliceRegistryError(f"umbrella {umbrella_id} includes non-object batch")
+            batch_id = _as_non_empty_string(batch.get("batch_id"), field="batch_id", slice_id=f"{umbrella_id}::<batch>")
+            slice_ids = _as_string_list(batch.get("slice_ids"), field="slice_ids", slice_id=batch_id)
+            if len(slice_ids) < 2:
+                raise RoadmapSliceRegistryError(
+                    f"invalid batch cardinality for {batch_id}: slice_ids must contain at least 2 slices"
+                )
+            normalized_batches.append({"batch_id": batch_id, "slice_ids": sorted(set(slice_ids))})
+        normalized_umbrellas.append(
+            {
+                "umbrella_id": umbrella_id,
+                "batches": sorted(normalized_batches, key=lambda item: item["batch_id"]),
+            }
+        )
+
+    reserved_slice_ids = payload.get("reserved_slice_ids", [])
+    if not isinstance(reserved_slice_ids, list):
+        raise RoadmapSliceRegistryError("roadmap_structure.reserved_slice_ids must be a list")
+    reserved = _as_string_list(reserved_slice_ids, field="reserved_slice_ids", slice_id="<structure>") if reserved_slice_ids else []
+
+    return {
+        "artifact_type": "roadmap_structure",
+        "version": str(payload.get("version", "1.0.0")),
+        "umbrellas": sorted(normalized_umbrellas, key=lambda item: item["umbrella_id"]),
+        "reserved_slice_ids": sorted(set(reserved)),
+    }
+
+
+def validate_registry_structure_consistency(
+    slices: list[dict[str, Any]],
+    structure: dict[str, Any],
+) -> None:
+    slice_ids = {row["slice_id"] for row in slices}
+    reserved_slice_ids = set(structure.get("reserved_slice_ids", []))
+
+    mapped: dict[str, str] = {}
+    for umbrella in structure["umbrellas"]:
+        umbrella_id = umbrella["umbrella_id"]
+        for batch in umbrella["batches"]:
+            batch_id = batch["batch_id"]
+            placement = f"{umbrella_id}/{batch_id}"
+            for slice_id in batch["slice_ids"]:
+                if slice_id not in slice_ids:
+                    raise RoadmapSliceRegistryError(f"roadmap structure references unknown slice_id: {slice_id}")
+                if slice_id in mapped:
+                    raise RoadmapSliceRegistryError(
+                        f"duplicate slice placement without explicit allowance: {slice_id} in {mapped[slice_id]} and {placement}"
+                    )
+                mapped[slice_id] = placement
+
+    unmapped = sorted(slice_ids - set(mapped) - reserved_slice_ids)
+    if unmapped:
+        raise RoadmapSliceRegistryError(
+            "slice_registry contains unplaced slices that are not reserved: " + ", ".join(unmapped)
+        )
+
+
+def load_slice_registry(path: Path | str) -> list[dict[str, Any]]:
+    payload = _load_json_object(path, label="slice_registry")
+    return validate_slice_registry(payload)
+
+
+def load_roadmap_structure(path: Path | str) -> dict[str, Any]:
+    payload = _load_json_object(path, label="roadmap_structure")
+    return validate_roadmap_structure(payload)
+
+
+def load_governed_slice_registry_artifacts(
+    *,
+    slice_registry_path: Path | str,
+    roadmap_structure_path: Path | str,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    slices = load_slice_registry(slice_registry_path)
+    structure = load_roadmap_structure(roadmap_structure_path)
+    validate_registry_structure_consistency(slices, structure)
+    return slices, structure
+
+
+__all__ = [
+    "RoadmapSliceRegistryError",
+    "load_governed_slice_registry_artifacts",
+    "load_roadmap_structure",
+    "load_slice_registry",
+    "validate_registry_structure_consistency",
+    "validate_roadmap_structure",
+    "validate_slice_registry",
+]

--- a/tests/test_roadmap_slice_registry.py
+++ b/tests/test_roadmap_slice_registry.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from spectrum_systems.modules.runtime.roadmap_slice_registry import (
+    RoadmapSliceRegistryError,
+    load_governed_slice_registry_artifacts,
+)
+
+
+_FIXTURE_ROOT = Path("contracts/roadmap")
+
+
+def test_valid_registry_and_structure_load_successfully() -> None:
+    slices, structure = load_governed_slice_registry_artifacts(
+        slice_registry_path=_FIXTURE_ROOT / "slice_registry.json",
+        roadmap_structure_path=_FIXTURE_ROOT / "roadmap_structure.json",
+    )
+
+    assert slices
+    assert structure["umbrellas"]
+
+
+def test_loader_returns_deterministic_ordering() -> None:
+    slices_a, structure_a = load_governed_slice_registry_artifacts(
+        slice_registry_path=_FIXTURE_ROOT / "slice_registry.json",
+        roadmap_structure_path=_FIXTURE_ROOT / "roadmap_structure.json",
+    )
+    slices_b, structure_b = load_governed_slice_registry_artifacts(
+        slice_registry_path=_FIXTURE_ROOT / "slice_registry.json",
+        roadmap_structure_path=_FIXTURE_ROOT / "roadmap_structure.json",
+    )
+
+    assert [row["slice_id"] for row in slices_a] == sorted(row["slice_id"] for row in slices_a)
+    assert slices_a == slices_b
+    assert structure_a == structure_b
+
+
+def test_orphan_slice_reference_fails(tmp_path: Path) -> None:
+    bad_structure = json.loads((_FIXTURE_ROOT / "roadmap_structure.json").read_text(encoding="utf-8"))
+    bad_structure["umbrellas"][0]["batches"][0]["slice_ids"].append("NOT-REAL-01")
+    structure_path = tmp_path / "roadmap_structure.json"
+    structure_path.write_text(json.dumps(bad_structure), encoding="utf-8")
+
+    with pytest.raises(RoadmapSliceRegistryError, match="unknown slice_id"):
+        load_governed_slice_registry_artifacts(
+            slice_registry_path=_FIXTURE_ROOT / "slice_registry.json",
+            roadmap_structure_path=structure_path,
+        )
+
+
+def test_duplicate_slice_id_fails(tmp_path: Path) -> None:
+    bad_registry = json.loads((_FIXTURE_ROOT / "slice_registry.json").read_text(encoding="utf-8"))
+    bad_registry["slices"].append(dict(bad_registry["slices"][0]))
+    registry_path = tmp_path / "slice_registry.json"
+    registry_path.write_text(json.dumps(bad_registry), encoding="utf-8")
+
+    with pytest.raises(RoadmapSliceRegistryError, match="duplicate slice_id"):
+        load_governed_slice_registry_artifacts(
+            slice_registry_path=registry_path,
+            roadmap_structure_path=_FIXTURE_ROOT / "roadmap_structure.json",
+        )
+
+
+def test_single_slice_batch_fails(tmp_path: Path) -> None:
+    bad_structure = json.loads((_FIXTURE_ROOT / "roadmap_structure.json").read_text(encoding="utf-8"))
+    bad_structure["umbrellas"][0]["batches"][0]["slice_ids"] = ["AEX-01"]
+    structure_path = tmp_path / "roadmap_structure.json"
+    structure_path.write_text(json.dumps(bad_structure), encoding="utf-8")
+
+    with pytest.raises(RoadmapSliceRegistryError, match="at least 2 slices"):
+        load_governed_slice_registry_artifacts(
+            slice_registry_path=_FIXTURE_ROOT / "slice_registry.json",
+            roadmap_structure_path=structure_path,
+        )
+
+
+def test_single_batch_umbrella_fails(tmp_path: Path) -> None:
+    bad_structure = json.loads((_FIXTURE_ROOT / "roadmap_structure.json").read_text(encoding="utf-8"))
+    bad_structure["umbrellas"][0]["batches"] = bad_structure["umbrellas"][0]["batches"][:1]
+    structure_path = tmp_path / "roadmap_structure.json"
+    structure_path.write_text(json.dumps(bad_structure), encoding="utf-8")
+
+    with pytest.raises(RoadmapSliceRegistryError, match="at least 2 batches"):
+        load_governed_slice_registry_artifacts(
+            slice_registry_path=_FIXTURE_ROOT / "slice_registry.json",
+            roadmap_structure_path=structure_path,
+        )
+
+
+def test_implementation_metadata_presence_is_enforced(tmp_path: Path) -> None:
+    bad_registry = json.loads((_FIXTURE_ROOT / "slice_registry.json").read_text(encoding="utf-8"))
+    bad_registry["slices"][0]["implementation_notes"] = ""
+    registry_path = tmp_path / "slice_registry.json"
+    registry_path.write_text(json.dumps(bad_registry), encoding="utf-8")
+
+    with pytest.raises(RoadmapSliceRegistryError, match="implementation_notes"):
+        load_governed_slice_registry_artifacts(
+            slice_registry_path=registry_path,
+            roadmap_structure_path=_FIXTURE_ROOT / "roadmap_structure.json",
+        )


### PR DESCRIPTION
### Motivation
- Provide a canonical, machine-readable Table 1 (slice registry) and Table 2 (execution structure) so roadmap-driven execution can be artifact-first and replayable without relying on prompt prose.
- Enforce fail-closed consistency checks so RDX sequencing and PQX execution only operate on well-formed, non-degenerate slices/batches/umbrellas.
- Surface implementation metadata and inferred provenance so future minimal-prompt execution and PQX/RDX consumers can inspect deterministic slice intent.

### Description
- Added `contracts/roadmap/slice_registry.json` containing 59 canonical slice records with required semantic and implementation fields and deterministic ordering by `slice_id`.
- Added `contracts/roadmap/roadmap_structure.json` expressing `umbrella -> batches -> slice_ids` and reservable slice gaps as the machine form of Table 2.
- Implemented `spectrum_systems/modules/runtime/roadmap_slice_registry.py` which provides thin loaders and fail-closed validators that enforce required per-slice metadata, duplicate `slice_id` detection, orphan references, duplicate placements, unmapped non-reserved slices, and batch/umbrella cardinality constraints (>=2 slices per batch, >=2 batches per umbrella).
- Added targeted tests `tests/test_roadmap_slice_registry.py` plus plan/review/delivery artifacts under `docs/review-actions/` and `docs/reviews/` to satisfy plan-first and review requirements.

### Testing
- Ran `pytest tests/test_execution_hierarchy.py tests/test_prompt_queue_execution_loop.py` and observed all tests pass (22 passed). 
- Ran `pytest tests/test_roadmap_slice_registry.py` and observed all targeted tests pass (7 passed).
- Executed `python scripts/run_contract_preflight.py` against the changed paths and observed the preflight tool blocked under the repo's governed PQX required-context policy (strategy gate decision: BLOCK).
- Executed `python scripts/run_review_artifact_validation.py` with narrow targets and observed the review-artifact validation flow was blocked by an environment npm install step (Ajv install failed) despite pytest replay passing locally; this is an environment/runtime artifact and not a functional test failure in the new loader/tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8e4eabc948329a324335b41b8396e)