### PR TITLE
GRC-FOUNDATION: add governed readiness, failure packetization, and bounded repair inputs

### DIFF
--- a/contracts/examples/artifact_readiness_result.json
+++ b/contracts/examples/artifact_readiness_result.json
@@ -1,0 +1,34 @@
+{
+  "artifact_type": "artifact_readiness_result",
+  "schema_version": "1.0.0",
+  "readiness_id": "arr-8d64317d467cc920",
+  "slice_id": "AUT-05",
+  "owning_system": "RIL",
+  "runtime_seam": "review_control_decision_projection",
+  "status": "blocked",
+  "blocking_reasons": [
+    {
+      "failure_class": "invalid_artifact_shape",
+      "reason": "schema validation failed for tests/fixtures/roadmaps/aut_reg_05a/review_control_signal.json: 'system_response' is a required property",
+      "artifact_refs": [
+        "tests/fixtures/roadmaps/aut_reg_05a/review_control_signal.json"
+      ],
+      "invariant_refs": [
+        "control_decision_shape"
+      ]
+    }
+  ],
+  "checked_artifact_refs": [
+    "tests/fixtures/roadmaps/aut_reg_05a/repo_review_snapshot.json",
+    "tests/fixtures/roadmaps/aut_reg_05a/review_control_signal.json"
+  ],
+  "contract_invariant_refs": [
+    "control_decision_shape",
+    "control_decision_payload_nested"
+  ],
+  "expected_failure_classes": [
+    "missing_artifact",
+    "invalid_artifact_shape",
+    "slice_contract_mismatch"
+  ]
+}

--- a/contracts/examples/bounded_repair_candidate_artifact.json
+++ b/contracts/examples/bounded_repair_candidate_artifact.json
@@ -1,0 +1,21 @@
+{
+  "artifact_type": "bounded_repair_candidate_artifact",
+  "schema_version": "1.0.0",
+  "candidate_id": "brc-3ba6433dd60d65f6",
+  "failure_packet_ref": "execution_failure_packet:efp-f7fdb3f3746f877c",
+  "failing_slice_ref": "slice:AUT-07",
+  "repairability_class": "artifact_only",
+  "minimal_repair_scope": [
+    "contracts/examples/build_admission_record.example.json",
+    "contracts/examples/normalized_execution_request.example.json",
+    "contracts/examples/tlc_handoff_record.example.json"
+  ],
+  "touched_artifact_intent": [
+    "contracts/examples/build_admission_record.example.json",
+    "contracts/examples/normalized_execution_request.example.json",
+    "contracts/examples/tlc_handoff_record.example.json"
+  ],
+  "bounded_rationale": "Classified authenticity_lineage_mismatch from canonical failure packet.",
+  "recurrence_prevention_note": "Preserve artifact-first validation and prevent recurrence by enforcing readiness invariants.",
+  "explicit_no_go": null
+}

--- a/contracts/examples/cde_repair_continuation_input.json
+++ b/contracts/examples/cde_repair_continuation_input.json
@@ -1,0 +1,16 @@
+{
+  "artifact_type": "cde_repair_continuation_input",
+  "schema_version": "1.0.0",
+  "continuation_input_id": "cri-5f604b8644e6f4db",
+  "failure_packet_ref": "execution_failure_packet:efp-f7fdb3f3746f877c",
+  "repair_candidate_ref": "bounded_repair_candidate_artifact:brc-3ba6433dd60d65f6",
+  "failing_slice_ref": "slice:AUT-07",
+  "repairability_class": "artifact_only",
+  "recommended_continuation": "continue_repair_bounded",
+  "evidence_refs": [
+    "slice_execution:AUT-07",
+    "trace:aut-07-2026-04-10",
+    "system_enforcement_result_artifact:sel-001",
+    "pytest_failure:tests/test_repo_write_lineage_guard.py::test_authenticity_mismatch"
+  ]
+}

--- a/contracts/examples/execution_failure_packet.json
+++ b/contracts/examples/execution_failure_packet.json
@@ -1,0 +1,30 @@
+{
+  "artifact_type": "execution_failure_packet",
+  "schema_version": "1.0.0",
+  "failure_packet_id": "efp-f7fdb3f3746f877c",
+  "slice_id": "AUT-07",
+  "batch_id": "BATCH-AUT",
+  "umbrella_id": "AUTONOMY_EXECUTION",
+  "roadmap_context_ref": "contracts/roadmap/roadmap_structure.json",
+  "readiness_ref": "artifact_readiness_result:arr-8d64317d467cc920",
+  "execution_refs": [
+    "slice_execution:AUT-07"
+  ],
+  "trace_refs": [
+    "trace:aut-07-2026-04-10"
+  ],
+  "enforcement_refs": [
+    "system_enforcement_result_artifact:sel-001"
+  ],
+  "validation_refs": [
+    "pytest_failure:tests/test_repo_write_lineage_guard.py::test_authenticity_mismatch"
+  ],
+  "classified_failure_type": "authenticity_lineage_mismatch",
+  "explanation": "authenticity verification failed for contracts/examples/build_admission_record.example.json",
+  "affected_artifact_refs": [
+    "contracts/examples/build_admission_record.example.json",
+    "contracts/examples/normalized_execution_request.example.json",
+    "contracts/examples/tlc_handoff_record.example.json"
+  ],
+  "repairability_hint": "artifact_only"
+}

--- a/contracts/examples/tpa_repair_gating_input.json
+++ b/contracts/examples/tpa_repair_gating_input.json
@@ -1,0 +1,20 @@
+{
+  "artifact_type": "tpa_repair_gating_input",
+  "schema_version": "1.0.0",
+  "gating_input_id": "rgi-0aa4f0d83a16fc84",
+  "failure_packet_ref": "execution_failure_packet:efp-f7fdb3f3746f877c",
+  "repair_candidate_ref": "bounded_repair_candidate_artifact:brc-3ba6433dd60d65f6",
+  "repair_scope_refs": [
+    "contracts/examples/build_admission_record.example.json",
+    "contracts/examples/normalized_execution_request.example.json",
+    "contracts/examples/tlc_handoff_record.example.json"
+  ],
+  "complexity_score": 2,
+  "risk_level": "low",
+  "retry_budget_remaining": 1,
+  "allowed_artifact_refs": [
+    "contracts/examples/build_admission_record.example.json",
+    "contracts/examples/normalized_execution_request.example.json",
+    "contracts/examples/tlc_handoff_record.example.json"
+  ]
+}

--- a/contracts/roadmap/slice_registry.json
+++ b/contracts/roadmap/slice_registry.json
@@ -478,7 +478,25 @@
       "source_basis": [
         "roadmap",
         "inferred"
-      ]
+      ],
+      "failure_surface": {
+        "owning_system": "RIL",
+        "runtime_seam": "review_control_decision_projection",
+        "required_artifacts": [
+          "tests/fixtures/roadmaps/aut_reg_05a/repo_review_snapshot.json",
+          "tests/fixtures/roadmaps/aut_reg_05a/review_control_signal.json"
+        ],
+        "contract_invariants": [
+          "control_decision_shape",
+          "control_decision_payload_nested"
+        ],
+        "expected_failure_classes": [
+          "missing_artifact",
+          "invalid_artifact_shape",
+          "slice_contract_mismatch"
+        ],
+        "repairability_class": "artifact_only"
+      }
     },
     {
       "slice_id": "AUT-06",
@@ -546,7 +564,27 @@
       "source_basis": [
         "roadmap",
         "inferred"
-      ]
+      ],
+      "failure_surface": {
+        "owning_system": "TPA",
+        "runtime_seam": "repo_write_lineage_authenticity_guard",
+        "required_artifacts": [
+          "contracts/examples/build_admission_record.example.json",
+          "contracts/examples/normalized_execution_request.example.json",
+          "contracts/examples/tlc_handoff_record.example.json"
+        ],
+        "contract_invariants": [
+          "lineage_authenticity",
+          "lineage_trace_alignment"
+        ],
+        "expected_failure_classes": [
+          "missing_artifact",
+          "invalid_artifact_shape",
+          "cross_artifact_mismatch",
+          "authenticity_lineage_mismatch"
+        ],
+        "repairability_class": "artifact_only"
+      }
     },
     {
       "slice_id": "AUT-08",
@@ -648,7 +686,26 @@
       "source_basis": [
         "roadmap",
         "inferred"
-      ]
+      ],
+      "failure_surface": {
+        "owning_system": "RIL",
+        "runtime_seam": "review_control_decision_command_wiring",
+        "required_artifacts": [
+          "tests/fixtures/roadmaps/aut_reg_05a/repo_review_snapshot.json",
+          "tests/fixtures/roadmaps/aut_reg_05a/review_control_signal.json"
+        ],
+        "contract_invariants": [
+          "control_decision_shape",
+          "control_decision_payload_nested",
+          "program_artifact_presence"
+        ],
+        "expected_failure_classes": [
+          "missing_artifact",
+          "invalid_artifact_shape",
+          "slice_contract_mismatch"
+        ],
+        "repairability_class": "slice_metadata"
+      }
     },
     {
       "slice_id": "BRF-01",

--- a/contracts/schemas/artifact_readiness_result.schema.json
+++ b/contracts/schemas/artifact_readiness_result.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/artifact_readiness_result.schema.json",
+  "title": "Artifact Readiness Result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "readiness_id",
+    "slice_id",
+    "owning_system",
+    "runtime_seam",
+    "status",
+    "blocking_reasons",
+    "checked_artifact_refs",
+    "contract_invariant_refs",
+    "expected_failure_classes"
+  ],
+  "properties": {
+    "artifact_type": {"type": "string", "const": "artifact_readiness_result"},
+    "schema_version": {"type": "string", "const": "1.0.0"},
+    "readiness_id": {"type": "string", "minLength": 1},
+    "slice_id": {"type": "string", "minLength": 1},
+    "owning_system": {"type": "string", "pattern": "^[A-Z0-9-]+$"},
+    "runtime_seam": {"type": "string", "minLength": 1},
+    "status": {"type": "string", "enum": ["ready", "blocked"]},
+    "blocking_reasons": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["failure_class", "reason", "artifact_refs", "invariant_refs"],
+        "properties": {
+          "failure_class": {
+            "type": "string",
+            "enum": [
+              "missing_artifact",
+              "invalid_artifact_shape",
+              "cross_artifact_mismatch",
+              "authenticity_lineage_mismatch",
+              "slice_contract_mismatch",
+              "runtime_logic_defect",
+              "policy_blocked",
+              "retry_budget_exhausted"
+            ]
+          },
+          "reason": {"type": "string", "minLength": 1},
+          "artifact_refs": {"type": "array", "items": {"type": "string", "minLength": 1}},
+          "invariant_refs": {"type": "array", "items": {"type": "string", "minLength": 1}}
+        }
+      }
+    },
+    "checked_artifact_refs": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+    "contract_invariant_refs": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+    "expected_failure_classes": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}}
+  }
+}

--- a/contracts/schemas/bounded_repair_candidate_artifact.schema.json
+++ b/contracts/schemas/bounded_repair_candidate_artifact.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/bounded_repair_candidate_artifact.schema.json",
+  "title": "Bounded Repair Candidate Artifact",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "candidate_id",
+    "failure_packet_ref",
+    "failing_slice_ref",
+    "repairability_class",
+    "minimal_repair_scope",
+    "touched_artifact_intent",
+    "bounded_rationale",
+    "recurrence_prevention_note",
+    "explicit_no_go"
+  ],
+  "properties": {
+    "artifact_type": {"type": "string", "const": "bounded_repair_candidate_artifact"},
+    "schema_version": {"type": "string", "const": "1.0.0"},
+    "candidate_id": {"type": "string", "minLength": 1},
+    "failure_packet_ref": {"type": "string", "pattern": "^execution_failure_packet:.+"},
+    "failing_slice_ref": {"type": "string", "pattern": "^slice:.+"},
+    "repairability_class": {"type": "string", "enum": ["artifact_only", "slice_metadata", "runtime_code", "escalate"]},
+    "minimal_repair_scope": {"type": "array", "items": {"type": "string", "minLength": 1}},
+    "touched_artifact_intent": {"type": "array", "items": {"type": "string", "minLength": 1}},
+    "bounded_rationale": {"type": "string", "minLength": 1},
+    "recurrence_prevention_note": {"type": "string", "minLength": 1},
+    "explicit_no_go": {"type": ["string", "null"]}
+  }
+}

--- a/contracts/schemas/cde_repair_continuation_input.schema.json
+++ b/contracts/schemas/cde_repair_continuation_input.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/cde_repair_continuation_input.schema.json",
+  "title": "CDE Repair Continuation Input",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "continuation_input_id",
+    "failure_packet_ref",
+    "repair_candidate_ref",
+    "failing_slice_ref",
+    "repairability_class",
+    "recommended_continuation",
+    "evidence_refs"
+  ],
+  "properties": {
+    "artifact_type": {"type": "string", "const": "cde_repair_continuation_input"},
+    "schema_version": {"type": "string", "const": "1.0.0"},
+    "continuation_input_id": {"type": "string", "minLength": 1},
+    "failure_packet_ref": {"type": "string", "pattern": "^execution_failure_packet:.+"},
+    "repair_candidate_ref": {"type": "string", "pattern": "^bounded_repair_candidate_artifact:.+"},
+    "failing_slice_ref": {"type": "string", "pattern": "^slice:.+"},
+    "repairability_class": {"type": "string", "enum": ["artifact_only", "slice_metadata", "runtime_code", "escalate"]},
+    "recommended_continuation": {"type": "string", "enum": ["continue_repair_bounded", "stop_escalate"]},
+    "evidence_refs": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}}
+  }
+}

--- a/contracts/schemas/execution_failure_packet.schema.json
+++ b/contracts/schemas/execution_failure_packet.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/execution_failure_packet.schema.json",
+  "title": "Execution Failure Packet",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "failure_packet_id",
+    "slice_id",
+    "readiness_ref",
+    "execution_refs",
+    "trace_refs",
+    "enforcement_refs",
+    "validation_refs",
+    "classified_failure_type",
+    "explanation",
+    "affected_artifact_refs",
+    "repairability_hint"
+  ],
+  "properties": {
+    "artifact_type": {"type": "string", "const": "execution_failure_packet"},
+    "schema_version": {"type": "string", "const": "1.0.0"},
+    "failure_packet_id": {"type": "string", "minLength": 1},
+    "slice_id": {"type": "string", "minLength": 1},
+    "batch_id": {"type": ["string", "null"]},
+    "umbrella_id": {"type": ["string", "null"]},
+    "roadmap_context_ref": {"type": ["string", "null"]},
+    "readiness_ref": {"type": "string", "pattern": "^artifact_readiness_result:.+"},
+    "execution_refs": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+    "trace_refs": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+    "enforcement_refs": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+    "validation_refs": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+    "classified_failure_type": {
+      "type": "string",
+      "enum": [
+        "missing_artifact",
+        "invalid_artifact_shape",
+        "cross_artifact_mismatch",
+        "authenticity_lineage_mismatch",
+        "slice_contract_mismatch",
+        "runtime_logic_defect",
+        "policy_blocked",
+        "retry_budget_exhausted"
+      ]
+    },
+    "explanation": {"type": "string", "minLength": 1},
+    "affected_artifact_refs": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+    "repairability_hint": {"type": "string", "enum": ["artifact_only", "slice_metadata", "runtime_code", "escalate"]}
+  }
+}

--- a/contracts/schemas/tpa_repair_gating_input.schema.json
+++ b/contracts/schemas/tpa_repair_gating_input.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/tpa_repair_gating_input.schema.json",
+  "title": "TPA Repair Gating Input",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "gating_input_id",
+    "failure_packet_ref",
+    "repair_candidate_ref",
+    "repair_scope_refs",
+    "complexity_score",
+    "risk_level",
+    "retry_budget_remaining",
+    "allowed_artifact_refs"
+  ],
+  "properties": {
+    "artifact_type": {"type": "string", "const": "tpa_repair_gating_input"},
+    "schema_version": {"type": "string", "const": "1.0.0"},
+    "gating_input_id": {"type": "string", "minLength": 1},
+    "failure_packet_ref": {"type": "string", "pattern": "^execution_failure_packet:.+"},
+    "repair_candidate_ref": {"type": "string", "pattern": "^bounded_repair_candidate_artifact:.+"},
+    "repair_scope_refs": {"type": "array", "items": {"type": "string", "minLength": 1}},
+    "complexity_score": {"type": "integer", "minimum": 0},
+    "risk_level": {"type": "string", "enum": ["low", "medium", "high"]},
+    "retry_budget_remaining": {"type": "integer", "minimum": 0},
+    "allowed_artifact_refs": {"type": "array", "items": {"type": "string", "minLength": 1}}
+  }
+}

--- a/contracts/standards-manifest.json
+++ b/contracts/standards-manifest.json
@@ -3,7 +3,7 @@
   "artifact_id": "STD-CONTRACTS",
   "artifact_version": "1.3.108",
   "schema_version": "1.3.98",
-  "standards_version": "1.3.108",
+  "standards_version": "1.3.109",
   "record_id": "REC-STD-2026-04-09-CTX-A",
   "run_id": "run-20260409T000000Z-ctx-a",
   "created_at": "2026-04-09T00:00:00Z",
@@ -223,6 +223,19 @@
       "notes": "BATCH-LTV-C deterministic artifact aging posture for brownfield control and trust/retrieval weighting."
     },
     {
+      "artifact_type": "artifact_readiness_result",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.109",
+      "last_updated_in": "1.3.109",
+      "example_path": "contracts/examples/artifact_readiness_result.json",
+      "notes": "Fail-closed pre-execution readiness result for governed slice failure-surface validation."
+    },
+    {
       "artifact_type": "artifact_validation_decision",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -378,6 +391,19 @@
       "notes": "Extracted strategic intelligence pack from book sources with evidence anchors."
     },
     {
+      "artifact_type": "bounded_repair_candidate_artifact",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.109",
+      "last_updated_in": "1.3.109",
+      "example_path": "contracts/examples/bounded_repair_candidate_artifact.json",
+      "notes": "FRE bounded repair candidate derived from canonical failure packet without execution authority."
+    },
+    {
       "artifact_type": "build_admission_record",
       "artifact_class": "coordination",
       "schema_version": "1.2.0",
@@ -454,6 +480,19 @@
       "last_updated_in": "1.3.58",
       "example_path": "contracts/examples/capability_readiness_record.json",
       "notes": "BATCH-A2 deterministic capability readiness posture signal for unattended-operation supervision gating."
+    },
+    {
+      "artifact_type": "cde_repair_continuation_input",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.109",
+      "last_updated_in": "1.3.109",
+      "example_path": "contracts/examples/cde_repair_continuation_input.json",
+      "notes": "CDE decision input derived from failure packet + bounded repair candidate."
     },
     {
       "artifact_type": "certification_integrity_result",
@@ -1484,6 +1523,19 @@
         "spectrum-systems"
       ],
       "artifact_class": "coordination"
+    },
+    {
+      "artifact_type": "execution_failure_packet",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.109",
+      "last_updated_in": "1.3.109",
+      "example_path": "contracts/examples/execution_failure_packet.json",
+      "notes": "Canonical RIL packetized blocked execution surface for downstream FRE/CDE/TPA consumption."
     },
     {
       "artifact_type": "execution_policy",
@@ -4469,6 +4521,19 @@
       "last_updated_in": "1.3.72",
       "example_path": "contracts/examples/tpa_policy_composition.json",
       "notes": "Contract-backed deterministic precedence/merge rules across tpa_scope_policy, complexity regression, simplicity review, cleanup-only, and schema-backed lightweight evidence omission allowlist constraints."
+    },
+    {
+      "artifact_type": "tpa_repair_gating_input",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.109",
+      "last_updated_in": "1.3.109",
+      "example_path": "contracts/examples/tpa_repair_gating_input.json",
+      "notes": "TPA repair gating input containing bounded scope, risk, complexity, and retry budget signals."
     },
     {
       "artifact_type": "tpa_scope_policy",

--- a/docs/review-actions/PLAN-GRC-FOUNDATION-2026-04-10.md
+++ b/docs/review-actions/PLAN-GRC-FOUNDATION-2026-04-10.md
@@ -1,0 +1,24 @@
+# PLAN-GRC-FOUNDATION-2026-04-10
+
+**Primary Type:** BUILD
+
+## Scope
+Deliver governed repair-loop closure foundation for GRC-01/02/03/04 without creating a new system and without ownership duplication.
+
+## Canonical alignment
+- `README.md`
+- `docs/architecture/system_registry.md`
+
+## Planned execution
+1. Inspect and extend repo-native contract/runtime surfaces already used for AUT seams, failure diagnosis, and review/fix artifacts.
+2. Implement GRC-01 additive slice failure-surface declarations in `slice_registry` with fail-closed validation in the runtime loader.
+3. Implement GRC-02/GRC-03/GRC-04 foundation utilities for artifact readiness gating, canonical failure packetization (RIL-owned interpretation), bounded repair candidate generation (FRE-owned), CDE continuation input derivation, and TPA repair gating input derivation.
+4. Publish schema-backed contracts and examples for new governed artifacts; update standards manifest version registry.
+5. Add focused tests anchored to AUT-05/AUT-07/AUT-10 mismatch classes and ownership boundaries.
+6. Produce review and delivery governance artifacts documenting ownership safety, representability, and remaining gaps.
+7. Run targeted and required contract checks; commit and open PR artifact.
+
+## Non-goals
+- No prompt-driven execution fallback.
+- No new runtime authority system.
+- No auto-repair execution loop expansion beyond bounded foundation inputs.

--- a/docs/reviews/GRC-FOUNDATION-DELIVERY-REPORT.md
+++ b/docs/reviews/GRC-FOUNDATION-DELIVERY-REPORT.md
@@ -1,0 +1,52 @@
+# GRC-FOUNDATION Delivery Report
+
+## Files changed
+- `docs/review-actions/PLAN-GRC-FOUNDATION-2026-04-10.md`
+- `contracts/roadmap/slice_registry.json`
+- `spectrum_systems/modules/runtime/roadmap_slice_registry.py`
+- `spectrum_systems/modules/runtime/governed_repair_foundation.py`
+- `contracts/schemas/artifact_readiness_result.schema.json`
+- `contracts/schemas/execution_failure_packet.schema.json`
+- `contracts/schemas/bounded_repair_candidate_artifact.schema.json`
+- `contracts/schemas/cde_repair_continuation_input.schema.json`
+- `contracts/schemas/tpa_repair_gating_input.schema.json`
+- `contracts/examples/artifact_readiness_result.json`
+- `contracts/examples/execution_failure_packet.json`
+- `contracts/examples/bounded_repair_candidate_artifact.json`
+- `contracts/examples/cde_repair_continuation_input.json`
+- `contracts/examples/tpa_repair_gating_input.json`
+- `contracts/standards-manifest.json`
+- `tests/test_governed_repair_foundation.py`
+- `tests/test_contracts.py`
+- `docs/reviews/RVW-GRC-FOUNDATION.md`
+- `docs/reviews/GRC-FOUNDATION-DELIVERY-REPORT.md`
+
+## Schemas/modules/tests added or modified
+- Added new GRC foundation runtime module for readiness + packetization + repair candidate + continuation/gating inputs.
+- Added five schema-backed contracts and examples for new artifacts.
+- Extended slice registry runtime validation with fail-closed failure-surface declaration support.
+- Added focused GRC foundation tests and contract example validation coverage.
+
+## Failure classes supported
+- `missing_artifact`
+- `invalid_artifact_shape`
+- `cross_artifact_mismatch`
+- `authenticity_lineage_mismatch`
+- `slice_contract_mismatch`
+- `runtime_logic_defect`
+- `policy_blocked`
+- `retry_budget_exhausted`
+
+## Repairability classes supported
+- `artifact_only`
+- `slice_metadata`
+- `runtime_code`
+- `escalate`
+
+## AUT representability status
+- AUT-05: representable via readiness + packetization + bounded candidate.
+- AUT-07: representable via authenticity/lineage and cross-artifact mismatch readiness blockers.
+- AUT-10: representable via command wiring mismatch readiness blocker and slice-metadata candidate.
+
+## Next recommended GRC batch
+GRC-INTEGRATION-01: Wire these foundation artifacts into TLC-orchestrated bounded retry execution through PQX with SEL retry-budget enforcement and CDE/TPA decision artifacts as required runtime gates.

--- a/docs/reviews/RVW-GRC-FOUNDATION.md
+++ b/docs/reviews/RVW-GRC-FOUNDATION.md
@@ -1,0 +1,41 @@
+# RVW-GRC-FOUNDATION
+
+## Scope
+GRC-01 / GRC-02 / GRC-03 / GRC-04 foundation implementation for governed repair-loop closure.
+
+## 1) Did this batch add a governed repair-loop foundation without creating a new system?
+Yes. The batch extends existing runtime/contract surfaces with schema-governed artifacts for readiness, failure packetization, bounded repair candidacy, CDE continuation input, and TPA repair gating input. No new system acronym or authority was introduced.
+
+## 2) Are failure packetization and repair candidate generation ownership-safe?
+Yes.
+- RIL-owned interpretation boundary is represented by `execution_failure_packet` generation from blocked readiness/execution evidence.
+- FRE-owned bounded proposal is represented by `bounded_repair_candidate_artifact` generation from canonical packet input only.
+- CDE and TPA receive derived decision/gating inputs, not generated repairs.
+
+## 3) Did any step duplicate PQX, FRE, CDE, TPA, TLC, RQX, RIL, SEL, or PRG responsibilities?
+No duplication was intentionally introduced.
+- PQX execution remains out-of-scope for these new builders.
+- CDE input builder does not emit repairs.
+- TPA input builder does not plan fixes.
+- TLC is not used for diagnosis or repair planning in this slice.
+
+## 4) Can the system now represent the next bounded repair step without a human writing it?
+Yes for the foundation scope. A blocked seam can now emit:
+1. `artifact_readiness_result`
+2. `execution_failure_packet`
+3. `bounded_repair_candidate_artifact`
+4. `cde_repair_continuation_input`
+5. `tpa_repair_gating_input`
+
+## 5) What remains open before full auto repair-and-resume?
+- Integrating these artifacts into a full runtime loop that applies approved bounded repair slices through PQX and resumes via TLC under SEL retry enforcement.
+- End-to-end orchestration wiring for multi-attempt repair cycles with budget exhaustion handling.
+- Expanded seam declarations beyond AUT-05/AUT-07/AUT-10.
+
+## 6) Which real recent failures are now representable end-to-end?
+- AUT-05 control decision shape mismatch (`invalid_artifact_shape`).
+- AUT-07 authenticity/lineage mismatch (`authenticity_lineage_mismatch`, `cross_artifact_mismatch`).
+- AUT-10 nested command wiring mismatch (`slice_contract_mismatch`).
+
+## Verdict
+**FOUNDATION VALID**

--- a/spectrum_systems/modules/runtime/governed_repair_foundation.py
+++ b/spectrum_systems/modules/runtime/governed_repair_foundation.py
@@ -1,0 +1,392 @@
+"""GRC foundation: readiness gating, failure packetization, and bounded repair handoff artifacts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from jsonschema import Draft202012Validator
+
+from spectrum_systems.contracts import load_schema, validate_artifact
+from spectrum_systems.modules.runtime.lineage_authenticity import LineageAuthenticityError, verify_authenticity
+from spectrum_systems.utils.deterministic_id import deterministic_id
+
+
+class GovernedRepairFoundationError(ValueError):
+    """Raised when governed repair foundation logic must fail closed."""
+
+
+_CANONICAL_FAILURE_CLASSES = {
+    "missing_artifact",
+    "invalid_artifact_shape",
+    "cross_artifact_mismatch",
+    "authenticity_lineage_mismatch",
+    "slice_contract_mismatch",
+    "runtime_logic_defect",
+    "policy_blocked",
+    "retry_budget_exhausted",
+}
+
+_REPAIRABILITY_CLASSES = {"artifact_only", "slice_metadata", "runtime_code", "escalate"}
+
+
+def _validate(instance: dict[str, Any], schema_name: str) -> None:
+    schema = load_schema(schema_name)
+    validator = Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(instance), key=lambda err: str(list(err.absolute_path)))
+    if errors:
+        details = "; ".join(error.message for error in errors)
+        raise GovernedRepairFoundationError(f"{schema_name} failed schema validation: {details}")
+
+
+def _normalize_ref_list(values: Any, *, field: str) -> list[str]:
+    if not isinstance(values, list):
+        raise GovernedRepairFoundationError(f"{field} must be a list")
+    normalized = sorted({str(item).strip() for item in values if isinstance(item, str) and item.strip()})
+    if not normalized:
+        raise GovernedRepairFoundationError(f"{field} must include at least one non-empty entry")
+    return normalized
+
+
+def _classify_repairability(*, failure_class: str, touched_refs: list[str]) -> str:
+    if failure_class == "runtime_logic_defect":
+        return "runtime_code"
+    if failure_class == "slice_contract_mismatch":
+        return "slice_metadata"
+    if failure_class in {"policy_blocked", "retry_budget_exhausted"}:
+        return "escalate"
+    if touched_refs:
+        return "artifact_only"
+    return "escalate"
+
+
+def evaluate_slice_artifact_readiness(
+    *,
+    slice_id: str,
+    owning_system: str,
+    runtime_seam: str,
+    required_artifacts: list[dict[str, str]],
+    contract_invariants: list[str],
+    expected_failure_classes: list[str],
+    command: str,
+) -> dict[str, Any]:
+    """Produce fail-closed readiness result without executing slice work."""
+    if not isinstance(slice_id, str) or not slice_id.strip():
+        raise GovernedRepairFoundationError("slice_id must be a non-empty string")
+    if not isinstance(command, str) or not command.strip():
+        raise GovernedRepairFoundationError("command must be a non-empty string")
+
+    blockers: list[dict[str, Any]] = []
+    checked_refs: list[str] = []
+
+    for artifact in required_artifacts:
+        if not isinstance(artifact, dict):
+            raise GovernedRepairFoundationError("required_artifacts entries must be objects")
+        artifact_ref = str(artifact.get("artifact_ref") or "").strip()
+        schema_name = str(artifact.get("schema") or "").strip()
+        authenticity_issuer = str(artifact.get("authenticity_issuer") or "").strip()
+        if not artifact_ref or not schema_name:
+            raise GovernedRepairFoundationError("required_artifacts entries require artifact_ref and schema")
+        checked_refs.append(artifact_ref)
+
+        path = Path(artifact_ref)
+        if not path.is_file():
+            blockers.append(
+                {
+                    "failure_class": "missing_artifact",
+                    "reason": f"missing required artifact: {artifact_ref}",
+                    "artifact_refs": [artifact_ref],
+                    "invariant_refs": [],
+                }
+            )
+            continue
+
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            blockers.append(
+                {
+                    "failure_class": "invalid_artifact_shape",
+                    "reason": f"artifact must be a JSON object: {artifact_ref}",
+                    "artifact_refs": [artifact_ref],
+                    "invariant_refs": [],
+                }
+            )
+            continue
+
+        try:
+            validate_artifact(payload, schema_name)
+        except Exception as exc:
+            blockers.append(
+                {
+                    "failure_class": "invalid_artifact_shape",
+                    "reason": f"schema validation failed for {artifact_ref}: {exc}",
+                    "artifact_refs": [artifact_ref],
+                    "invariant_refs": [],
+                }
+            )
+            continue
+
+        if authenticity_issuer:
+            try:
+                verify_authenticity(artifact=payload, expected_issuer=authenticity_issuer)
+            except LineageAuthenticityError as exc:
+                blockers.append(
+                    {
+                        "failure_class": "authenticity_lineage_mismatch",
+                        "reason": f"authenticity verification failed for {artifact_ref}: {exc}",
+                        "artifact_refs": [artifact_ref],
+                        "invariant_refs": ["authenticity_lineage"],
+                    }
+                )
+
+    if "control_decision_payload_nested" in contract_invariants and "decision['control_decision']" not in command:
+        blockers.append(
+            {
+                "failure_class": "slice_contract_mismatch",
+                "reason": "slice command contract mismatch: nested control_decision payload not wired",
+                "artifact_refs": [],
+                "invariant_refs": ["control_decision_payload_nested"],
+            }
+        )
+
+    if "lineage_trace_alignment" in contract_invariants:
+        trace_ids: set[str] = set()
+        for artifact in required_artifacts:
+            ref = str(artifact.get("artifact_ref") or "").strip()
+            path = Path(ref)
+            if not path.is_file():
+                continue
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(payload, dict) and isinstance(payload.get("trace_id"), str) and payload["trace_id"].strip():
+                trace_ids.add(payload["trace_id"].strip())
+        if len(trace_ids) > 1:
+            blockers.append(
+                {
+                    "failure_class": "cross_artifact_mismatch",
+                    "reason": "cross-artifact mismatch: required lineage artifacts disagree on trace_id",
+                    "artifact_refs": checked_refs,
+                    "invariant_refs": ["lineage_trace_alignment"],
+                }
+            )
+
+    readiness = {
+        "artifact_type": "artifact_readiness_result",
+        "schema_version": "1.0.0",
+        "readiness_id": deterministic_id(
+            prefix="arr",
+            namespace="grc_readiness",
+            payload={"slice_id": slice_id, "blockers": blockers, "command": command},
+        ),
+        "slice_id": slice_id,
+        "owning_system": owning_system,
+        "runtime_seam": runtime_seam,
+        "status": "ready" if not blockers else "blocked",
+        "blocking_reasons": blockers,
+        "checked_artifact_refs": sorted(set(checked_refs)),
+        "contract_invariant_refs": sorted(set(contract_invariants)),
+        "expected_failure_classes": sorted(set(expected_failure_classes)),
+    }
+    _validate(readiness, "artifact_readiness_result")
+    return readiness
+
+
+def build_execution_failure_packet(
+    *,
+    readiness_result: dict[str, Any],
+    execution_refs: list[str],
+    trace_refs: list[str],
+    enforcement_refs: list[str],
+    validation_refs: list[str],
+    batch_id: str | None,
+    umbrella_id: str | None,
+    roadmap_context_ref: str | None,
+) -> dict[str, Any]:
+    """Canonical RIL-owned packetization from blocked readiness/execution surface."""
+    _validate(readiness_result, "artifact_readiness_result")
+    if readiness_result["status"] != "blocked":
+        raise GovernedRepairFoundationError("execution failure packet requires blocked readiness surface")
+
+    blockers = readiness_result["blocking_reasons"]
+    if not blockers:
+        raise GovernedRepairFoundationError("blocked readiness result must contain blocking_reasons")
+    primary = str(blockers[0]["failure_class"])
+    if primary not in _CANONICAL_FAILURE_CLASSES:
+        raise GovernedRepairFoundationError(f"unsupported failure class for packetization: {primary}")
+
+    affected_refs: list[str] = []
+    for blocker in blockers:
+        affected_refs.extend(str(ref) for ref in blocker.get("artifact_refs", []) if isinstance(ref, str) and ref.strip())
+
+    packet = {
+        "artifact_type": "execution_failure_packet",
+        "schema_version": "1.0.0",
+        "failure_packet_id": deterministic_id(
+            prefix="efp",
+            namespace="grc_failure_packet",
+            payload={
+                "slice_id": readiness_result["slice_id"],
+                "readiness_id": readiness_result["readiness_id"],
+                "primary_failure_class": primary,
+            },
+        ),
+        "slice_id": readiness_result["slice_id"],
+        "batch_id": batch_id,
+        "umbrella_id": umbrella_id,
+        "roadmap_context_ref": roadmap_context_ref,
+        "readiness_ref": f"artifact_readiness_result:{readiness_result['readiness_id']}",
+        "execution_refs": _normalize_ref_list(execution_refs, field="execution_refs"),
+        "trace_refs": _normalize_ref_list(trace_refs, field="trace_refs"),
+        "enforcement_refs": _normalize_ref_list(enforcement_refs, field="enforcement_refs"),
+        "validation_refs": _normalize_ref_list(validation_refs, field="validation_refs"),
+        "classified_failure_type": primary,
+        "explanation": str(blockers[0]["reason"]),
+        "affected_artifact_refs": sorted(set(affected_refs or readiness_result.get("checked_artifact_refs", []))),
+        "repairability_hint": _classify_repairability(
+            failure_class=primary,
+            touched_refs=sorted(set(affected_refs)),
+        ),
+    }
+    _validate(packet, "execution_failure_packet")
+    return packet
+
+
+def build_bounded_repair_candidate(
+    *,
+    failure_packet: dict[str, Any],
+    max_scope_refs: int = 5,
+) -> dict[str, Any]:
+    """FRE bounded repair candidate generation from canonical failure packet."""
+    _validate(failure_packet, "execution_failure_packet")
+    if max_scope_refs < 1:
+        raise GovernedRepairFoundationError("max_scope_refs must be >= 1")
+
+    touched_refs = [
+        str(ref).strip() for ref in failure_packet.get("affected_artifact_refs", []) if isinstance(ref, str) and ref.strip()
+    ]
+    if len(touched_refs) > max_scope_refs:
+        raise GovernedRepairFoundationError("bounded repair candidate rejected: scope exceeds bounded authority")
+
+    repairability_class = str(failure_packet["repairability_hint"])
+    if repairability_class not in _REPAIRABILITY_CLASSES:
+        raise GovernedRepairFoundationError("failure packet repairability_hint is not supported")
+
+    no_go = None
+    if repairability_class == "escalate":
+        no_go = "repair scope exceeds bounded authority; escalation required"
+
+    candidate = {
+        "artifact_type": "bounded_repair_candidate_artifact",
+        "schema_version": "1.0.0",
+        "candidate_id": deterministic_id(
+            prefix="brc",
+            namespace="grc_bounded_repair_candidate",
+            payload={
+                "failure_packet_id": failure_packet["failure_packet_id"],
+                "repairability_class": repairability_class,
+                "scope": sorted(set(touched_refs)),
+            },
+        ),
+        "failure_packet_ref": f"execution_failure_packet:{failure_packet['failure_packet_id']}",
+        "failing_slice_ref": f"slice:{failure_packet['slice_id']}",
+        "repairability_class": repairability_class,
+        "minimal_repair_scope": sorted(set(touched_refs)),
+        "touched_artifact_intent": sorted(set(touched_refs)),
+        "bounded_rationale": f"Classified {failure_packet['classified_failure_type']} from canonical failure packet.",
+        "recurrence_prevention_note": "Preserve artifact-first validation and prevent recurrence by enforcing readiness invariants.",
+        "explicit_no_go": no_go,
+    }
+    _validate(candidate, "bounded_repair_candidate_artifact")
+    return candidate
+
+
+def build_cde_repair_continuation_input(
+    *,
+    failure_packet: dict[str, Any],
+    repair_candidate: dict[str, Any],
+) -> dict[str, Any]:
+    """Derive CDE continuation input without generating repair content in CDE."""
+    _validate(failure_packet, "execution_failure_packet")
+    _validate(repair_candidate, "bounded_repair_candidate_artifact")
+
+    continuation = {
+        "artifact_type": "cde_repair_continuation_input",
+        "schema_version": "1.0.0",
+        "continuation_input_id": deterministic_id(
+            prefix="cri",
+            namespace="grc_cde_continuation",
+            payload={
+                "failure_packet_id": failure_packet["failure_packet_id"],
+                "candidate_id": repair_candidate["candidate_id"],
+            },
+        ),
+        "failure_packet_ref": f"execution_failure_packet:{failure_packet['failure_packet_id']}",
+        "repair_candidate_ref": f"bounded_repair_candidate_artifact:{repair_candidate['candidate_id']}",
+        "failing_slice_ref": f"slice:{failure_packet['slice_id']}",
+        "repairability_class": repair_candidate["repairability_class"],
+        "recommended_continuation": "stop_escalate"
+        if repair_candidate["repairability_class"] == "escalate"
+        else "continue_repair_bounded",
+        "evidence_refs": sorted(
+            set(
+                failure_packet["execution_refs"]
+                + failure_packet["trace_refs"]
+                + failure_packet["enforcement_refs"]
+                + failure_packet["validation_refs"]
+            )
+        ),
+    }
+    _validate(continuation, "cde_repair_continuation_input")
+    return continuation
+
+
+def build_tpa_repair_gating_input(
+    *,
+    failure_packet: dict[str, Any],
+    repair_candidate: dict[str, Any],
+    retry_budget_remaining: int,
+    complexity_score: int,
+    risk_level: str,
+) -> dict[str, Any]:
+    """Derive TPA repair gating input without planning or executing the repair."""
+    _validate(failure_packet, "execution_failure_packet")
+    _validate(repair_candidate, "bounded_repair_candidate_artifact")
+    if retry_budget_remaining < 0:
+        raise GovernedRepairFoundationError("retry_budget_remaining must be >= 0")
+    if complexity_score < 0:
+        raise GovernedRepairFoundationError("complexity_score must be >= 0")
+    if risk_level not in {"low", "medium", "high"}:
+        raise GovernedRepairFoundationError("risk_level must be one of low|medium|high")
+
+    gating = {
+        "artifact_type": "tpa_repair_gating_input",
+        "schema_version": "1.0.0",
+        "gating_input_id": deterministic_id(
+            prefix="rgi",
+            namespace="grc_tpa_gating",
+            payload={
+                "failure_packet_id": failure_packet["failure_packet_id"],
+                "candidate_id": repair_candidate["candidate_id"],
+                "retry_budget_remaining": retry_budget_remaining,
+            },
+        ),
+        "failure_packet_ref": f"execution_failure_packet:{failure_packet['failure_packet_id']}",
+        "repair_candidate_ref": f"bounded_repair_candidate_artifact:{repair_candidate['candidate_id']}",
+        "repair_scope_refs": repair_candidate["minimal_repair_scope"],
+        "complexity_score": complexity_score,
+        "risk_level": risk_level,
+        "retry_budget_remaining": retry_budget_remaining,
+        "allowed_artifact_refs": repair_candidate["touched_artifact_intent"],
+    }
+    _validate(gating, "tpa_repair_gating_input")
+    return gating
+
+
+__all__ = [
+    "GovernedRepairFoundationError",
+    "build_bounded_repair_candidate",
+    "build_cde_repair_continuation_input",
+    "build_execution_failure_packet",
+    "build_tpa_repair_gating_input",
+    "evaluate_slice_artifact_readiness",
+]

--- a/spectrum_systems/modules/runtime/roadmap_slice_registry.py
+++ b/spectrum_systems/modules/runtime/roadmap_slice_registry.py
@@ -29,6 +29,33 @@ _REQUIRED_SLICE_FIELDS = (
     "likely_tests",
     "invariants",
 )
+_REPAIRABILITY_CLASSES = {"artifact_only", "slice_metadata", "runtime_code", "escalate"}
+_EXPECTED_FAILURE_CLASSES = {
+    "missing_artifact",
+    "invalid_artifact_shape",
+    "cross_artifact_mismatch",
+    "authenticity_lineage_mismatch",
+    "slice_contract_mismatch",
+    "runtime_logic_defect",
+    "policy_blocked",
+    "retry_budget_exhausted",
+}
+_CANONICAL_SYSTEM_OWNERS = {
+    "AEX",
+    "PQX",
+    "HNX",
+    "TPA",
+    "MAP",
+    "RDX",
+    "FRE",
+    "RIL",
+    "RQX",
+    "SEL",
+    "CDE",
+    "TLC",
+    "PRG",
+}
+_FAILURE_SURFACE_REQUIRED_SLICE_IDS = {"AUT-05", "AUT-07", "AUT-10"}
 
 _ALLOWED_EXECUTION_TYPES = {"code", "validation", "repair", "governance"}
 _GENERIC_IMPLEMENTATION_NOTE_PATTERNS = (
@@ -211,6 +238,54 @@ def _validate_execution_type_command_alignment(slice_id: str, execution_type: st
         )
 
 
+def _validate_failure_surface_declaration(slice_id: str, declaration: Any) -> dict[str, Any]:
+    if not isinstance(declaration, dict):
+        raise RoadmapSliceRegistryError(f"slice {slice_id} has invalid failure_surface: expected object")
+    owning_system = _as_non_empty_string(
+        declaration.get("owning_system"), field="failure_surface.owning_system", slice_id=slice_id
+    )
+    if owning_system not in _CANONICAL_SYSTEM_OWNERS:
+        raise RoadmapSliceRegistryError(
+            f"slice {slice_id} has invalid failure_surface.owning_system: {owning_system!r} is not canonical"
+        )
+    runtime_seam = _as_non_empty_string(
+        declaration.get("runtime_seam"), field="failure_surface.runtime_seam", slice_id=slice_id
+    )
+    required_artifacts = _as_string_list(
+        declaration.get("required_artifacts"), field="failure_surface.required_artifacts", slice_id=slice_id
+    )
+    contract_invariants = _as_string_list(
+        declaration.get("contract_invariants"), field="failure_surface.contract_invariants", slice_id=slice_id
+    )
+    expected_failure_classes = _as_string_list(
+        declaration.get("expected_failure_classes"),
+        field="failure_surface.expected_failure_classes",
+        slice_id=slice_id,
+    )
+    invalid_failure_classes = [item for item in expected_failure_classes if item not in _EXPECTED_FAILURE_CLASSES]
+    if invalid_failure_classes:
+        raise RoadmapSliceRegistryError(
+            f"slice {slice_id} has invalid failure_surface.expected_failure_classes: "
+            f"{', '.join(sorted(invalid_failure_classes))}"
+        )
+    repairability_class = _as_non_empty_string(
+        declaration.get("repairability_class"), field="failure_surface.repairability_class", slice_id=slice_id
+    )
+    if repairability_class not in _REPAIRABILITY_CLASSES:
+        raise RoadmapSliceRegistryError(
+            f"slice {slice_id} has invalid failure_surface.repairability_class: "
+            f"{repairability_class!r} not in {sorted(_REPAIRABILITY_CLASSES)}"
+        )
+    return {
+        "owning_system": owning_system,
+        "runtime_seam": runtime_seam,
+        "required_artifacts": required_artifacts,
+        "contract_invariants": contract_invariants,
+        "expected_failure_classes": expected_failure_classes,
+        "repairability_class": repairability_class,
+    }
+
+
 def validate_pqx_slice_execution_compatibility(slices: list[dict[str, Any]]) -> None:
     family_command_sets: dict[tuple[str, tuple[str, ...]], str] = {}
     family_first_commands: dict[tuple[str, str], str] = {}
@@ -283,35 +358,42 @@ def validate_slice_registry(payload: dict[str, Any]) -> list[dict[str, Any]]:
             if field not in row:
                 raise RoadmapSliceRegistryError(f"slice {slice_id} missing required field: {field}")
 
-        normalized.append(
-            {
-                "slice_id": slice_id,
-                "what_it_does": _as_non_empty_string(row.get("what_it_does"), field="what_it_does", slice_id=slice_id),
-                "purpose": _as_non_empty_string(row.get("purpose"), field="purpose", slice_id=slice_id),
-                "why_it_matters": _as_non_empty_string(
-                    row.get("why_it_matters"), field="why_it_matters", slice_id=slice_id
-                ),
-                "execution_type": _as_non_empty_string(
-                    row.get("execution_type"), field="execution_type", slice_id=slice_id
-                ),
-                "commands": _as_string_list(row.get("commands"), field="commands", slice_id=slice_id),
-                "success_criteria": _as_string_list(
-                    row.get("success_criteria"), field="success_criteria", slice_id=slice_id
-                ),
-                "implementation_notes": _as_non_empty_string(
-                    row.get("implementation_notes"), field="implementation_notes", slice_id=slice_id
-                ),
-                "likely_entrypoints": _as_string_list(
-                    row.get("likely_entrypoints"), field="likely_entrypoints", slice_id=slice_id
-                ),
-                "likely_tests": _as_string_list(row.get("likely_tests"), field="likely_tests", slice_id=slice_id),
-                "invariants": _as_string_list(row.get("invariants"), field="invariants", slice_id=slice_id),
-                "status": _as_non_empty_string(row.get("status", "planned"), field="status", slice_id=slice_id),
-                "source_basis": _as_string_list(
-                    row.get("source_basis", ["inferred"]), field="source_basis", slice_id=slice_id
-                ),
-            }
-        )
+        failure_surface = row.get("failure_surface")
+        if slice_id in _FAILURE_SURFACE_REQUIRED_SLICE_IDS and not isinstance(failure_surface, dict):
+            raise RoadmapSliceRegistryError(
+                f"slice {slice_id} missing required field: failure_surface"
+            )
+
+        normalized_row = {
+            "slice_id": slice_id,
+            "what_it_does": _as_non_empty_string(row.get("what_it_does"), field="what_it_does", slice_id=slice_id),
+            "purpose": _as_non_empty_string(row.get("purpose"), field="purpose", slice_id=slice_id),
+            "why_it_matters": _as_non_empty_string(
+                row.get("why_it_matters"), field="why_it_matters", slice_id=slice_id
+            ),
+            "execution_type": _as_non_empty_string(
+                row.get("execution_type"), field="execution_type", slice_id=slice_id
+            ),
+            "commands": _as_string_list(row.get("commands"), field="commands", slice_id=slice_id),
+            "success_criteria": _as_string_list(
+                row.get("success_criteria"), field="success_criteria", slice_id=slice_id
+            ),
+            "implementation_notes": _as_non_empty_string(
+                row.get("implementation_notes"), field="implementation_notes", slice_id=slice_id
+            ),
+            "likely_entrypoints": _as_string_list(
+                row.get("likely_entrypoints"), field="likely_entrypoints", slice_id=slice_id
+            ),
+            "likely_tests": _as_string_list(row.get("likely_tests"), field="likely_tests", slice_id=slice_id),
+            "invariants": _as_string_list(row.get("invariants"), field="invariants", slice_id=slice_id),
+            "status": _as_non_empty_string(row.get("status", "planned"), field="status", slice_id=slice_id),
+            "source_basis": _as_string_list(
+                row.get("source_basis", ["inferred"]), field="source_basis", slice_id=slice_id
+            ),
+        }
+        if isinstance(failure_surface, dict):
+            normalized_row["failure_surface"] = _validate_failure_surface_declaration(slice_id, failure_surface)
+        normalized.append(normalized_row)
 
     validate_pqx_slice_execution_compatibility(normalized)
     return sorted(normalized, key=lambda item: item["slice_id"])

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -544,6 +544,17 @@ class ContractSchemaTests(unittest.TestCase):
             instance = load_example(name)
             validate_artifact(instance, name)
 
+    def test_grc_foundation_contract_examples_validate(self) -> None:
+        for name in (
+            "artifact_readiness_result",
+            "execution_failure_packet",
+            "bounded_repair_candidate_artifact",
+            "cde_repair_continuation_input",
+            "tpa_repair_gating_input",
+        ):
+            instance = load_example(name)
+            validate_artifact(instance, name)
+
 
     def test_prompt_registry_examples_validate(self) -> None:
         for name in ("prompt_registry_entry", "prompt_alias_map", "routing_policy", "routing_decision", "agent_execution_trace"):

--- a/tests/test_governed_repair_foundation.py
+++ b/tests/test_governed_repair_foundation.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from spectrum_systems.modules.runtime.governed_repair_foundation import (
+    GovernedRepairFoundationError,
+    build_bounded_repair_candidate,
+    build_cde_repair_continuation_input,
+    build_execution_failure_packet,
+    build_tpa_repair_gating_input,
+    evaluate_slice_artifact_readiness,
+)
+from spectrum_systems.modules.runtime.roadmap_slice_registry import RoadmapSliceRegistryError, load_slice_registry
+
+
+_FIXTURE_ROOT = Path("tests/fixtures/roadmaps/aut_reg_05a")
+
+
+def _load_slice(slice_id: str) -> dict:
+    rows = load_slice_registry(Path("contracts/roadmap/slice_registry.json"))
+    return next(row for row in rows if row["slice_id"] == slice_id)
+
+
+def test_failure_surface_declaration_required_for_aut_seam() -> None:
+    aut05 = _load_slice("AUT-05")
+    assert aut05["failure_surface"]["runtime_seam"] == "review_control_decision_projection"
+
+
+def test_invalid_failure_surface_owner_fails_closed(tmp_path: Path) -> None:
+    payload = json.loads(Path("contracts/roadmap/slice_registry.json").read_text(encoding="utf-8"))
+    row = next(item for item in payload["slices"] if item["slice_id"] == "AUT-05")
+    row["failure_surface"]["owning_system"] = "NOT-A-SYSTEM"
+    path = tmp_path / "slice_registry.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(RoadmapSliceRegistryError, match="owning_system"):
+        load_slice_registry(path)
+
+
+def test_invalid_failure_surface_repairability_class_fails_closed(tmp_path: Path) -> None:
+    payload = json.loads(Path("contracts/roadmap/slice_registry.json").read_text(encoding="utf-8"))
+    row = next(item for item in payload["slices"] if item["slice_id"] == "AUT-10")
+    row["failure_surface"]["repairability_class"] = "full_autonomy"
+    path = tmp_path / "slice_registry.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(RoadmapSliceRegistryError, match="repairability_class"):
+        load_slice_registry(path)
+
+
+def test_artifact_readiness_missing_artifact_blocks() -> None:
+    result = evaluate_slice_artifact_readiness(
+        slice_id="AUT-05",
+        owning_system="RIL",
+        runtime_seam="review_control_decision_projection",
+        required_artifacts=[
+            {
+                "artifact_ref": "tests/fixtures/roadmaps/aut_reg_05a/review_control_signal.does_not_exist.json",
+                "schema": "review_control_signal",
+            }
+        ],
+        contract_invariants=["control_decision_shape"],
+        expected_failure_classes=["missing_artifact"],
+        command="python -c 'noop'",
+    )
+    assert result["status"] == "blocked"
+    assert result["blocking_reasons"][0]["failure_class"] == "missing_artifact"
+
+
+def test_artifact_readiness_invalid_shape_blocks(tmp_path: Path) -> None:
+    broken = json.loads((_FIXTURE_ROOT / "review_control_signal.json").read_text(encoding="utf-8"))
+    del broken["control_decision"]["system_response"]
+    broken_path = tmp_path / "broken_review_control_signal.json"
+    broken_path.write_text(json.dumps(broken), encoding="utf-8")
+
+    result = evaluate_slice_artifact_readiness(
+        slice_id="AUT-05",
+        owning_system="RIL",
+        runtime_seam="review_control_decision_projection",
+        required_artifacts=[
+            {"artifact_ref": str(broken_path), "schema": "review_control_signal"},
+        ],
+        contract_invariants=["control_decision_shape"],
+        expected_failure_classes=["invalid_artifact_shape"],
+        command="python -c 'noop'",
+    )
+    assert result["status"] == "blocked"
+    assert result["blocking_reasons"][0]["failure_class"] == "invalid_artifact_shape"
+
+
+def test_artifact_readiness_authenticity_and_lineage_mismatch_blocks(tmp_path: Path) -> None:
+    adm = json.loads(Path("contracts/examples/build_admission_record.example.json").read_text(encoding="utf-8"))
+    adm["authenticity"]["issuer"] = "PQX"
+    adm["trace_id"] = "trace-mismatch-a"
+    req = json.loads(Path("contracts/examples/normalized_execution_request.example.json").read_text(encoding="utf-8"))
+    req["trace_id"] = "trace-mismatch-b"
+    handoff = json.loads(Path("contracts/examples/tlc_handoff_record.example.json").read_text(encoding="utf-8"))
+    handoff["trace_id"] = "trace-mismatch-c"
+
+    adm_path = tmp_path / "build_admission_record.example.json"
+    req_path = tmp_path / "normalized_execution_request.example.json"
+    handoff_path = tmp_path / "tlc_handoff_record.example.json"
+    adm_path.write_text(json.dumps(adm), encoding="utf-8")
+    req_path.write_text(json.dumps(req), encoding="utf-8")
+    handoff_path.write_text(json.dumps(handoff), encoding="utf-8")
+
+    result = evaluate_slice_artifact_readiness(
+        slice_id="AUT-07",
+        owning_system="TPA",
+        runtime_seam="repo_write_lineage_authenticity_guard",
+        required_artifacts=[
+            {"artifact_ref": str(adm_path), "schema": "build_admission_record", "authenticity_issuer": "AEX"},
+            {"artifact_ref": str(req_path), "schema": "normalized_execution_request", "authenticity_issuer": "AEX"},
+            {"artifact_ref": str(handoff_path), "schema": "tlc_handoff_record", "authenticity_issuer": "TLC"},
+        ],
+        contract_invariants=["lineage_trace_alignment"],
+        expected_failure_classes=["authenticity_lineage_mismatch", "cross_artifact_mismatch"],
+        command="python -c 'noop'",
+    )
+    classes = {row["failure_class"] for row in result["blocking_reasons"]}
+    assert "authenticity_lineage_mismatch" in classes
+    assert "cross_artifact_mismatch" in classes
+
+
+def test_artifact_readiness_command_wiring_mismatch_blocks() -> None:
+    result = evaluate_slice_artifact_readiness(
+        slice_id="AUT-10",
+        owning_system="RIL",
+        runtime_seam="review_control_decision_command_wiring",
+        required_artifacts=[
+            {
+                "artifact_ref": "contracts/examples/review_control_signal_artifact.json",
+                "schema": "review_control_signal_artifact",
+            },
+        ],
+        contract_invariants=["control_decision_payload_nested"],
+        expected_failure_classes=["slice_contract_mismatch"],
+        command="python -c \"build_review_roadmap(snapshot=snapshot, control_decision=decision)\"",
+    )
+    assert result["status"] == "blocked"
+    assert {row["failure_class"] for row in result["blocking_reasons"]} == {"slice_contract_mismatch"}
+
+
+def test_failure_packetization_and_repair_candidate_and_inputs() -> None:
+    readiness = evaluate_slice_artifact_readiness(
+        slice_id="AUT-10",
+        owning_system="RIL",
+        runtime_seam="review_control_decision_command_wiring",
+        required_artifacts=[
+            {
+                "artifact_ref": "contracts/examples/review_control_signal_artifact.json",
+                "schema": "review_control_signal_artifact",
+            },
+        ],
+        contract_invariants=["control_decision_payload_nested"],
+        expected_failure_classes=["slice_contract_mismatch"],
+        command="python -c \"build_review_roadmap(snapshot=snapshot, control_decision=decision)\"",
+    )
+
+    packet = build_execution_failure_packet(
+        readiness_result=readiness,
+        execution_refs=["slice_execution:AUT-10"],
+        trace_refs=["trace:aut-10"],
+        enforcement_refs=["system_enforcement_result_artifact:sel-aut-10"],
+        validation_refs=["pytest_failure:tests/test_review_roadmap_generator.py::test_requires_nested_control_decision"],
+        batch_id="BATCH-AUT",
+        umbrella_id="AUTONOMY_EXECUTION",
+        roadmap_context_ref="contracts/roadmap/roadmap_structure.json",
+    )
+    assert packet["classified_failure_type"] == "slice_contract_mismatch"
+
+    candidate = build_bounded_repair_candidate(failure_packet=packet)
+    assert candidate["repairability_class"] == "slice_metadata"
+
+    cde_input = build_cde_repair_continuation_input(failure_packet=packet, repair_candidate=candidate)
+    assert cde_input["recommended_continuation"] == "continue_repair_bounded"
+
+    tpa_input = build_tpa_repair_gating_input(
+        failure_packet=packet,
+        repair_candidate=candidate,
+        retry_budget_remaining=1,
+        complexity_score=2,
+        risk_level="medium",
+    )
+    assert tpa_input["retry_budget_remaining"] == 1
+
+
+def test_oversized_scope_is_rejected() -> None:
+    packet = json.loads(Path("contracts/examples/execution_failure_packet.json").read_text(encoding="utf-8"))
+    packet["affected_artifact_refs"] = [f"contracts/examples/a{i}.json" for i in range(8)]
+    with pytest.raises(GovernedRepairFoundationError, match="scope exceeds bounded authority"):
+        build_bounded_repair_candidate(failure_packet=packet, max_scope_refs=2)
+
+
+def test_no_ownership_bleed_in_artifact_outputs() -> None:
+    packet = json.loads(Path("contracts/examples/execution_failure_packet.json").read_text(encoding="utf-8"))
+    candidate = build_bounded_repair_candidate(failure_packet=packet)
+    cde_input = build_cde_repair_continuation_input(failure_packet=packet, repair_candidate=candidate)
+    tpa_input = build_tpa_repair_gating_input(
+        failure_packet=packet,
+        repair_candidate=candidate,
+        retry_budget_remaining=1,
+        complexity_score=1,
+        risk_level="low",
+    )
+    assert "candidate_id" not in cde_input
+    assert "recommended_continuation" in cde_input
+    assert "repair_scope_refs" in tpa_input


### PR DESCRIPTION
### Motivation
- Provide the minimal, schema-backed foundation so the system can convert blocked execution surfaces into machine-readable failure packets and produce bounded repair candidates without introducing new system authority or ownership bleed.
- Anchor the work to real AUT seam failures (AUT-05, AUT-07, AUT-10) so readiness checks, classification, and bounded repair scope are grounded in existing repo fixtures and runtime shapes.
- Preserve artifact-first and fail-closed behavior while enabling downstream CDE/TPA inputs for governed continuation and gating decisions.

### Description
- Added a new runtime module `spectrum_systems/modules/runtime/governed_repair_foundation.py` implementing `evaluate_slice_artifact_readiness`, `build_execution_failure_packet`, `build_bounded_repair_candidate`, `build_cde_repair_continuation_input`, and `build_tpa_repair_gating_input` to perform fail-closed readiness checks, canonical RIL packetization, FRE bounded candidate generation, and derived CDE/TPA inputs. 
- Extended `contracts/roadmap/slice_registry.json` and the loader `spectrum_systems/modules/runtime/roadmap_slice_registry.py` to support and enforce an additive `failure_surface` declaration (fields: `owning_system`, `runtime_seam`, `required_artifacts`, `contract_invariants`, `expected_failure_classes`, `repairability_class`) and mandated declarations for `AUT-05`, `AUT-07`, and `AUT-10` seams.
- Added five new schema contracts and examples under `contracts/schemas/` and `contracts/examples/`: `artifact_readiness_result`, `execution_failure_packet`, `bounded_repair_candidate_artifact`, `cde_repair_continuation_input`, and `tpa_repair_gating_input`, and registered them in `contracts/standards-manifest.json` (bumped `standards_version` to `1.3.109`).
- Added focused tests in `tests/test_governed_repair_foundation.py` and updated contract example validation in `tests/test_contracts.py`, plus created plan/review/delivery docs in `docs/review-actions/` and `docs/reviews/` to record ownership decisions and remaining work.

### Testing
- Ran `pytest tests/test_governed_repair_foundation.py` which passed (10 tests) and validated readiness, blocker classification, packetization, candidate generation, CDE/TPA inputs, and scope-rejection behavior. 
- Ran `pytest tests/test_slice_registry_execution_contract.py` which passed (11 tests) to ensure slice registry compatibility and new declaration validation. 
- Ran `pytest tests/test_contracts.py tests/test_contract_enforcement.py` which passed (117 tests total) and executed `python scripts/run_contract_enforcement.py` which reported zero failures. 
- Executed the repository contract-boundary audit script `.codex/skills/contract-boundary-audit/run.sh`; it produced repository-wide warnings (baseline consumer/schema checks) and did not finish within the bounded execution window in this environment, but core contract tests and contract enforcement passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d93b52b0f0832980974d6e56d8abdc)