### PR TITLE
Add BATCH-AUT-RUN-01 governed execution review & delivery reports

### DIFF
--- a/docs/reviews/BATCH-AUT-RUN-01-DELIVERY-REPORT.md
+++ b/docs/reviews/BATCH-AUT-RUN-01-DELIVERY-REPORT.md
@@ -1,0 +1,38 @@
+# BATCH-AUT-RUN-01 — DELIVERY REPORT
+
+Date: 2026-04-10
+
+## Umbrellas executed
+- `AUTONOMY_EXECUTION` (partial; blocked before completion)
+
+## Batches executed
+- `BATCH-AEX` (completed)
+- `BATCH-AUT` (blocked)
+
+## Slices executed
+- Successful: `AEX-01`, `AEX-02`, `AUT-01`, `AUT-02`, `AUT-03`, `AUT-04`
+- Failed: `AUT-05`
+
+## Failures encountered
+- `AUT-05` command failed:
+  - `python -c "import json; from spectrum_systems.modules.runtime.review_roadmap_generator import build_review_roadmap; snapshot=json.load(open('tests/fixtures/roadmaps/aut_reg_05a/repo_review_snapshot.json')); decision=json.load(open('tests/fixtures/roadmaps/aut_reg_05a/review_control_signal.json')); build_review_roadmap(snapshot=snapshot, control_decision=decision)"`
+- Failure reason: `ReviewRoadmapGeneratorError: control_decision.system_response must be a non-empty string`
+
+## Repair loops triggered
+- Failure path was identified and progression was blocked fail-closed.
+- Full repair-loop execution (`RQX → RIL → FRE → CDE → TPA → PQX`) was **not completed** in this run artifact.
+
+## Enforcement actions
+- SEL-style fail-closed blocking occurred at `AUT-05` after command failure.
+- Batch progression was blocked (`BATCH-AUT` decision: block).
+- Umbrella progression was blocked (`AUTONOMY_EXECUTION` decision: block).
+
+## Final execution status
+- **Status:** `blocked_fail_closed`
+- Executed umbrellas: `1`
+- Executed batches: `2`
+- Executed slices: `7`
+- Failures: `1`
+
+## Conclusion
+Artifact-driven routing and fail-closed blocking are functioning for the executed span, but full governed roadmap execution is not complete and cannot be promoted as end-to-end successful in this pass.

--- a/docs/reviews/RVW-BATCH-AUT-RUN-01.md
+++ b/docs/reviews/RVW-BATCH-AUT-RUN-01.md
@@ -1,0 +1,45 @@
+# RVW-BATCH-AUT-RUN-01
+
+Date: 2026-04-10  
+Reviewer role: RQX (governance review artifact)  
+Scope: First full artifact-driven roadmap execution pass (no prompt logic)
+
+## Evidence reviewed
+- `contracts/roadmap/slice_registry.json`
+- `contracts/roadmap/roadmap_structure.json`
+- Runtime trace captured from governed execution pass at `/tmp/BATCH-AUT-RUN-01.json`
+
+## Execution summary
+- Execution sequencing was retrieved from `roadmap_structure` and command behavior from `slice_registry`.
+- The run proceeded through `AUTONOMY_EXECUTION` → `BATCH-AEX` then into `BATCH-AUT`.
+- Slices executed successfully through `AUT-04`.
+- `AUT-05` failed fail-closed on missing required `control_decision.system_response` content in the fixture used by the registered command.
+- Progression was blocked at batch and umbrella levels after the failure.
+
+## Required answers
+
+1. **Did execution rely only on `slice_registry` + `roadmap_structure`?**  
+   **Yes.** Selection order came from `roadmap_structure`, and executed commands came directly from `slice_registry`.
+
+2. **Were any slices still effectively prompt-driven?**  
+   **No in this run path.** Executed slices (`AEX-01`, `AEX-02`, `AUT-01`..`AUT-05`) were driven by registered command metadata, not prompt-injected instructions.
+
+3. **Did repair loops behave correctly?**  
+   **Partially.** Failure was detected and blocked fail-closed as expected, but a full governed repair-loop execution chain (`RQX → RIL → FRE → CDE → TPA → PQX`) was not completed in this pass because execution halted at first blocked slice.
+
+4. **Were any boundaries violated?**  
+   **No boundary violations were observed in this pass.** Execution remained command-driven, and failure produced progression blocking rather than implicit continuation.
+
+5. **Where did execution feel weakest?**  
+   `AUT-05` command/fixture compatibility is weak: the registered command expects a valid `control_decision.system_response` field, but the current fixture path resolves to empty/invalid input and trips fail-closed logic.
+
+6. **Did any slice behave as proxy instead of real execution?**  
+   **No in executed scope.** Each executed slice ran real commands (Python runtime calls and pytest checks), not placeholder no-op commands.
+
+7. **Can we trust this execution end-to-end?**  
+   **Not yet.** Trust is partial for early-path behavior (AEX and initial AUT slices), but not end-to-end because the roadmap halted at `AUT-05` before later umbrellas and repair-loop completion evidence.
+
+## Verdict
+**NOT TRUSTABLE**
+
+The system is artifact-driven and fail-closed in the executed path, but the full roadmap cannot be trusted end-to-end until `AUT-05` inputs are corrected and full progression/repair coverage is completed.


### PR DESCRIPTION
### Motivation
- Prove the roadmap can be executed using only `slice_registry` (execution commands) and `roadmap_structure` (sequencing) with no prompt-level execution logic.  
- Validate fail-closed behavior, repair-loop gating, and enforcement boundaries for the AEX→TLC→TPA→PQX→RQX→RIL→FRE→CDE flow.  
- Produce the mandatory review and delivery artifacts required by the governed run-plan so the outcome and next steps are auditable.  

### Description
- Add `docs/reviews/RVW-BATCH-AUT-RUN-01.md` containing the review Q/A, execution summary, observed weaknesses, and the verdict `NOT TRUSTABLE`.  
- Add `docs/reviews/BATCH-AUT-RUN-01-DELIVERY-REPORT.md` containing umbrellas/batches/slices executed, failure details, enforcement actions, repair-loop notes, and final `blocked_fail_closed` status.  
- The reports record that sequencing came from `contracts/roadmap/roadmap_structure.json` and execution commands came from `contracts/roadmap/slice_registry.json`, and that SEL blocked progression after a failing slice (`AUT-05`); a runtime trace was captured during the run (`/tmp/BATCH-AUT-RUN-01.json`).  

### Testing
- Ran an inline artifact-driven execution harness using `load_governed_slice_registry_artifacts(...)` with `SPECTRUM_LINEAGE_AUTH_SECRET_*` environment secrets set, which executed slice-registered commands and produced a `blocked_fail_closed` run with 7 executed slices and 1 failure (slice `AUT-05`).  
- Individual slice commands executed their embedded test invocations (pytest/python commands) as part of the run and produced per-slice exit codes and stdout/stderr captured in the trace.  
- Attempted to validate the generated review artifacts with `python scripts/run_review_artifact_validation.py`, but the full validator failed in this environment due to external `npm` package install/network restrictions and the validator requiring explicit `--allow-full-pytest`/targets flags, so the review-validator step did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8fea0d3308329a10766d380e87870)