### PR TITLE
REGISTRY-ALIGN-01: Align system_registry for learning, control-prep, and roadmap-design

### DIFF
--- a/docs/architecture/system_registry.md
+++ b/docs/architecture/system_registry.md
@@ -219,6 +219,9 @@ CDE is the only system allowed to emit:
   - review_interpretation
   - review_integration
   - review_projection
+  - evaluation_interpretation
+  - drift_interpretation
+  - control_input_interpretation_support
 - **consumes:**
   - review_artifact
   - review_signal_artifact
@@ -230,6 +233,9 @@ CDE is the only system allowed to emit:
 - **must_not_do:**
   - enforce policy decisions (SEL-owned)
   - execute work or repairs (PQX-owned)
+  - generate repair plans (FRE-owned)
+  - prioritize adoption candidates (PRG-owned)
+  - issue policy authority decisions (TPA-owned)
   - decide closure state (CDE-owned)
 
 ### RQX
@@ -297,6 +303,7 @@ CDE is the only system allowed to emit:
   - review_signal_artifact
   - review_action_tracker_artifact
 - **produces:**
+  - cde_control_decision_output
   - closure_decision_artifact
 - **must_not_do:**
   - execute work (PQX-owned)
@@ -344,6 +351,10 @@ CDE is the only system allowed to emit:
   - program_governance
   - roadmap_alignment
   - program_drift_management
+  - evaluation_pattern_aggregation
+  - recommendation_generation
+  - adoption_candidate_prioritization
+  - adaptive_readiness_recommendation
 - **consumes:**
   - roadmap_signal_bundle
   - roadmap_review_view_artifact
@@ -351,12 +362,63 @@ CDE is the only system allowed to emit:
 - **produces:**
   - program_brief
   - program_feedback_record
+  - evaluation_pattern_report
+  - policy_change_candidate
+  - slice_contract_update_candidate
+  - program_alignment_assessment
+  - prioritized_adoption_candidate_set
+  - adaptive_readiness_record
   - program_roadmap_alignment_result
 - **must_not_do:**
   - execute bounded work (PQX-owned)
+  - gate execution admission (AEX/TPA-owned)
   - enforce runtime blocks (SEL-owned)
   - interpret review integration packets (RIL-owned)
+  - issue closure authority decisions (CDE-owned)
+  - issue policy authority decisions (TPA-owned)
   - influence runtime execution authority or admission decisions (PQX/AEX-owned)
+
+## Control-Prep Artifact Rule (Non-Authoritative)
+- The following artifacts are **preparatory only** and **MUST NOT** be treated as authoritative decisions:
+  - `control_signal_fusion_record`
+  - `prioritized_adoption_candidate_set`
+  - `cde_control_decision_input`
+  - `tpa_policy_update_input`
+  - `control_prep_readiness_record`
+- These preparatory artifacts may:
+  - fuse signals
+  - rank bounded options
+  - prepare future authority inputs
+  - assess readiness for a future governed cycle
+- These preparatory artifacts must **NOT**:
+  - authorize closure
+  - authorize enforcement
+  - authorize policy application
+  - substitute for CDE outputs
+  - substitute for TPA outputs
+
+## Learning / Detection / Recommendation Artifact Ownership
+| Artifact | Canonical owner | Constraint |
+| --- | --- | --- |
+| `evaluation_summary_artifact` | RIL | Interpretation artifact only; non-authoritative. |
+| `execution_observability_artifact` | RIL | Observation/interpretation only; no execution mutation authority. |
+| `drift_detection_record` | RIL | Detection artifact only; no direct runtime action. |
+| `slice_failure_pattern_record` | RIL | Pattern interpretation only; no repair execution authority. |
+| `evaluation_pattern_report` | PRG | Recommendation input only; non-authoritative. |
+| `policy_change_candidate` | PRG | Candidate artifact only; requires TPA authority output before policy application. |
+| `slice_contract_update_candidate` | PRG | Candidate artifact only; no direct execution effect. |
+| `program_alignment_assessment` | PRG | Governance assessment only; non-authoritative for closure/enforcement. |
+| `program_roadmap_alignment_result` | PRG | Program alignment output only; no closure authority. |
+| `adaptive_readiness_record` | PRG | Recommendation artifact only; cannot substitute for CDE closure/readiness decisions. |
+
+## CDE/TPA Authority Boundary: Prep vs Authority
+- **CDE boundary**
+  - `cde_control_decision_input` is a non-authoritative preparatory artifact.
+  - CDE decision outputs (including `closure_decision_artifact` and `cde_control_decision_output`) are authoritative.
+- **TPA boundary**
+  - `tpa_policy_update_input` is a non-authoritative preparatory artifact.
+  - TPA policy outputs (`allow`, `reject`, `narrow`, `evidence_required`) are authoritative.
+- Preparatory artifacts may be consumed by future governed cycles, but may not be treated as authority artifacts themselves.
 
 ## Anti-Duplication Table
 | Invalid behavior | Why invalid | Canonical owner |
@@ -377,6 +439,11 @@ CDE is the only system allowed to emit:
 | PQX accepts repo-writing requests directly | Execution system cannot be public repo-write entrypoint | AEX |
 | AEX executes work | Admission boundary cannot execute bounded work | PQX |
 | AEX decides trust/policy admissibility | Admission boundary cannot own trust-policy authority | TPA |
+| PRG emits authoritative closure or gating decisions | Recommendation/planning cannot become decision authority | CDE / TPA |
+| RIL ranks adoption candidates | Interpretation layer cannot own program prioritization | PRG |
+| TLC emits control decisions from prep artifacts | Orchestration cannot convert preparatory inputs into authority outputs | CDE / TPA |
+| Control-prep artifacts treated as final decisions | Preparatory artifacts cannot substitute for authority decisions | CDE / TPA |
+| Drift detection directly changes runtime behavior | Detection cannot directly mutate runtime behavior outside governed authority paths | TPA / SEL / PQX via governed cycle |
 
 ## Allowed Interaction Graph
 - AEX → TLC
@@ -417,6 +484,32 @@ CDE is the only system allowed to emit:
   - PQX is the only execution path for applying repairs and rerunning tests.
   - SEL enforces scope, retry budget, and decision-state boundaries for each repair attempt.
 
+## Serial Multi-Umbrella Execution Rule
+- When multiple umbrellas are executed in one governed serial cycle:
+  - each umbrella **MUST** fully complete before the next umbrella begins
+  - each umbrella **MUST** emit its own `umbrella_decision_artifact`
+  - later umbrellas may consume prior umbrella outputs
+  - later umbrellas **MUST NOT** mutate prior umbrella outputs
+  - any fail-closed stop condition halts the serial cycle unless a bounded permitted fix cycle is explicitly invoked
+
+## Roadmap Design Rules (Registry Alignment Constitution)
+1. Every roadmap row **MUST** map to one canonical system owner from this registry.
+2. No roadmap row may assign a responsibility to a non-owner.
+3. Preparatory rows that produce future authority inputs **MUST** be labeled non-authoritative.
+4. Decision rows **MUST** invoke the authoritative decision owner (CDE/TPA), never a recommendation/prep layer.
+5. Execution rows **MUST** route execution through PQX.
+6. Enforcement rows **MUST** route enforcement through SEL.
+7. Repo-mutating rows **MUST** preserve lineage `AEX → TLC → TPA → PQX`.
+8. Review-related rows **MUST** distinguish:
+   - RQX review-loop execution
+   - RIL interpretation/projection
+9. Roadmaps **MUST** separate:
+   - observe / interpret / recommend / prepare
+   - decide / gate / enforce / execute
+10. Multi-umbrella roadmap bundles **MUST** preserve complete per-umbrella completion boundaries.
+11. Batch and umbrella decision artifacts control progression only and **MUST NOT** substitute for CDE closure authority.
+12. New roadmap proposals **MUST** be duplication-checked against this registry before admission.
+
 ## System Invariants
 1. Execution is owned only by **PQX**.
 2. Recovery and repair planning are owned only by **FRE**.
@@ -427,6 +520,15 @@ CDE is the only system allowed to emit:
 7. Program governance is owned only by **PRG**.
 8. Review-loop execution is owned only by **RQX**.
 9. Repo-mutation admission is owned only by **AEX**.
+
+## Roadmap Alignment Checklist (Lightweight)
+- Does each roadmap row map to exactly one canonical owner?
+- Is any preparatory artifact being treated as an authority artifact?
+- Does any recommendation layer implicitly decide, gate, or enforce?
+- Does any orchestration layer perform execution or policy reasoning?
+- Are serial umbrella completion boundaries explicit?
+- Are repo-mutation paths preserving `AEX → TLC → TPA → PQX` lineage?
+- Are batch/umbrella decision artifacts being misused as closure authority?
 
 ## Canonical Repo-Mutation Path
 

--- a/docs/review-actions/PLAN-REGISTRY-ALIGN-01-2026-04-10.md
+++ b/docs/review-actions/PLAN-REGISTRY-ALIGN-01-2026-04-10.md
@@ -1,0 +1,25 @@
+# Plan — REGISTRY-ALIGN-01 — 2026-04-10
+
+## Prompt type
+PLAN
+
+## Scope
+Align `docs/architecture/system_registry.md` to current governed ownership boundaries for learning, control-prep, serial multi-umbrella execution, and roadmap-design constitution guidance while preserving single-responsibility ownership and anti-duplication constraints.
+
+## Files in scope
+| File | Action | Purpose |
+| --- | --- | --- |
+| `docs/architecture/system_registry.md` | MODIFY | Add and clarify ownership, prep-vs-authority rules, anti-duplication rows, serial umbrella execution constraints, and roadmap-design rules/checklist. |
+| `docs/reviews/RVW-REGISTRY-ALIGN-01.md` | ADD | Record consistency review, boundary checks, verdict, and remaining ambiguity scan. |
+| `docs/reviews/REGISTRY-ALIGN-01-DELIVERY-REPORT.md` | ADD | Summarize delivered registry changes and readiness as roadmap-alignment constitution. |
+
+## Constraints
+- Do not create new systems or rename existing systems.
+- Preserve hard ownership boundaries and fail-closed governance posture.
+- Keep preparatory artifacts explicitly non-authoritative.
+- Keep wording constitutional, enforceable, and concise.
+- Keep terminology normalized: execution, artifact, failure, retrieve.
+
+## Validation
+1. Manual consistency pass on `docs/architecture/system_registry.md` for ownership conflicts and prep-vs-authority boundaries.
+2. `python -m json.tool docs/reviews/review-registry.json >/dev/null` (repository seam sanity check for review registry integrity; no schema mutation expected).

--- a/docs/reviews/REGISTRY-ALIGN-01-DELIVERY-REPORT.md
+++ b/docs/reviews/REGISTRY-ALIGN-01-DELIVERY-REPORT.md
@@ -1,0 +1,46 @@
+# REGISTRY-ALIGN-01 Delivery Report
+
+## Prompt type
+VALIDATE
+
+## Batch
+- `REGISTRY-ALIGN-01`
+
+## Umbrella
+- `GOVERNANCE_CONSTITUTION_ALIGNMENT`
+
+## Sections updated/added in `docs/architecture/system_registry.md`
+- Updated `RIL` ownership and constraints to include evaluation/drift/control-input interpretation support and preserve non-authority boundaries.
+- Updated `PRG` ownership and constraints to include evaluation pattern aggregation, recommendation generation, adoption prioritization, and adaptive readiness recommendation without authority crossover.
+- Added **Control-Prep Artifact Rule (Non-Authoritative)** section.
+- Added **Learning / Detection / Recommendation Artifact Ownership** section.
+- Added **CDE/TPA Authority Boundary: Prep vs Authority** section.
+- Extended **Anti-Duplication Table** with new prep/recommendation/drift rows.
+- Added **Serial Multi-Umbrella Execution Rule** section.
+- Added **Roadmap Design Rules (Registry Alignment Constitution)** section.
+- Added **Roadmap Alignment Checklist (Lightweight)** section.
+
+## Ownership clarifications made
+- RIL now explicitly owns interpretation surfaces (`review`, `evaluation`, `drift`, and `control_input_interpretation_support`) but remains non-execution, non-enforcement, non-authority.
+- PRG now explicitly owns recommendation/prioritization surfaces and adaptive readiness recommendation while remaining non-execution and non-authority.
+- CDE and TPA authority outputs are explicitly separated from preparatory inputs (`cde_control_decision_input`, `tpa_policy_update_input`).
+
+## New anti-duplication rows added
+- PRG authoritative closure/gating output emission is invalid; canonical owner is CDE/TPA.
+- RIL adoption candidate ranking is invalid; canonical owner is PRG.
+- TLC control-decision emission from prep artifacts is invalid; canonical owner is CDE/TPA.
+- Treating control-prep artifacts as final decisions is invalid; canonical owner is CDE/TPA.
+- Drift detection directly changing runtime behavior is invalid; governed authority path remains TPA/SEL/PQX via governed cycle.
+
+## New roadmap-design guidance added
+- Explicit owner mapping requirement per roadmap row.
+- Explicit non-authoritative labeling for prep rows.
+- Decision-row owner constraints bound to CDE/TPA.
+- Execution and enforcement routing constraints bound to PQX/SEL.
+- Mandatory repo-mutation lineage `AEX → TLC → TPA → PQX`.
+- Mandatory separation of observe/interpret/recommend/prepare from decide/gate/enforce/execute.
+- Mandatory completion boundaries for serial multi-umbrella bundles.
+- Mandatory duplication check against the registry before roadmap admission.
+
+## Readiness statement
+The registry is now ready to serve as the canonical roadmap-alignment document for future roadmap design, with explicit prep-vs-authority boundaries and enforceable owner routing constraints.

--- a/docs/reviews/RVW-REGISTRY-ALIGN-01.md
+++ b/docs/reviews/RVW-REGISTRY-ALIGN-01.md
@@ -1,0 +1,34 @@
+# Review — REGISTRY-ALIGN-01
+
+## Prompt type
+REVIEW
+
+## Scope
+Review `docs/architecture/system_registry.md` alignment after REGISTRY-ALIGN-01 updates for learning ownership, control-prep boundaries, serial umbrella execution constraints, and roadmap-design governance rules.
+
+## Questions and answers
+
+### 1) Did the updated registry remain consistent with the existing canonical system boundaries?
+Yes. The update preserves existing system names and role boundaries and retains single-responsibility ownership language. No new system was introduced and no existing owner was renamed or reassigned.
+
+### 2) Did it correctly add the newer learning and control-prep surfaces?
+Yes. RIL and PRG ownership now include the newer interpretation/detection/recommendation surfaces, and a dedicated ownership table maps newly introduced artifacts to canonical owners.
+
+### 3) Did it preserve the distinction between preparatory artifacts and authoritative decisions?
+Yes. A dedicated non-authoritative control-prep rule now states mandatory non-authoritative status for preparatory artifacts and explicitly forbids substitution for CDE or TPA outputs. A CDE/TPA prep-vs-authority boundary section reinforces the same rule.
+
+### 4) Did it avoid creating any new system or ownership duplication?
+Yes. The anti-duplication table was extended to cover the new surfaces without introducing duplicate ownership. Invalid behavior rows now explicitly prevent prep/recommendation/orchestration layers from becoming shadow authority.
+
+### 5) Is it now materially more useful as a roadmap-alignment constitution?
+Yes. The new roadmap design rules and lightweight checklist make owner mapping, prep-vs-authority labeling, lineage, and umbrella completion boundaries explicit and enforceable for future roadmap generation.
+
+### 6) Are there any remaining ambiguities that could still confuse future roadmap design?
+Minor residual ambiguity remains around where recommendation artifacts should be persisted across long serial cycles. This does not change ownership boundaries, but future roadmap rows should continue to annotate artifact lifecycle and retrieve points explicitly.
+
+## Consistency pass performed
+- Performed a full manual consistency pass over the updated registry for ownership conflicts and prep-vs-authority violations.
+- Verified no contradiction against canonical role names and no ownership boundary inversion.
+
+## Verdict
+**REGISTRY ALIGNED**


### PR DESCRIPTION
### Motivation
- The canonical `docs/architecture/system_registry.md` was behind the built system and needed to reflect newer learning, drift, and control-prep surfaces while preserving single-responsibility ownership.
- The registry must explicitly distinguish non-authoritative preparatory artifacts from authoritative CDE/TPA outputs and prevent recommendation/prep layers from becoming shadow authority.
- The registry must encode serial multi-umbrella execution rules and concrete roadmap-design constraints so it can serve as a practical constitution for future roadmap generation.

### Description
- Updated `RIL` to own `evaluation_interpretation`, `drift_interpretation`, and `control_input_interpretation_support`, and tightened `must_not_do` constraints (e.g., cannot generate repairs, prioritize adoption candidates, or issue policy authority).
- Extended `PRG` ownership to include `evaluation_pattern_aggregation`, `recommendation_generation`, `adoption_candidate_prioritization`, and `adaptive_readiness_recommendation`, and added produced recommendation artifacts (e.g., `evaluation_pattern_report`, `policy_change_candidate`, `prioritized_adoption_candidate_set`) while preserving non-authority constraints.
- Added a constitutional `Control-Prep Artifact Rule` declaring specific preparatory artifacts (e.g., `control_signal_fusion_record`, `cde_control_decision_input`, `tpa_policy_update_input`) as non-authoritative, plus a `Learning / Detection / Recommendation Artifact Ownership` mapping table and an explicit `CDE/TPA Authority Boundary: Prep vs Authority` section.
- Extended the anti-duplication table with new invalid-behavior rows, added a `Serial Multi-Umbrella Execution Rule`, concrete `Roadmap Design Rules` (12 rules), and a short `Roadmap Alignment Checklist`; also added plan/review/delivery artifacts: `docs/review-actions/PLAN-REGISTRY-ALIGN-01-2026-04-10.md`, `docs/reviews/RVW-REGISTRY-ALIGN-01.md`, and `docs/reviews/REGISTRY-ALIGN-01-DELIVERY-REPORT.md`.

### Testing
- Ran `python -m json.tool docs/reviews/review-registry.json >/dev/null` to validate review-registry JSON integrity and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d97029394483299930863b4bd1eb32)