### PR TITLE
GRC-INTEGRATION-02: delegation-truth tests and continuity evidence for governed repair loop

### DIFF
--- a/docs/review-actions/PLAN-GRC-INTEGRATION-02-2026-04-10.md
+++ b/docs/review-actions/PLAN-GRC-INTEGRATION-02-2026-04-10.md
@@ -1,0 +1,16 @@
+# PLAN-GRC-INTEGRATION-02-2026-04-10
+
+## Primary Type
+BUILD
+
+## Scope
+Strengthen governed repair-loop trust by adding delegation-truth tests and linkage-proof assertions for runtime execution continuity without widening subsystem ownership.
+
+## Steps
+1. Inspect governed repair loop runtime and existing execution tests plus artifact schemas/builders to map real delegated outputs and linkage refs.
+2. Add focused delegation tests in `tests/test_governed_repair_loop_delegation.py` covering schema validity, handoff continuity, forbidden path enforcement, delegation evidence, and owner purity.
+3. Make only surgical runtime updates if tests expose evidential gaps (e.g., missing emitted continuation/gating/execution linkage refs) while keeping ownership boundaries intact.
+4. Add required review and delivery artifacts:
+   - `docs/reviews/RVW-GRC-INTEGRATION-02.md`
+   - `docs/reviews/GRC-INTEGRATION-02-DELIVERY-REPORT.md`
+5. Run required pytest commands and any adjacent relevant tests, then commit and open PR message via MCP tool.

--- a/docs/reviews/GRC-INTEGRATION-02-DELIVERY-REPORT.md
+++ b/docs/reviews/GRC-INTEGRATION-02-DELIVERY-REPORT.md
@@ -1,0 +1,52 @@
+# GRC-INTEGRATION-02 Delivery Report
+
+## Files changed
+- `docs/review-actions/PLAN-GRC-INTEGRATION-02-2026-04-10.md`
+- `spectrum_systems/modules/runtime/governed_repair_loop_execution.py`
+- `tests/test_governed_repair_loop_delegation.py`
+- `docs/reviews/RVW-GRC-INTEGRATION-02.md`
+- `docs/reviews/GRC-INTEGRATION-02-DELIVERY-REPORT.md`
+
+## Tests added
+- New delegation-truth suite: `tests/test_governed_repair_loop_delegation.py`
+  - schema-valid stage artifacts
+  - stage linkage continuity
+  - forbidden path enforcement
+  - builder-contract replay evidence
+  - owner-purity assertions
+
+## Runtime changes required
+Yes, surgical continuity-evidence updates in governed loop execution:
+- Include `continuation_input` in trace outputs.
+- Include `gating_input_ref` in TPA gating decision outputs.
+- Include `approved_slice_ref` and `gating_input_ref` in PQX execution outputs.
+- Include `execution_record_ref` in review output.
+- Bind TLC resume `trigger_ref` to the PQX execution record ref.
+
+## Artifact schemas validated
+- `execution_failure_packet`
+- `bounded_repair_candidate_artifact`
+- `cde_repair_continuation_input`
+- `tpa_repair_gating_input`
+- `resume_record`
+
+## Linkage refs now proven
+- candidate -> failure packet
+- continuation input -> failure packet + repair candidate
+- CDE decision -> continuation input
+- TPA gating decision -> gating input
+- PQX execution -> approved TPA slice + gating input
+- review output -> PQX execution record
+- resume record -> PQX execution record trigger
+
+## Forbidden branches proven
+- High risk/complexity rejection blocks before PQX.
+- Retry budget exhaustion blocks before PQX.
+- Policy-blocked classification stops continuation before execution.
+- Unrepaired review outcome halts before TLC resume.
+
+## Remaining trust gap
+- PQX execution/review artifacts in this loop are still lightweight records (not full canonical PQX/RQX contract artifacts), but cross-stage continuity and builder-contract conformance are now explicitly enforced in integration tests.
+
+## Next recommended step
+- Promote execution/review stage outputs to full canonical artifact envelopes in-loop, then extend this delegation suite to schema-validate those envelopes directly.

--- a/docs/reviews/RVW-GRC-INTEGRATION-02.md
+++ b/docs/reviews/RVW-GRC-INTEGRATION-02.md
@@ -1,0 +1,22 @@
+# RVW-GRC-INTEGRATION-02
+
+## 1) Do the new tests prove schema-valid stage artifacts?
+Yes. The delegation test suite validates `execution_failure_packet`, `bounded_repair_candidate_artifact`, `cde_repair_continuation_input`, `tpa_repair_gating_input`, and `resume_record` with contract validators in-loop.
+
+## 2) Do they prove real stage-to-stage linkage continuity?
+Yes. The tests assert explicit handoff references from packet -> candidate -> continuation input -> TPA gating input -> PQX execution -> RQX/RIL review -> TLC resume trigger.
+
+## 3) Do they prove forbidden paths actually stop execution?
+Yes. Tests cover risk-budget rejection, retry exhaustion, policy-blocked stop, and unrepaired review outcome; all assert no forbidden PQX execution or TLC resume continuation occurs.
+
+## 4) Is there still any risk that the orchestration layer is faking ownership via assembled dicts?
+Residual risk remains but is reduced. Builder-contract replay assertions now reconstruct packet/candidate/continuation/gating artifacts through canonical builders and require emitted trace artifacts to match exactly, raising the bar beyond owner-label stamping.
+
+## 5) Did any runtime change introduce ownership bleed?
+No. Runtime changes were limited to continuity evidence fields (`continuation_input` trace emission, `gating_input_ref`, `approved_slice_ref`, `execution_record_ref`, resume trigger linkage) without moving decision or execution authority across subsystem boundaries.
+
+## 6) Is the governed repair loop now materially more trustworthy than after GRC-INTEGRATION-01?
+Yes. The loop is now validated for schema-backed artifact production, linkage continuity, forbidden-branch halting, and stronger delegation evidence.
+
+## Verdict
+**DELEGATION PROVEN**

--- a/spectrum_systems/modules/runtime/governed_repair_loop_execution.py
+++ b/spectrum_systems/modules/runtime/governed_repair_loop_execution.py
@@ -183,24 +183,55 @@ def _cde_decide(continuation_input: dict[str, Any], *, force_stop: bool) -> dict
 
 
 def _tpa_gate(gating_input: dict[str, Any], *, policy_blocked: bool) -> dict[str, Any]:
+    gating_input_ref = f"tpa_repair_gating_input:{gating_input['gating_input_id']}"
     constraints_missing = not bool(gating_input.get("repair_scope_refs")) or not bool(gating_input.get("allowed_artifact_refs"))
     if constraints_missing:
-        return {"approved": False, "owner": "TPA", "reason": "missing_constraints", "approved_slice": None}
+        return {
+            "approved": False,
+            "owner": "TPA",
+            "reason": "missing_constraints",
+            "approved_slice": None,
+            "gating_input_ref": gating_input_ref,
+        }
     if policy_blocked:
-        return {"approved": False, "owner": "TPA", "reason": "policy_blocked", "approved_slice": None}
+        return {
+            "approved": False,
+            "owner": "TPA",
+            "reason": "policy_blocked",
+            "approved_slice": None,
+            "gating_input_ref": gating_input_ref,
+        }
     if gating_input["retry_budget_remaining"] <= 0:
-        return {"approved": False, "owner": "TPA", "reason": "retry_budget_exhausted", "approved_slice": None}
+        return {
+            "approved": False,
+            "owner": "TPA",
+            "reason": "retry_budget_exhausted",
+            "approved_slice": None,
+            "gating_input_ref": gating_input_ref,
+        }
     if gating_input["risk_level"] == "high" and gating_input["complexity_score"] > 3:
-        return {"approved": False, "owner": "TPA", "reason": "risk_budget_exceeded", "approved_slice": None}
+        return {
+            "approved": False,
+            "owner": "TPA",
+            "reason": "risk_budget_exceeded",
+            "approved_slice": None,
+            "gating_input_ref": gating_input_ref,
+        }
     approved_slice = {
         "slice_id": f"repair:{gating_input['gating_input_id']}",
         "scope_refs": list(gating_input["repair_scope_refs"]),
         "allowed_artifact_refs": list(gating_input["allowed_artifact_refs"]),
     }
-    return {"approved": True, "owner": "TPA", "reason": "approved", "approved_slice": approved_slice}
+    return {
+        "approved": True,
+        "owner": "TPA",
+        "reason": "approved",
+        "approved_slice": approved_slice,
+        "gating_input_ref": gating_input_ref,
+    }
 
 
-def _pqx_execute(*, approved_slice: dict[str, Any], trace_id: str) -> dict[str, Any]:
+def _pqx_execute(*, approved_slice: dict[str, Any], trace_id: str, gating_input_ref: str) -> dict[str, Any]:
     for ref in approved_slice["scope_refs"]:
         if ref not in set(approved_slice["allowed_artifact_refs"]):
             raise GovernedRepairLoopExecutionError("PQX attempted to execute outside TPA-approved scope")
@@ -208,12 +239,14 @@ def _pqx_execute(*, approved_slice: dict[str, Any], trace_id: str) -> dict[str, 
     return {
         "owner": "PQX",
         "pqx_slice_execution_record": f"pqx_slice_execution_record:{execution_id}",
+        "approved_slice_ref": approved_slice["slice_id"],
+        "gating_input_ref": gating_input_ref,
         "execution_status": "success",
         "trace_artifacts": [f"trace:{trace_id}:pqx_repair_execution", f"trace:{trace_id}:pqx_scope:{len(approved_slice['scope_refs'])}"],
     }
 
 
-def _rqx_ril_review(*, case: FailureCase, trace_id: str, tmp_dir: Path | None) -> dict[str, Any]:
+def _rqx_ril_review(*, case: FailureCase, trace_id: str, tmp_dir: Path | None, execution_record_ref: str) -> dict[str, Any]:
     repaired_required_artifacts, repaired_command = _load_repaired_readiness_inputs(case, tmp_dir=tmp_dir)
     repaired_readiness = evaluate_slice_artifact_readiness(
         slice_id=case.slice_id,
@@ -229,6 +262,7 @@ def _rqx_ril_review(*, case: FailureCase, trace_id: str, tmp_dir: Path | None) -
         "review_owner": "RQX",
         "interpretation_owner": "RIL",
         "repaired": repaired,
+        "execution_record_ref": execution_record_ref,
         "review_ref": f"review_result_artifact:{deterministic_id(prefix='rqr', namespace='grc_rqx_review', payload=[case.slice_id, repaired])}",
         "interpretation_ref": f"review_integration_packet_artifact:{deterministic_id(prefix='ril', namespace='grc_ril_interpret', payload=[case.slice_id, repaired])}",
         "follow_up_candidate_needed": not repaired,
@@ -236,7 +270,7 @@ def _rqx_ril_review(*, case: FailureCase, trace_id: str, tmp_dir: Path | None) -
     }
 
 
-def _build_resume_record(*, case: FailureCase, trace_id: str, run_id: str) -> dict[str, Any]:
+def _build_resume_record(*, case: FailureCase, trace_id: str, run_id: str, trigger_ref: str) -> dict[str, Any]:
     record = {
         "artifact_type": "resume_record",
         "schema_version": "1.0.0",
@@ -245,7 +279,7 @@ def _build_resume_record(*, case: FailureCase, trace_id: str, run_id: str) -> di
         "resume_reason": "repair_validated_resume_from_failed_slice",
         "resumed_at": _now_iso(),
         "validation_result": {"status": "valid", "reason_codes": ["RESUME_ALLOWED", "TRACE_CONTINUITY_CONFIRMED"]},
-        "trigger_ref": f"slice:{case.slice_id}",
+        "trigger_ref": trigger_ref,
         "trace": {"trace_id": trace_id, "agent_run_id": run_id},
     }
     validate_artifact(record, "resume_record")
@@ -316,6 +350,7 @@ def run_governed_repair_loop(
                 "failure": readiness,
                 "packet": packet,
                 "candidate": candidate,
+                "continuation_input": continuation_input,
                 "decision": cde_decision,
             },
         }
@@ -337,14 +372,24 @@ def run_governed_repair_loop(
                 "failure": readiness,
                 "packet": packet,
                 "candidate": candidate,
+                "continuation_input": continuation_input,
                 "decision": cde_decision,
                 "gating_input": gating_input,
                 "gating_decision": tpa_decision,
             },
         }
 
-    execution = _pqx_execute(approved_slice=tpa_decision["approved_slice"], trace_id=trace_id)
-    review = _rqx_ril_review(case=case, trace_id=trace_id, tmp_dir=tmp_dir)
+    execution = _pqx_execute(
+        approved_slice=tpa_decision["approved_slice"],
+        trace_id=trace_id,
+        gating_input_ref=tpa_decision["gating_input_ref"],
+    )
+    review = _rqx_ril_review(
+        case=case,
+        trace_id=trace_id,
+        tmp_dir=tmp_dir,
+        execution_record_ref=execution["pqx_slice_execution_record"],
+    )
     if not review["repaired"]:
         return {
             "status": "not_repaired",
@@ -353,6 +398,7 @@ def run_governed_repair_loop(
                 "failure": readiness,
                 "packet": packet,
                 "candidate": candidate,
+                "continuation_input": continuation_input,
                 "decision": cde_decision,
                 "gating_input": gating_input,
                 "gating_decision": tpa_decision,
@@ -361,7 +407,12 @@ def run_governed_repair_loop(
             },
         }
 
-    resume_record = _build_resume_record(case=case, trace_id=trace_id, run_id=run_id)
+    resume_record = _build_resume_record(
+        case=case,
+        trace_id=trace_id,
+        run_id=run_id,
+        trigger_ref=execution["pqx_slice_execution_record"],
+    )
     return {
         "status": "resumed",
         "stop_reason": None,
@@ -369,6 +420,7 @@ def run_governed_repair_loop(
             "failure": readiness,
             "packet": packet,
             "candidate": candidate,
+            "continuation_input": continuation_input,
             "decision": cde_decision,
             "gating_input": gating_input,
             "gating_decision": tpa_decision,

--- a/tests/test_governed_repair_loop_delegation.py
+++ b/tests/test_governed_repair_loop_delegation.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from spectrum_systems.contracts import validate_artifact
+from spectrum_systems.modules.runtime import governed_repair_loop_execution as loop_module
+from spectrum_systems.modules.runtime.governed_repair_foundation import (
+    build_bounded_repair_candidate,
+    build_cde_repair_continuation_input,
+    build_execution_failure_packet,
+    build_tpa_repair_gating_input,
+)
+
+
+def _run(case_id: str, tmp_path: Path, **overrides):
+    payload = {
+        "failure_case_id": case_id,
+        "batch_id": "GRC-INTEGRATION-02",
+        "umbrella_id": "GOVERNED_REPAIR_LOOP_CLOSURE",
+        "run_id": f"run-{case_id.lower()}",
+        "trace_id": f"trace-{case_id.lower()}",
+        "retry_budget": 2,
+        "complexity_score": 2,
+        "risk_level": "medium",
+        "tmp_dir": tmp_path / case_id.lower(),
+    }
+    payload.update(overrides)
+    return loop_module.run_governed_repair_loop(**payload)
+
+
+def test_schema_valid_stage_artifacts_and_linkage_for_aut05(tmp_path: Path) -> None:
+    result = _run("AUT-05", tmp_path)
+    trace = result["trace"]
+
+    validate_artifact(trace["packet"], "execution_failure_packet")
+    validate_artifact(trace["candidate"], "bounded_repair_candidate_artifact")
+    validate_artifact(trace["continuation_input"], "cde_repair_continuation_input")
+    validate_artifact(trace["gating_input"], "tpa_repair_gating_input")
+    validate_artifact(trace["resume"]["resume_record"], "resume_record")
+
+    packet = trace["packet"]
+    candidate = trace["candidate"]
+    continuation_input = trace["continuation_input"]
+    gating_input = trace["gating_input"]
+    execution = trace["execution"]
+    review = trace["review"]
+    resume = trace["resume"]["resume_record"]
+
+    assert candidate["failure_packet_ref"] == f"execution_failure_packet:{packet['failure_packet_id']}"
+    assert continuation_input["failure_packet_ref"] == f"execution_failure_packet:{packet['failure_packet_id']}"
+    assert continuation_input["repair_candidate_ref"] == f"bounded_repair_candidate_artifact:{candidate['candidate_id']}"
+    assert trace["decision"]["continuation_input_ref"] == (
+        f"cde_repair_continuation_input:{continuation_input['continuation_input_id']}"
+    )
+
+    assert gating_input["repair_candidate_ref"] == f"bounded_repair_candidate_artifact:{candidate['candidate_id']}"
+    assert gating_input["failure_packet_ref"] == f"execution_failure_packet:{packet['failure_packet_id']}"
+    assert trace["gating_decision"]["gating_input_ref"] == f"tpa_repair_gating_input:{gating_input['gating_input_id']}"
+
+    assert execution["approved_slice_ref"] == trace["gating_decision"]["approved_slice"]["slice_id"]
+    assert execution["gating_input_ref"] == trace["gating_decision"]["gating_input_ref"]
+    assert review["execution_record_ref"] == execution["pqx_slice_execution_record"]
+    assert resume["trigger_ref"] == execution["pqx_slice_execution_record"]
+
+
+def test_builder_contract_replay_matches_emitted_artifacts_for_aut05(tmp_path: Path) -> None:
+    result = _run("AUT-05", tmp_path)
+    trace = result["trace"]
+
+    expected_packet = build_execution_failure_packet(
+        readiness_result=trace["failure"],
+        execution_refs=["slice_execution:AUT-05"],
+        trace_refs=["trace:trace-aut-05:failure"],
+        enforcement_refs=["system_enforcement_result_artifact:sel:AUT-05"],
+        validation_refs=["validation_ref:AUT-05:readiness"],
+        batch_id="GRC-INTEGRATION-02",
+        umbrella_id="GOVERNED_REPAIR_LOOP_CLOSURE",
+        roadmap_context_ref="contracts/roadmap/roadmap_structure.json",
+    )
+    expected_candidate = build_bounded_repair_candidate(failure_packet=expected_packet)
+    expected_continuation = build_cde_repair_continuation_input(
+        failure_packet=expected_packet,
+        repair_candidate=expected_candidate,
+    )
+    expected_gating_input = build_tpa_repair_gating_input(
+        failure_packet=expected_packet,
+        repair_candidate=expected_candidate,
+        retry_budget_remaining=1,
+        complexity_score=2,
+        risk_level="medium",
+    )
+
+    assert trace["packet"] == expected_packet
+    assert trace["candidate"] == expected_candidate
+    assert trace["continuation_input"] == expected_continuation
+    assert trace["gating_input"] == expected_gating_input
+
+
+def test_aut07_real_artifacts_are_materialized_and_linked(tmp_path: Path) -> None:
+    result = _run("AUT-07", tmp_path)
+    trace = result["trace"]
+
+    for artifact_ref in trace["failure"]["checked_artifact_refs"]:
+        assert Path(artifact_ref).is_file()
+
+    validate_artifact(trace["packet"], "execution_failure_packet")
+    validate_artifact(trace["candidate"], "bounded_repair_candidate_artifact")
+    assert trace["candidate"]["failure_packet_ref"] == (
+        f"execution_failure_packet:{trace['packet']['failure_packet_id']}"
+    )
+
+
+def test_forbidden_paths_halt_execution_and_resume(tmp_path: Path) -> None:
+    high_risk = _run("AUT-05", tmp_path, complexity_score=9, risk_level="high")
+    assert high_risk["status"] == "blocked"
+    assert high_risk["stop_reason"] == "risk_budget_exceeded"
+    assert "execution" not in high_risk["trace"]
+    assert "resume" not in high_risk["trace"]
+
+    retry_exhausted = _run("AUT-10", tmp_path, retry_budget=1)
+    assert retry_exhausted["status"] == "blocked"
+    assert retry_exhausted["stop_reason"] == "retry_budget_exhausted"
+    assert "execution" not in retry_exhausted["trace"]
+    assert "resume" not in retry_exhausted["trace"]
+
+    policy_blocked = _run("AUT-05", tmp_path, policy_blocked=True)
+    assert policy_blocked["status"] == "stopped"
+    assert policy_blocked["trace"]["packet"]["classified_failure_type"] == "policy_blocked"
+    assert "execution" not in policy_blocked["trace"]
+    assert "resume" not in policy_blocked["trace"]
+
+
+def test_no_resume_when_review_reports_not_repaired(tmp_path: Path, monkeypatch) -> None:
+    original = loop_module.evaluate_slice_artifact_readiness
+
+    def _blocked_repaired_readiness(*, command: str, **kwargs):
+        if "decision['control_decision']" in command:
+            blocked = original(command="python -c \"build_review_roadmap(snapshot=snapshot, control_decision=decision)\"", **kwargs)
+            blocked["status"] = "blocked"
+            return blocked
+        return original(command=command, **kwargs)
+
+    monkeypatch.setattr(loop_module, "evaluate_slice_artifact_readiness", _blocked_repaired_readiness)
+    result = _run("AUT-05", tmp_path)
+
+    assert result["status"] == "not_repaired"
+    assert result["trace"]["review"]["repaired"] is False
+    assert "resume" not in result["trace"]
+
+
+def test_owner_purity_across_delegated_stages(tmp_path: Path) -> None:
+    result = _run("AUT-05", tmp_path)
+    trace = result["trace"]
+
+    assert trace["failure"]["owning_system"] == "RIL"
+    assert trace["packet"]["artifact_type"] == "execution_failure_packet"
+    assert trace["candidate"]["artifact_type"] == "bounded_repair_candidate_artifact"
+    assert trace["decision"]["decision_owner"] == "CDE"
+    assert trace["gating_decision"]["owner"] == "TPA"
+    assert trace["execution"]["owner"] == "PQX"
+    assert trace["review"]["review_owner"] == "RQX"
+    assert trace["review"]["interpretation_owner"] == "RIL"
+    assert trace["resume"]["owner"] == "TLC"


### PR DESCRIPTION
### Motivation

- Strengthen trust that `run_governed_repair_loop(...)` produces real, schema-valid artifacts and preserves stage-to-stage lineage rather than just returning assembled trace dicts.
- Provide automated, artifact-first evidence that subsystem boundaries and forbidden branches are enforced end-to-end without widening runtime authority.

### Description

- Add a focused delegation-truth test suite in `tests/test_governed_repair_loop_delegation.py` that validates artifact schemas, stage linkage, forbidden-path halting, builder-contract replay, and owner-purity assertions.
- Make surgical runtime continuity-evidence updates in `spectrum_systems/modules/runtime/governed_repair_loop_execution.py` to emit canonical handoff refs including `continuation_input` in traces, `gating_input_ref` on TPA decisions, `approved_slice_ref` and `gating_input_ref` on PQX execution outputs, `execution_record_ref` in review outputs, and bind the TLC `resume_record.trigger_ref` to the PQX execution record.
- Add plan and review artifacts for the change: `docs/review-actions/PLAN-GRC-INTEGRATION-02-2026-04-10.md`, `docs/reviews/RVW-GRC-INTEGRATION-02.md`, and `docs/reviews/GRC-INTEGRATION-02-DELIVERY-REPORT.md` documenting scope, findings, and next steps.

### Testing

- Ran `pytest tests/test_governed_repair_loop_execution.py -q` and the suite passed (6 passed). 
- Ran `pytest tests/test_governed_repair_loop_delegation.py -q` and the new delegation tests passed (6 passed).
- Ran `pytest tests/test_contracts.py -q` and contract validation passed (80 passed), exercising schema validators used by the new tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9568395108329961c2bff1cedcef5)