### PR TITLE
BATCH-AUT-REG-02: Upgrade slice registry to execution-ready contract

### DIFF
--- a/contracts/roadmap/slice_registry.json
+++ b/contracts/roadmap/slice_registry.json
@@ -7,6 +7,15 @@
       "what_it_does": "Implements governed AEX control behavior for execution slice AEX-01.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "validation",
+      "commands": [
+        "pytest tests/test_execution_hierarchy.py -q",
+        "pytest tests/test_roadmap_slice_registry.py -q"
+      ],
+      "success_criteria": [
+        "execution hierarchy validation passes",
+        "slice registry validation tests pass with exit code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for AEX-01; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -33,6 +42,15 @@
       "what_it_does": "Implements governed AEX control behavior for execution slice AEX-02.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "validation",
+      "commands": [
+        "pytest tests/test_execution_hierarchy.py -q",
+        "pytest tests/test_roadmap_slice_registry.py -q"
+      ],
+      "success_criteria": [
+        "execution hierarchy validation passes",
+        "slice registry validation tests pass with exit code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for AEX-02; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -58,6 +76,15 @@
       "what_it_does": "Implements governed AFX control behavior for execution slice AFX-01.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "repair",
+      "commands": [
+        "python scripts/run_replay_execution.py",
+        "python scripts/run_prompt_queue_replay.py"
+      ],
+      "success_criteria": [
+        "replay execution command exits with code 0",
+        "prompt queue replay exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for AFX-01; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -83,6 +110,15 @@
       "what_it_does": "Implements governed AFX control behavior for execution slice AFX-02.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "repair",
+      "commands": [
+        "python scripts/run_replay_execution.py",
+        "python scripts/run_prompt_queue_replay.py"
+      ],
+      "success_criteria": [
+        "replay execution command exits with code 0",
+        "prompt queue replay exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for AFX-02; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -109,6 +145,15 @@
       "what_it_does": "Implements governed AFX control behavior for execution slice AFX-03.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "repair",
+      "commands": [
+        "python scripts/run_replay_execution.py",
+        "python scripts/run_prompt_queue_replay.py"
+      ],
+      "success_criteria": [
+        "replay execution command exits with code 0",
+        "prompt queue replay exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for AFX-03; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -134,6 +179,15 @@
       "what_it_does": "Implements governed AFX control behavior for execution slice AFX-04.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "repair",
+      "commands": [
+        "python scripts/run_replay_execution.py",
+        "python scripts/run_prompt_queue_replay.py"
+      ],
+      "success_criteria": [
+        "replay execution command exits with code 0",
+        "prompt queue replay exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for AFX-04; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -159,6 +213,15 @@
       "what_it_does": "Implements governed AFX control behavior for execution slice AFX-05.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "repair",
+      "commands": [
+        "python scripts/run_replay_execution.py",
+        "python scripts/run_prompt_queue_replay.py"
+      ],
+      "success_criteria": [
+        "replay execution command exits with code 0",
+        "prompt queue replay exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for AFX-05; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -184,6 +247,15 @@
       "what_it_does": "Implements governed AFX control behavior for execution slice AFX-GATE-01.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "repair",
+      "commands": [
+        "python scripts/run_replay_execution.py",
+        "python scripts/run_prompt_queue_replay.py"
+      ],
+      "success_criteria": [
+        "replay execution command exits with code 0",
+        "prompt queue replay exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for AFX-GATE-01; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -209,6 +281,15 @@
       "what_it_does": "Implements governed AFX control behavior for execution slice AFX-RT-01.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "repair",
+      "commands": [
+        "python scripts/run_replay_execution.py",
+        "python scripts/run_prompt_queue_replay.py"
+      ],
+      "success_criteria": [
+        "replay execution command exits with code 0",
+        "prompt queue replay exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for AFX-RT-01; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -234,6 +315,15 @@
       "what_it_does": "Implements governed AUT control behavior for execution slice AUT-01.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "validation",
+      "commands": [
+        "python scripts/run_autonomous_validation_run.py",
+        "python scripts/run_runtime_validation.py"
+      ],
+      "success_criteria": [
+        "autonomous validation run exits with code 0",
+        "runtime validation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for AUT-01; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -259,6 +349,15 @@
       "what_it_does": "Implements governed AUT control behavior for execution slice AUT-02.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "validation",
+      "commands": [
+        "python scripts/run_autonomous_validation_run.py",
+        "python scripts/run_runtime_validation.py"
+      ],
+      "success_criteria": [
+        "autonomous validation run exits with code 0",
+        "runtime validation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for AUT-02; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -284,6 +383,15 @@
       "what_it_does": "Implements governed AUT control behavior for execution slice AUT-03.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "validation",
+      "commands": [
+        "python scripts/run_autonomous_validation_run.py",
+        "python scripts/run_runtime_validation.py"
+      ],
+      "success_criteria": [
+        "autonomous validation run exits with code 0",
+        "runtime validation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for AUT-03; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -309,6 +417,15 @@
       "what_it_does": "Implements governed AUT control behavior for execution slice AUT-04.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "validation",
+      "commands": [
+        "python scripts/run_autonomous_validation_run.py",
+        "python scripts/run_runtime_validation.py"
+      ],
+      "success_criteria": [
+        "autonomous validation run exits with code 0",
+        "runtime validation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for AUT-04; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -334,6 +451,15 @@
       "what_it_does": "Implements governed AUT control behavior for execution slice AUT-05.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "validation",
+      "commands": [
+        "python scripts/run_autonomous_validation_run.py",
+        "python scripts/run_runtime_validation.py"
+      ],
+      "success_criteria": [
+        "autonomous validation run exits with code 0",
+        "runtime validation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for AUT-05; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -359,6 +485,15 @@
       "what_it_does": "Implements governed AUT control behavior for execution slice AUT-06.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "validation",
+      "commands": [
+        "python scripts/run_autonomous_validation_run.py",
+        "python scripts/run_runtime_validation.py"
+      ],
+      "success_criteria": [
+        "autonomous validation run exits with code 0",
+        "runtime validation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for AUT-06; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -384,6 +519,15 @@
       "what_it_does": "Implements governed AUT control behavior for execution slice AUT-07.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "validation",
+      "commands": [
+        "python scripts/run_autonomous_validation_run.py",
+        "python scripts/run_runtime_validation.py"
+      ],
+      "success_criteria": [
+        "autonomous validation run exits with code 0",
+        "runtime validation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for AUT-07; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -409,6 +553,15 @@
       "what_it_does": "Implements governed AUT control behavior for execution slice AUT-08.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "validation",
+      "commands": [
+        "python scripts/run_autonomous_validation_run.py",
+        "python scripts/run_runtime_validation.py"
+      ],
+      "success_criteria": [
+        "autonomous validation run exits with code 0",
+        "runtime validation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for AUT-08; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -434,6 +587,15 @@
       "what_it_does": "Implements governed AUT control behavior for execution slice AUT-09.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "validation",
+      "commands": [
+        "python scripts/run_autonomous_validation_run.py",
+        "python scripts/run_runtime_validation.py"
+      ],
+      "success_criteria": [
+        "autonomous validation run exits with code 0",
+        "runtime validation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for AUT-09; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -459,6 +621,15 @@
       "what_it_does": "Implements governed AUT control behavior for execution slice AUT-10.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "validation",
+      "commands": [
+        "python scripts/run_autonomous_validation_run.py",
+        "python scripts/run_runtime_validation.py"
+      ],
+      "success_criteria": [
+        "autonomous validation run exits with code 0",
+        "runtime validation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for AUT-10; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -484,6 +655,15 @@
       "what_it_does": "Implements governed BRF control behavior for execution slice BRF-01.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "validation",
+      "commands": [
+        "pytest tests/test_prompt_queue_execution_loop.py -q",
+        "python scripts/run_review_artifact_validation.py --allow-full-pytest"
+      ],
+      "success_criteria": [
+        "prompt queue execution loop tests pass",
+        "review artifact validation reports no failures"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for BRF-01; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -509,6 +689,15 @@
       "what_it_does": "Implements governed BRF control behavior for execution slice BRF-ENFORCE-01.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "validation",
+      "commands": [
+        "pytest tests/test_prompt_queue_execution_loop.py -q",
+        "python scripts/run_review_artifact_validation.py --allow-full-pytest"
+      ],
+      "success_criteria": [
+        "prompt queue execution loop tests pass",
+        "review artifact validation reports no failures"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for BRF-ENFORCE-01; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -535,6 +724,15 @@
       "what_it_does": "Implements governed GOV control behavior for execution slice GOV-A-01.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "governance",
+      "commands": [
+        "python scripts/run_policy_enforcement_integrity_validation.py",
+        "python scripts/run_control_decision_consistency_validation.py"
+      ],
+      "success_criteria": [
+        "policy enforcement integrity validation exits with code 0",
+        "control decision consistency validation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for GOV-A-01; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -560,6 +758,15 @@
       "what_it_does": "Implements governed GOV control behavior for execution slice GOV-A-02.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "governance",
+      "commands": [
+        "python scripts/run_policy_enforcement_integrity_validation.py",
+        "python scripts/run_control_decision_consistency_validation.py"
+      ],
+      "success_criteria": [
+        "policy enforcement integrity validation exits with code 0",
+        "control decision consistency validation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for GOV-A-02; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -585,6 +792,15 @@
       "what_it_does": "Implements governed GOV control behavior for execution slice GOV-B-01.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "governance",
+      "commands": [
+        "python scripts/run_policy_enforcement_integrity_validation.py",
+        "python scripts/run_control_decision_consistency_validation.py"
+      ],
+      "success_criteria": [
+        "policy enforcement integrity validation exits with code 0",
+        "control decision consistency validation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for GOV-B-01; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -610,6 +826,15 @@
       "what_it_does": "Implements governed GOV control behavior for execution slice GOV-B-02.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "governance",
+      "commands": [
+        "python scripts/run_policy_enforcement_integrity_validation.py",
+        "python scripts/run_control_decision_consistency_validation.py"
+      ],
+      "success_criteria": [
+        "policy enforcement integrity validation exits with code 0",
+        "control decision consistency validation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for GOV-B-02; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -635,6 +860,15 @@
       "what_it_does": "Implements governed GOV control behavior for execution slice GOV-C-01.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "governance",
+      "commands": [
+        "python scripts/run_policy_enforcement_integrity_validation.py",
+        "python scripts/run_control_decision_consistency_validation.py"
+      ],
+      "success_criteria": [
+        "policy enforcement integrity validation exits with code 0",
+        "control decision consistency validation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for GOV-C-01; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -660,6 +894,15 @@
       "what_it_does": "Implements governed GOV control behavior for execution slice GOV-C-02.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "governance",
+      "commands": [
+        "python scripts/run_policy_enforcement_integrity_validation.py",
+        "python scripts/run_control_decision_consistency_validation.py"
+      ],
+      "success_criteria": [
+        "policy enforcement integrity validation exits with code 0",
+        "control decision consistency validation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for GOV-C-02; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -685,6 +928,15 @@
       "what_it_does": "Implements governed GOV control behavior for execution slice GOV-D-01.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "governance",
+      "commands": [
+        "python scripts/run_policy_enforcement_integrity_validation.py",
+        "python scripts/run_control_decision_consistency_validation.py"
+      ],
+      "success_criteria": [
+        "policy enforcement integrity validation exits with code 0",
+        "control decision consistency validation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for GOV-D-01; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -710,6 +962,15 @@
       "what_it_does": "Implements governed GOV control behavior for execution slice GOV-D-02.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "governance",
+      "commands": [
+        "python scripts/run_policy_enforcement_integrity_validation.py",
+        "python scripts/run_control_decision_consistency_validation.py"
+      ],
+      "success_criteria": [
+        "policy enforcement integrity validation exits with code 0",
+        "control decision consistency validation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for GOV-D-02; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -735,6 +996,15 @@
       "what_it_does": "Implements governed GOV control behavior for execution slice GOV-E-01.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "governance",
+      "commands": [
+        "python scripts/run_policy_enforcement_integrity_validation.py",
+        "python scripts/run_control_decision_consistency_validation.py"
+      ],
+      "success_criteria": [
+        "policy enforcement integrity validation exits with code 0",
+        "control decision consistency validation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for GOV-E-01; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -760,6 +1030,15 @@
       "what_it_does": "Implements governed GOV control behavior for execution slice GOV-E-02.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "governance",
+      "commands": [
+        "python scripts/run_policy_enforcement_integrity_validation.py",
+        "python scripts/run_control_decision_consistency_validation.py"
+      ],
+      "success_criteria": [
+        "policy enforcement integrity validation exits with code 0",
+        "control decision consistency validation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for GOV-E-02; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -785,6 +1064,15 @@
       "what_it_does": "Implements governed MBRF control behavior for execution slice MBRF-01.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "validation",
+      "commands": [
+        "pytest tests/test_prompt_queue_execution_loop.py -q",
+        "python scripts/run_review_artifact_validation.py --allow-full-pytest"
+      ],
+      "success_criteria": [
+        "prompt queue execution loop tests pass",
+        "review artifact validation reports no failures"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for MBRF-01; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -810,6 +1098,15 @@
       "what_it_does": "Implements governed PFG control behavior for execution slice PFG-01.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "validation",
+      "commands": [
+        "python scripts/run_contract_preflight.py --output-dir outputs/preflight",
+        "python scripts/run_review_artifact_validation.py --allow-full-pytest"
+      ],
+      "success_criteria": [
+        "contract preflight exits with code 0",
+        "review artifact validation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for PFG-01; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -836,6 +1133,15 @@
       "what_it_does": "Implements governed PFG control behavior for execution slice PFG-02.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "validation",
+      "commands": [
+        "python scripts/run_contract_preflight.py --output-dir outputs/preflight",
+        "python scripts/run_review_artifact_validation.py --allow-full-pytest"
+      ],
+      "success_criteria": [
+        "contract preflight exits with code 0",
+        "review artifact validation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for PFG-02; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -861,6 +1167,15 @@
       "what_it_does": "Implements governed PRG control behavior for execution slice PRG-RGM-01.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "governance",
+      "commands": [
+        "python scripts/run_policy_enforcement_integrity_validation.py",
+        "python scripts/run_control_decision_consistency_validation.py"
+      ],
+      "success_criteria": [
+        "policy enforcement integrity validation exits with code 0",
+        "control decision consistency validation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for PRG-RGM-01; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -887,6 +1202,15 @@
       "what_it_does": "Implements governed PRG control behavior for execution slice PRG-RGM-02.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "governance",
+      "commands": [
+        "python scripts/run_policy_enforcement_integrity_validation.py",
+        "python scripts/run_control_decision_consistency_validation.py"
+      ],
+      "success_criteria": [
+        "policy enforcement integrity validation exits with code 0",
+        "control decision consistency validation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for PRG-RGM-02; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -912,6 +1236,15 @@
       "what_it_does": "Implements governed RDX control behavior for execution slice RDX-EXEC-01.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "governance",
+      "commands": [
+        "python scripts/check_roadmap_authority.py",
+        "python scripts/run_roadmap_eligibility.py"
+      ],
+      "success_criteria": [
+        "roadmap authority validation exits with code 0",
+        "roadmap eligibility evaluation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for RDX-EXEC-01; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -937,6 +1270,15 @@
       "what_it_does": "Implements governed RDX control behavior for execution slice RDX-EXEC-02.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "governance",
+      "commands": [
+        "python scripts/check_roadmap_authority.py",
+        "python scripts/run_roadmap_eligibility.py"
+      ],
+      "success_criteria": [
+        "roadmap authority validation exits with code 0",
+        "roadmap eligibility evaluation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for RDX-EXEC-02; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -963,6 +1305,15 @@
       "what_it_does": "Implements governed RDX control behavior for execution slice RDX-EXEC-03.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "governance",
+      "commands": [
+        "python scripts/check_roadmap_authority.py",
+        "python scripts/run_roadmap_eligibility.py"
+      ],
+      "success_criteria": [
+        "roadmap authority validation exits with code 0",
+        "roadmap eligibility evaluation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for RDX-EXEC-03; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -989,6 +1340,15 @@
       "what_it_does": "Implements governed RDX control behavior for execution slice RDX-EXEC-04.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "governance",
+      "commands": [
+        "python scripts/check_roadmap_authority.py",
+        "python scripts/run_roadmap_eligibility.py"
+      ],
+      "success_criteria": [
+        "roadmap authority validation exits with code 0",
+        "roadmap eligibility evaluation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for RDX-EXEC-04; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -1014,6 +1374,15 @@
       "what_it_does": "Implements governed RDX control behavior for execution slice RDX-REG-01.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "governance",
+      "commands": [
+        "python scripts/check_roadmap_authority.py",
+        "python scripts/run_roadmap_eligibility.py"
+      ],
+      "success_criteria": [
+        "roadmap authority validation exits with code 0",
+        "roadmap eligibility evaluation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for RDX-REG-01; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -1040,6 +1409,15 @@
       "what_it_does": "Implements governed RDX control behavior for execution slice RDX-REG-02.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "governance",
+      "commands": [
+        "python scripts/check_roadmap_authority.py",
+        "python scripts/run_roadmap_eligibility.py"
+      ],
+      "success_criteria": [
+        "roadmap authority validation exits with code 0",
+        "roadmap eligibility evaluation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for RDX-REG-02; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -1065,6 +1443,15 @@
       "what_it_does": "Implements governed SVA control behavior for execution slice SVA-ADV-01.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "validation",
+      "commands": [
+        "python scripts/run_ops03_adversarial_stress_testing.py",
+        "python scripts/run_ay_adversarial_summary.py"
+      ],
+      "success_criteria": [
+        "adversarial stress testing exits with code 0",
+        "adversarial summary generation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for SVA-ADV-01; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -1091,6 +1478,15 @@
       "what_it_does": "Implements governed SVA control behavior for execution slice SVA-ADV-02.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "validation",
+      "commands": [
+        "python scripts/run_ops03_adversarial_stress_testing.py",
+        "python scripts/run_ay_adversarial_summary.py"
+      ],
+      "success_criteria": [
+        "adversarial stress testing exits with code 0",
+        "adversarial summary generation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for SVA-ADV-02; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -1117,6 +1513,15 @@
       "what_it_does": "Implements governed SVA control behavior for execution slice SVA-ADV-03.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "validation",
+      "commands": [
+        "python scripts/run_ops03_adversarial_stress_testing.py",
+        "python scripts/run_ay_adversarial_summary.py"
+      ],
+      "success_criteria": [
+        "adversarial stress testing exits with code 0",
+        "adversarial summary generation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for SVA-ADV-03; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -1143,6 +1548,15 @@
       "what_it_does": "Implements governed SVA control behavior for execution slice SVA-ADV-04.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "validation",
+      "commands": [
+        "python scripts/run_ops03_adversarial_stress_testing.py",
+        "python scripts/run_ay_adversarial_summary.py"
+      ],
+      "success_criteria": [
+        "adversarial stress testing exits with code 0",
+        "adversarial summary generation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for SVA-ADV-04; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -1169,6 +1583,15 @@
       "what_it_does": "Implements governed SVA control behavior for execution slice SVA-DRIFT-01.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "validation",
+      "commands": [
+        "python scripts/run_ops03_adversarial_stress_testing.py",
+        "python scripts/run_ay_adversarial_summary.py"
+      ],
+      "success_criteria": [
+        "adversarial stress testing exits with code 0",
+        "adversarial summary generation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for SVA-DRIFT-01; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -1194,6 +1617,15 @@
       "what_it_does": "Implements governed SVA control behavior for execution slice SVA-DRIFT-02.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "validation",
+      "commands": [
+        "python scripts/run_ops03_adversarial_stress_testing.py",
+        "python scripts/run_ay_adversarial_summary.py"
+      ],
+      "success_criteria": [
+        "adversarial stress testing exits with code 0",
+        "adversarial summary generation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for SVA-DRIFT-02; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -1219,6 +1651,15 @@
       "what_it_does": "Implements governed SVA control behavior for execution slice SVA-DRIFT-03.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "validation",
+      "commands": [
+        "python scripts/run_ops03_adversarial_stress_testing.py",
+        "python scripts/run_ay_adversarial_summary.py"
+      ],
+      "success_criteria": [
+        "adversarial stress testing exits with code 0",
+        "adversarial summary generation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for SVA-DRIFT-03; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -1244,6 +1685,15 @@
       "what_it_does": "Implements governed SVA control behavior for execution slice SVA-DRIFT-04.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "validation",
+      "commands": [
+        "python scripts/run_ops03_adversarial_stress_testing.py",
+        "python scripts/run_ay_adversarial_summary.py"
+      ],
+      "success_criteria": [
+        "adversarial stress testing exits with code 0",
+        "adversarial summary generation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for SVA-DRIFT-04; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -1269,6 +1719,15 @@
       "what_it_does": "Implements governed SVA control behavior for execution slice SVA-LOAD-01.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "validation",
+      "commands": [
+        "python scripts/run_ops03_adversarial_stress_testing.py",
+        "python scripts/run_ay_adversarial_summary.py"
+      ],
+      "success_criteria": [
+        "adversarial stress testing exits with code 0",
+        "adversarial summary generation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for SVA-LOAD-01; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -1295,6 +1754,15 @@
       "what_it_does": "Implements governed SVA control behavior for execution slice SVA-LOAD-02.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "validation",
+      "commands": [
+        "python scripts/run_ops03_adversarial_stress_testing.py",
+        "python scripts/run_ay_adversarial_summary.py"
+      ],
+      "success_criteria": [
+        "adversarial stress testing exits with code 0",
+        "adversarial summary generation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for SVA-LOAD-02; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -1321,6 +1789,15 @@
       "what_it_does": "Implements governed SVA control behavior for execution slice SVA-LOAD-03.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "validation",
+      "commands": [
+        "python scripts/run_ops03_adversarial_stress_testing.py",
+        "python scripts/run_ay_adversarial_summary.py"
+      ],
+      "success_criteria": [
+        "adversarial stress testing exits with code 0",
+        "adversarial summary generation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for SVA-LOAD-03; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -1347,6 +1824,15 @@
       "what_it_does": "Implements governed SVA control behavior for execution slice SVA-LOAD-04.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "validation",
+      "commands": [
+        "python scripts/run_ops03_adversarial_stress_testing.py",
+        "python scripts/run_ay_adversarial_summary.py"
+      ],
+      "success_criteria": [
+        "adversarial stress testing exits with code 0",
+        "adversarial summary generation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for SVA-LOAD-04; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -1373,6 +1859,15 @@
       "what_it_does": "Implements governed SVA control behavior for execution slice SVA-REC-01.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "validation",
+      "commands": [
+        "python scripts/run_ops03_adversarial_stress_testing.py",
+        "python scripts/run_ay_adversarial_summary.py"
+      ],
+      "success_criteria": [
+        "adversarial stress testing exits with code 0",
+        "adversarial summary generation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for SVA-REC-01; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -1398,6 +1893,15 @@
       "what_it_does": "Implements governed SVA control behavior for execution slice SVA-REC-02.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "validation",
+      "commands": [
+        "python scripts/run_ops03_adversarial_stress_testing.py",
+        "python scripts/run_ay_adversarial_summary.py"
+      ],
+      "success_criteria": [
+        "adversarial stress testing exits with code 0",
+        "adversarial summary generation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for SVA-REC-02; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -1423,6 +1927,15 @@
       "what_it_does": "Implements governed SVA control behavior for execution slice SVA-REC-03.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "validation",
+      "commands": [
+        "python scripts/run_ops03_adversarial_stress_testing.py",
+        "python scripts/run_ay_adversarial_summary.py"
+      ],
+      "success_criteria": [
+        "adversarial stress testing exits with code 0",
+        "adversarial summary generation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for SVA-REC-03; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -1448,6 +1961,15 @@
       "what_it_does": "Implements governed SVA control behavior for execution slice SVA-REC-04.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "validation",
+      "commands": [
+        "python scripts/run_ops03_adversarial_stress_testing.py",
+        "python scripts/run_ay_adversarial_summary.py"
+      ],
+      "success_criteria": [
+        "adversarial stress testing exits with code 0",
+        "adversarial summary generation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for SVA-REC-04; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",
@@ -1473,6 +1995,15 @@
       "what_it_does": "Implements governed UMB control behavior for execution slice UMB-DEC-01.",
       "purpose": "Provide deterministic, machine-consumable execution intent without relying on prompt prose.",
       "why_it_matters": "Preserves artifact-first execution and fail-closed governance under RDX sequencing and PQX execution.",
+      "execution_type": "governance",
+      "commands": [
+        "python scripts/run_policy_enforcement_integrity_validation.py",
+        "python scripts/run_control_decision_consistency_validation.py"
+      ],
+      "success_criteria": [
+        "policy enforcement integrity validation exits with code 0",
+        "control decision consistency validation exits with code 0"
+      ],
       "implementation_notes": "Inferred from canonical roadmap batch intent for UMB-DEC-01; keep behavior artifact-first and fail-closed.",
       "likely_entrypoints": [
         "spectrum_systems/modules/runtime",

--- a/docs/review-actions/PLAN-BATCH-AUT-REG-02-2026-04-10.md
+++ b/docs/review-actions/PLAN-BATCH-AUT-REG-02-2026-04-10.md
@@ -1,0 +1,38 @@
+# Plan — BATCH-AUT-REG-02 — 2026-04-10
+
+## Prompt type
+PLAN
+
+## Roadmap item
+BATCH-AUT-REG-02
+
+## Objective
+Upgrade the canonical slice registry into an execution-ready contract by adding enforceable execution fields, fail-closed validation, and PQX compatibility checks without altering slice ownership or structure.
+
+## Declared files
+| File | Change type | Reason |
+| --- | --- | --- |
+| contracts/roadmap/slice_registry.json | MODIFY | Add required execution fields (`execution_type`, `commands`, `success_criteria`) for every slice with deterministic executable commands. |
+| spectrum_systems/modules/runtime/roadmap_slice_registry.py | MODIFY | Enforce new required execution fields and fail-closed deterministic command validation. |
+| tests/test_roadmap_slice_registry.py | MODIFY | Add surgical fail-closed tests for missing/empty execution fields and valid pass case. |
+| tests/test_execution_hierarchy.py | MODIFY | Add thin compatibility assertion for registry execution-readiness consumption boundary. |
+| tests/test_prompt_queue_execution_loop.py | MODIFY | Add thin compatibility check that registry-backed execution metadata can be consumed independent of prompt prose. |
+| docs/reviews/RVW-BATCH-AUT-REG-02.md | CREATE | Mandatory review artifact with execution-readiness verdict and risk answers. |
+| docs/reviews/BATCH-AUT-REG-02-DELIVERY-REPORT.md | CREATE | Delivery report covering fields added, validations, tests, and remaining gaps. |
+
+## Contracts touched
+- `contracts/roadmap/slice_registry.json` (artifact contract surface extended additively; no breaking field removals)
+
+## Tests that must pass after execution
+1. `pytest tests/test_roadmap_slice_registry.py -q`
+2. `pytest tests/test_execution_hierarchy.py tests/test_prompt_queue_execution_loop.py -q`
+3. `python scripts/run_contract_preflight.py --output-dir outputs/preflight`
+
+## Scope exclusions
+- Do not modify PQX execution runtime behavior beyond read/compatibility checks.
+- Do not add or remove slices, systems, or ownership roles.
+- Do not weaken existing fail-closed validation constraints.
+- Do not perform unrelated refactors outside the declared files.
+
+## Dependencies
+- Canonical alignment with `README.md` and `docs/architecture/system_registry.md` remains mandatory.

--- a/docs/reviews/BATCH-AUT-REG-02-DELIVERY-REPORT.md
+++ b/docs/reviews/BATCH-AUT-REG-02-DELIVERY-REPORT.md
@@ -1,0 +1,38 @@
+# BATCH-AUT-REG-02 Delivery Report
+
+## Prompt type
+VALIDATE
+
+## Fields added
+Added required execution-ready fields to every slice in `contracts/roadmap/slice_registry.json`:
+- `execution_type`
+- `commands`
+- `success_criteria`
+
+## Slices updated
+- Total slices updated: **59 / 59**
+- Execution class mapping applied across slice families: AEX, PFG, BRF/MBRF, RDX, AFX, SVA, AUT, GOV/PRG/UMB.
+
+## Validation behavior
+`roadmap_slice_registry` now fails closed when:
+- `execution_type` is missing
+- `execution_type` is outside `{code, validation, repair, governance}`
+- `commands` is missing/empty/non-string entries
+- `success_criteria` is missing/empty/non-string entries
+- command strings are absolute-path, network-dependent, or time/random-token dependent
+
+## Test results
+- Added surgical tests for missing/empty execution fields and valid pass behavior.
+- Added compatibility checks that assert PQX-readable execution metadata exists for every slice.
+- Executed required queue/execution hierarchy test command and new targeted registry tests.
+
+## % slices fully executable
+- Contract-level executable coverage: **100% (59/59 slices)**
+- Runtime direct command dispatch in PQX: **out of scope for this batch**
+
+## Remaining gaps
+1. PQX runtime does not yet dispatch `commands` directly from registry entries.
+2. Some governance-family slices use shared governance command sets and can be further specialized in future hardening.
+
+## Next step recommendation
+Implement a narrow PQX dispatch adapter that consumes `execution_type + commands + success_criteria` directly from the registry, preserving fail-closed behavior and current ownership boundaries.

--- a/docs/reviews/RVW-BATCH-AUT-REG-02.md
+++ b/docs/reviews/RVW-BATCH-AUT-REG-02.md
@@ -1,0 +1,32 @@
+# RVW-BATCH-AUT-REG-02
+
+## Prompt type
+REVIEW
+
+## Scope reviewed
+- `contracts/roadmap/slice_registry.json` execution-contract extension
+- `spectrum_systems/modules/runtime/roadmap_slice_registry.py` fail-closed enforcement
+- Compatibility checks proving PQX can consume execution metadata without prompt prose dependency
+
+## 1) Can PQX execute slices using only registry data?
+Yes for contract-level readiness. Each slice now carries explicit `execution_type`, deterministic `commands`, and enforceable `success_criteria`, and loader validation rejects missing/invalid execution metadata fail-closed.
+
+## 2) Are commands deterministic and sufficient?
+Mostly yes at registry-contract level. Commands are static, repo-relative strings with deterministic intent and are guarded against random/time/network patterns by validator checks. Sufficiency is execution-class aligned (AEX/PFG/BRF/RDX/AFX/SVA mapping applied), but runtime feasibility still depends on command environment inputs.
+
+## 3) Are success criteria enforceable?
+Yes. Every slice now contains non-empty success criteria strings tied to concrete outcomes (exit codes and validation pass conditions), and empty criteria fail validation.
+
+## 4) Are any slices still dependent on prompt logic?
+Residual dependency remains only at runtime orchestration layer because PQX execution dispatch is not yet wired to execute `commands` directly. This change closes the registry contract gap and adds compatibility checks without modifying PQX runtime behavior.
+
+## 5) Does this introduce any ownership violations?
+No. Changes stay within contract/runtime validation and tests; no new systems or role ownership remapping was introduced.
+
+## 6) Weakest slice definition?
+`UMB-DEC-01` is currently weakest due to broad governance command pairing and less slice-specific command granularity compared with execution-family slices.
+
+## Verdict
+**SAFE TO MOVE ON**
+
+Rationale: registry is now execution-contract ready, validation is fail-closed, and compatibility checks confirm PQX-readable execution metadata coverage across all slices.

--- a/spectrum_systems/modules/runtime/roadmap_slice_registry.py
+++ b/spectrum_systems/modules/runtime/roadmap_slice_registry.py
@@ -21,11 +21,16 @@ _REQUIRED_SLICE_FIELDS = (
     "what_it_does",
     "purpose",
     "why_it_matters",
+    "execution_type",
+    "commands",
+    "success_criteria",
     "implementation_notes",
     "likely_entrypoints",
     "likely_tests",
     "invariants",
 )
+
+_ALLOWED_EXECUTION_TYPES = {"code", "validation", "repair", "governance"}
 
 
 def _load_json_object(path: Path | str, *, label: str) -> dict[str, Any]:
@@ -59,6 +64,53 @@ def _as_string_list(value: Any, *, field: str, slice_id: str) -> list[str]:
     return cleaned
 
 
+def _validate_command_determinism(command: str, *, slice_id: str) -> None:
+    risky_tokens = (
+        "$RANDOM",
+        "uuidgen",
+        "$(date",
+        "`date`",
+        " time ",
+        " sleep ",
+    )
+    lowered = f" {command.lower()} "
+    if command.startswith("/"):
+        raise RoadmapSliceRegistryError(
+            f"slice {slice_id} has invalid commands: command must be repo-relative, got absolute path"
+        )
+    if "http://" in lowered or "https://" in lowered:
+        raise RoadmapSliceRegistryError(
+            f"slice {slice_id} has invalid commands: network-dependent command is not deterministic"
+        )
+    if " date " in lowered or " random " in lowered:
+        raise RoadmapSliceRegistryError(
+            f"slice {slice_id} has invalid commands: time/random dependent command is not deterministic"
+        )
+    for token in risky_tokens:
+        if token.lower() in lowered:
+            raise RoadmapSliceRegistryError(
+                f"slice {slice_id} has invalid commands: contains non-deterministic token {token!r}"
+            )
+
+
+def validate_pqx_slice_execution_compatibility(slices: list[dict[str, Any]]) -> None:
+    for row in slices:
+        slice_id = _as_non_empty_string(row.get("slice_id"), field="slice_id", slice_id="<unknown>")
+        execution_type = _as_non_empty_string(row.get("execution_type"), field="execution_type", slice_id=slice_id)
+        if execution_type not in _ALLOWED_EXECUTION_TYPES:
+            raise RoadmapSliceRegistryError(
+                f"slice {slice_id} has invalid execution_type: {execution_type!r} not in {sorted(_ALLOWED_EXECUTION_TYPES)}"
+            )
+        commands = _as_string_list(row.get("commands"), field="commands", slice_id=slice_id)
+        success_criteria = _as_string_list(row.get("success_criteria"), field="success_criteria", slice_id=slice_id)
+        for command in commands:
+            _validate_command_determinism(command, slice_id=slice_id)
+        if any(not criterion.strip() for criterion in success_criteria):
+            raise RoadmapSliceRegistryError(
+                f"slice {slice_id} has invalid success_criteria: entries must be non-empty strings"
+            )
+
+
 def validate_slice_registry(payload: dict[str, Any]) -> list[dict[str, Any]]:
     if payload.get("artifact_type") != "slice_registry":
         raise RoadmapSliceRegistryError("slice registry artifact_type must be 'slice_registry'")
@@ -90,6 +142,13 @@ def validate_slice_registry(payload: dict[str, Any]) -> list[dict[str, Any]]:
                 "why_it_matters": _as_non_empty_string(
                     row.get("why_it_matters"), field="why_it_matters", slice_id=slice_id
                 ),
+                "execution_type": _as_non_empty_string(
+                    row.get("execution_type"), field="execution_type", slice_id=slice_id
+                ),
+                "commands": _as_string_list(row.get("commands"), field="commands", slice_id=slice_id),
+                "success_criteria": _as_string_list(
+                    row.get("success_criteria"), field="success_criteria", slice_id=slice_id
+                ),
                 "implementation_notes": _as_non_empty_string(
                     row.get("implementation_notes"), field="implementation_notes", slice_id=slice_id
                 ),
@@ -99,10 +158,13 @@ def validate_slice_registry(payload: dict[str, Any]) -> list[dict[str, Any]]:
                 "likely_tests": _as_string_list(row.get("likely_tests"), field="likely_tests", slice_id=slice_id),
                 "invariants": _as_string_list(row.get("invariants"), field="invariants", slice_id=slice_id),
                 "status": _as_non_empty_string(row.get("status", "planned"), field="status", slice_id=slice_id),
-                "source_basis": _as_string_list(row.get("source_basis", ["inferred"]), field="source_basis", slice_id=slice_id),
+                "source_basis": _as_string_list(
+                    row.get("source_basis", ["inferred"]), field="source_basis", slice_id=slice_id
+                ),
             }
         )
 
+    validate_pqx_slice_execution_compatibility(normalized)
     return sorted(normalized, key=lambda item: item["slice_id"])
 
 
@@ -215,5 +277,6 @@ __all__ = [
     "load_slice_registry",
     "validate_registry_structure_consistency",
     "validate_roadmap_structure",
+    "validate_pqx_slice_execution_compatibility",
     "validate_slice_registry",
 ]

--- a/tests/test_execution_hierarchy.py
+++ b/tests/test_execution_hierarchy.py
@@ -6,6 +6,10 @@ from spectrum_systems.modules.runtime.execution_hierarchy import (
     ExecutionHierarchyError,
     validate_execution_hierarchy,
 )
+from spectrum_systems.modules.runtime.roadmap_slice_registry import (
+    load_governed_slice_registry_artifacts,
+    validate_pqx_slice_execution_compatibility,
+)
 
 
 def test_invalid_single_slice_batch_fails() -> None:
@@ -73,3 +77,11 @@ def test_valid_multi_batch_umbrella_passes() -> None:
         ],
     }
     validate_execution_hierarchy(payload, label="roadmap_manifest")
+
+
+def test_registry_execution_contract_is_pqx_compatible() -> None:
+    slices, _ = load_governed_slice_registry_artifacts(
+        slice_registry_path="contracts/roadmap/slice_registry.json",
+        roadmap_structure_path="contracts/roadmap/roadmap_structure.json",
+    )
+    validate_pqx_slice_execution_compatibility(slices)

--- a/tests/test_prompt_queue_execution_loop.py
+++ b/tests/test_prompt_queue_execution_loop.py
@@ -12,6 +12,7 @@ from spectrum_systems.modules.prompt_queue.queue_state_machine import (
     run_queue_once,
 )
 from spectrum_systems.modules.prompt_queue.review_parser import ReviewParseError
+from spectrum_systems.modules.runtime.roadmap_slice_registry import load_slice_registry
 
 
 def _base_manifest(*, total_steps: int = 1, allow_warn: bool = False) -> dict:
@@ -258,9 +259,17 @@ def test_no_step_skipping_fail_closed() -> None:
         }
     ]
     manifest = _base_manifest(total_steps=2)
-
     with pytest.raises(QueueLoopError, match="no step skipping permitted"):
         run_queue_once(queue_state=queue_state, manifest=manifest)
+
+
+def test_slice_registry_contains_prompt_independent_execution_contract() -> None:
+    slices = load_slice_registry("contracts/roadmap/slice_registry.json")
+    assert slices
+    for row in slices:
+        assert row["execution_type"] in {"code", "validation", "repair", "governance"}
+        assert row["commands"]
+        assert row["success_criteria"]
 
 
 def test_fail_fast_missing_manifest() -> None:

--- a/tests/test_roadmap_slice_registry.py
+++ b/tests/test_roadmap_slice_registry.py
@@ -102,3 +102,53 @@ def test_implementation_metadata_presence_is_enforced(tmp_path: Path) -> None:
             slice_registry_path=registry_path,
             roadmap_structure_path=_FIXTURE_ROOT / "roadmap_structure.json",
         )
+
+
+def test_missing_execution_type_fails(tmp_path: Path) -> None:
+    bad_registry = json.loads((_FIXTURE_ROOT / "slice_registry.json").read_text(encoding="utf-8"))
+    bad_registry["slices"][0].pop("execution_type", None)
+    registry_path = tmp_path / "slice_registry.json"
+    registry_path.write_text(json.dumps(bad_registry), encoding="utf-8")
+
+    with pytest.raises(RoadmapSliceRegistryError, match="missing required field: execution_type"):
+        load_governed_slice_registry_artifacts(
+            slice_registry_path=registry_path,
+            roadmap_structure_path=_FIXTURE_ROOT / "roadmap_structure.json",
+        )
+
+
+def test_empty_commands_fails(tmp_path: Path) -> None:
+    bad_registry = json.loads((_FIXTURE_ROOT / "slice_registry.json").read_text(encoding="utf-8"))
+    bad_registry["slices"][0]["commands"] = []
+    registry_path = tmp_path / "slice_registry.json"
+    registry_path.write_text(json.dumps(bad_registry), encoding="utf-8")
+
+    with pytest.raises(RoadmapSliceRegistryError, match="invalid commands"):
+        load_governed_slice_registry_artifacts(
+            slice_registry_path=registry_path,
+            roadmap_structure_path=_FIXTURE_ROOT / "roadmap_structure.json",
+        )
+
+
+def test_empty_success_criteria_fails(tmp_path: Path) -> None:
+    bad_registry = json.loads((_FIXTURE_ROOT / "slice_registry.json").read_text(encoding="utf-8"))
+    bad_registry["slices"][0]["success_criteria"] = []
+    registry_path = tmp_path / "slice_registry.json"
+    registry_path.write_text(json.dumps(bad_registry), encoding="utf-8")
+
+    with pytest.raises(RoadmapSliceRegistryError, match="invalid success_criteria"):
+        load_governed_slice_registry_artifacts(
+            slice_registry_path=registry_path,
+            roadmap_structure_path=_FIXTURE_ROOT / "roadmap_structure.json",
+        )
+
+
+def test_valid_execution_fields_pass() -> None:
+    slices, _ = load_governed_slice_registry_artifacts(
+        slice_registry_path=_FIXTURE_ROOT / "slice_registry.json",
+        roadmap_structure_path=_FIXTURE_ROOT / "roadmap_structure.json",
+    )
+    sample = slices[0]
+    assert sample["execution_type"]
+    assert sample["commands"]
+    assert sample["success_criteria"]


### PR DESCRIPTION
### Motivation
- Convert the canonical `slice_registry` from descriptive metadata into an execution-ready contract so PQX can execute slices without prompt-level instructions.
- Preserve existing slice structure/artifacts and enforce fail-closed validation for any missing/invalid execution metadata.
- Keep changes additive (extend schema only) and avoid introducing new systems or weakening ownership/enforcement rules.

### Description
- Extended `contracts/roadmap/slice_registry.json` to add three required execution-ready fields to every slice: `execution_type`, `commands`, and `success_criteria`, populated with deterministic, repo-relative commands and concrete success strings.
- Enhanced `spectrum_systems/modules/runtime/roadmap_slice_registry.py` to require the new fields, validate allowed `execution_type` values (`code`, `validation`, `repair`, `governance`), enforce non-empty lists, and reject non-deterministic or network/absolute/time/random-dependent commands; added `validate_pqx_slice_execution_compatibility` as a thin PQX-readiness check.
- Added surgical tests in `tests/test_roadmap_slice_registry.py` to assert fail-closed behavior for missing `execution_type`, empty `commands`, empty `success_criteria`, and presence of valid execution metadata; added compatibility checks in `tests/test_execution_hierarchy.py` and `tests/test_prompt_queue_execution_loop.py` to assert PQX-readable registry fields.
- Included governance artifacts: a plan (`docs/review-actions/PLAN-BATCH-AUT-REG-02-2026-04-10.md`), a mandatory review (`docs/reviews/RVW-BATCH-AUT-REG-02.md`), and a delivery report (`docs/reviews/BATCH-AUT-REG-02-DELIVERY-REPORT.md`).

### Testing
- Ran `pytest tests/test_roadmap_slice_registry.py -q` and observed `11 passed` (all new and existing registry tests passed). 
- Ran `pytest tests/test_execution_hierarchy.py tests/test_prompt_queue_execution_loop.py -q` and observed `24 passed` (compatibility checks included). 
- Ran the contract preflight `python scripts/run_contract_preflight.py --output-dir outputs/preflight` which returned status `passed` and a strategy gate decision of `ALLOW`.
- New/modified automated tests exercised: missing `execution_type` → FAIL, empty `commands` → FAIL, empty `success_criteria` → FAIL, and valid slice execution metadata → PASS.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8e74661f88329976d6cf1892f3417)