### PR TITLE
DASHBOARD-SNAPSHOT-01: add deterministic repo dashboard snapshot generator

### DIFF
--- a/artifacts/dashboard/repo_snapshot.json
+++ b/artifacts/dashboard/repo_snapshot.json
@@ -1,0 +1,120 @@
+{
+  "generated_at": "2026-04-11T00:20:42Z",
+  "repo_name": "spectrum-systems",
+  "root_counts": {
+    "files_total": 3629,
+    "runtime_modules": 151,
+    "tests": 344,
+    "contracts_total": 758,
+    "schemas": 410,
+    "examples": 348,
+    "docs": 983,
+    "run_artifacts": 151
+  },
+  "core_areas": [
+    {
+      "name": "artifacts",
+      "description": "Generated artifacts for governed execution."
+    },
+    {
+      "name": "contracts",
+      "description": "Schema and example contract artifacts."
+    },
+    {
+      "name": "docs",
+      "description": "Governance, architecture, and operating documentation."
+    },
+    {
+      "name": "runs",
+      "description": "Run artifacts and execution records."
+    },
+    {
+      "name": "spectrum_systems/modules/runtime",
+      "description": "Governed runtime module surface."
+    },
+    {
+      "name": "tests",
+      "description": "Deterministic validation and conformance coverage."
+    }
+  ],
+  "constitutional_center": [
+    "docs/architecture/system_registry.md",
+    "README.md",
+    "docs/review-actions/README.md",
+    "docs/roadmaps/system_roadmap.md"
+  ],
+  "runtime_hotspots": [
+    {
+      "area": "PQX",
+      "count": 17,
+      "note": "PQX orchestration and execution pathways."
+    },
+    {
+      "area": "Control",
+      "count": 21,
+      "note": "Control-layer and runtime gating logic."
+    },
+    {
+      "area": "Roadmap",
+      "count": 13,
+      "note": "Roadmap-linked execution and sequencing support."
+    },
+    {
+      "area": "Review",
+      "count": 11,
+      "note": "Review ingestion and projection interfaces."
+    },
+    {
+      "area": "Judgment",
+      "count": 6,
+      "note": "Judgment and policy decision logic."
+    },
+    {
+      "area": "Evaluation",
+      "count": 12,
+      "note": "Evaluation and quality validation modules."
+    },
+    {
+      "area": "Replay",
+      "count": 3,
+      "note": "Replay and rerun execution support."
+    },
+    {
+      "area": "Governed repair",
+      "count": 7,
+      "note": "Governed repair and remediation pathways."
+    }
+  ],
+  "operational_signals": [
+    {
+      "title": "Constitution present",
+      "status": "Strong",
+      "detail": "System registry foundation is present."
+    },
+    {
+      "title": "Governed execution surface",
+      "status": "Strong",
+      "detail": "Runtime and contract surfaces are both present."
+    },
+    {
+      "title": "Evidence and review density",
+      "status": "Strong",
+      "detail": "Review artifacts detected: 722 markdown files."
+    },
+    {
+      "title": "Roadmap sprawl risk",
+      "status": "Watch",
+      "detail": "Docs-to-runtime ratio: 6.51."
+    },
+    {
+      "title": "Runtime concentration",
+      "status": "Strong",
+      "detail": "Distinct runtime filename prefixes: 67."
+    },
+    {
+      "title": "Constitutional center coverage",
+      "status": "Strong",
+      "detail": "High-signal constitutional docs listed: 4."
+    }
+  ]
+}

--- a/docs/review-actions/PLAN-DASHBOARD-SNAPSHOT-01-2026-04-10.md
+++ b/docs/review-actions/PLAN-DASHBOARD-SNAPSHOT-01-2026-04-10.md
@@ -1,0 +1,28 @@
+# PLAN — DASHBOARD-SNAPSHOT-01
+
+- **Prompt Type:** PLAN
+- **Batch:** DASHBOARD-SNAPSHOT-01
+- **Umbrella:** REPO_OBSERVABILITY_LAYER
+- **Date:** 2026-04-10
+
+## Scope
+Build a deterministic, repo-native snapshot generator that emits `artifacts/dashboard/repo_snapshot.json` using filesystem inventory and simple heuristics aligned to the live dashboard contract.
+
+## Execution Steps
+1. Create `scripts/generate_repo_dashboard_snapshot.py` with deterministic repository scanning, compact contract emission, and `--output` support.
+2. Create `tests/test_generate_repo_dashboard_snapshot.py` to validate contract shape, output creation, deterministic list ordering, non-negative counts, custom output path support, and behavior with optional directories absent.
+3. Run required validation commands and generate `artifacts/dashboard/repo_snapshot.json`.
+4. Create `docs/reviews/RVW-DASHBOARD-SNAPSHOT-01.md` with verdict and answers to required review questions.
+5. Create `docs/reviews/DASHBOARD-SNAPSHOT-01-DELIVERY-REPORT.md` with files created, contract confirmation, validations, output location, and explicit v1 non-goals.
+
+## Determinism and Failure Rules
+- Deterministic ordering for emitted arrays and hotspot groups.
+- UTC ISO-8601 timestamp in `generated_at` only.
+- Fail closed on output-path or serialization failure (non-zero exit).
+- Ignore cache/temp directories (`.git`, `__pycache__`, `.pytest_cache`, `.mypy_cache`, `.venv`, `node_modules`, etc.).
+
+## Out of Scope
+- No dashboard contract redesign.
+- No generic analytics framework.
+- No prompt-driven logic.
+- No unrelated refactors.

--- a/docs/reviews/DASHBOARD-SNAPSHOT-01-DELIVERY-REPORT.md
+++ b/docs/reviews/DASHBOARD-SNAPSHOT-01-DELIVERY-REPORT.md
@@ -1,0 +1,41 @@
+# DASHBOARD-SNAPSHOT-01 Delivery Report
+
+- **Prompt Type:** VALIDATE
+- **Batch:** DASHBOARD-SNAPSHOT-01
+- **Umbrella:** REPO_OBSERVABILITY_LAYER
+- **Date:** 2026-04-11
+
+## Files created
+- `docs/review-actions/PLAN-DASHBOARD-SNAPSHOT-01-2026-04-10.md`
+- `scripts/generate_repo_dashboard_snapshot.py`
+- `tests/test_generate_repo_dashboard_snapshot.py`
+- `docs/reviews/RVW-DASHBOARD-SNAPSHOT-01.md`
+- `docs/reviews/DASHBOARD-SNAPSHOT-01-DELIVERY-REPORT.md`
+
+## Output contract implemented
+Implemented snapshot JSON contract with required fields:
+- `generated_at`
+- `repo_name`
+- `root_counts`
+- `core_areas`
+- `constitutional_center`
+- `runtime_hotspots`
+- `operational_signals`
+
+All contract arrays are emitted as deterministic lists, and `generated_at` is UTC ISO-8601.
+
+## Validation commands run
+- `python scripts/generate_repo_dashboard_snapshot.py`
+- `python scripts/generate_repo_dashboard_snapshot.py --output /tmp/repo_snapshot.json`
+- `pytest tests/test_generate_repo_dashboard_snapshot.py -q`
+
+## Snapshot output location
+- Default: `artifacts/dashboard/repo_snapshot.json`
+- Custom: user-provided via `--output <path>`
+
+## Intentional v1 non-goals
+- No contract redesign.
+- No generalized analytics platform.
+- No prompt-driven extraction logic.
+- No semantic deep classification beyond deterministic path/name heuristics.
+- No historical trend/diff layer.

--- a/docs/reviews/RVW-DASHBOARD-SNAPSHOT-01.md
+++ b/docs/reviews/RVW-DASHBOARD-SNAPSHOT-01.md
@@ -1,0 +1,35 @@
+# RVW-DASHBOARD-SNAPSHOT-01
+
+- **Prompt Type:** REVIEW
+- **Batch:** DASHBOARD-SNAPSHOT-01
+- **Umbrella:** REPO_OBSERVABILITY_LAYER
+- **Date:** 2026-04-11
+- **Verdict:** SNAPSHOT READY
+
+## 1) Does the snapshot reflect the real repo shape without inventing a parallel model?
+Yes. The generator inventories real filesystem surfaces and emits counts from repository-native paths (`docs/`, `contracts/`, `tests/`, `runs/`, `artifacts/`, and `spectrum_systems/modules/runtime`). Runtime hotspot classification is intentionally path/name keyword based and avoids synthetic architecture modeling.
+
+## 2) Is the contract stable enough for the live dashboard?
+Yes. The output shape is fixed, compact, deterministic, and aligned to the established contract:
+- Stable top-level keys
+- Stable `root_counts` keys
+- Deterministic sorting of `core_areas` and constitutional center paths
+- UTC ISO-8601 timestamp in `generated_at`
+
+## 3) Are the heuristics simple, deterministic, and honest?
+Yes. Heuristics are explicit and auditable:
+- Constitution presence by direct file existence check
+- Governed execution signal by runtime + contract surface presence
+- Review density from markdown inventory in review surfaces
+- Sprawl risk from docs/runtime ratio
+- Runtime concentration from filename prefix diversity
+
+## 4) Did the implementation avoid over-engineering?
+Yes. The script uses Python stdlib only, a straightforward CLI (`--output`), deterministic traversal, and direct JSON serialization. No framework layer or dynamic prompt logic was introduced.
+
+## 5) What are the obvious future upgrades for v2?
+1. Add optional strict schema validation for snapshot output.
+2. Add historical diff mode against prior snapshots.
+3. Expand run-artifact detection using a configurable include list.
+4. Add optional hotspot-to-owner mapping derived from canonical registry docs.
+5. Add lightweight CI check to ensure snapshot generation remains contract-compliant.

--- a/scripts/generate_repo_dashboard_snapshot.py
+++ b/scripts/generate_repo_dashboard_snapshot.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Generate deterministic repository snapshot for dashboard ingestion."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+IGNORED_DIRS = {
+    ".git",
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".venv",
+    "venv",
+    "node_modules",
+    ".tox",
+    ".ruff_cache",
+    ".idea",
+    ".vscode",
+}
+
+HOTSPOT_BUCKETS: list[tuple[str, tuple[str, ...], str]] = [
+    ("PQX", ("pqx",), "PQX orchestration and execution pathways."),
+    ("Control", ("control", "conductor", "slo"), "Control-layer and runtime gating logic."),
+    ("Roadmap", ("roadmap",), "Roadmap-linked execution and sequencing support."),
+    ("Review", ("review",), "Review ingestion and projection interfaces."),
+    ("Judgment", ("judg",), "Judgment and policy decision logic."),
+    ("Evaluation", ("eval", "factcheck"), "Evaluation and quality validation modules."),
+    ("Replay", ("replay",), "Replay and rerun execution support."),
+    (
+        "Governed repair",
+        ("repair", "remediation", "fix", "recovery"),
+        "Governed repair and remediation pathways.",
+    ),
+]
+
+
+@dataclass(frozen=True)
+class RepoSurface:
+    repo_root: Path
+    runtime_root: Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate dashboard repository snapshot JSON.")
+    parser.add_argument(
+        "--output",
+        default="artifacts/dashboard/repo_snapshot.json",
+        help="Output path for snapshot JSON.",
+    )
+    return parser.parse_args()
+
+
+def discover_repo_root() -> Path:
+    script_repo_root = Path(__file__).resolve().parents[1]
+    cwd = Path.cwd().resolve()
+
+    if (cwd / ".git").exists() and (cwd / "README.md").exists():
+        return cwd
+    if (script_repo_root / ".git").exists():
+        return script_repo_root
+
+    raise RuntimeError("Unable to locate repository root.")
+
+
+def iter_repo_files(repo_root: Path) -> Iterable[Path]:
+    for path in sorted(repo_root.rglob("*")):
+        relative_parts = path.relative_to(repo_root).parts
+        if any(part in IGNORED_DIRS for part in relative_parts):
+            continue
+        if path.is_file():
+            yield path
+
+
+def detect_runtime_root(repo_root: Path) -> Path:
+    preferred = repo_root / "spectrum_systems/modules/runtime"
+    if preferred.exists():
+        return preferred
+
+    candidates = sorted(
+        [
+            p
+            for p in repo_root.rglob("runtime")
+            if p.is_dir() and "spectrum_systems" in p.parts and not any(part in IGNORED_DIRS for part in p.parts)
+        ]
+    )
+    if candidates:
+        return candidates[0]
+    return preferred
+
+
+def count_docs(repo_root: Path) -> int:
+    doc_suffixes = {".md", ".mdx", ".rst", ".txt"}
+    total = 0
+    docs_root = repo_root / "docs"
+    if docs_root.exists():
+        total += sum(1 for p in docs_root.rglob("*") if p.is_file() and p.suffix.lower() in doc_suffixes)
+
+    for top_doc in ["README.md", "CONSTITUTION.md", "GOVERNANCE.md"]:
+        if (repo_root / top_doc).is_file():
+            total += 1
+
+    return total
+
+
+def build_core_areas(repo_root: Path, runtime_root: Path) -> list[dict[str, str]]:
+    area_candidates = [
+        ("docs", "Governance, architecture, and operating documentation."),
+        ("contracts", "Schema and example contract artifacts."),
+        (str(runtime_root.relative_to(repo_root)), "Governed runtime module surface."),
+        ("tests", "Deterministic validation and conformance coverage."),
+        ("runs", "Run artifacts and execution records."),
+        ("artifacts", "Generated artifacts for governed execution."),
+    ]
+
+    areas = [{"name": name, "description": description} for name, description in area_candidates if (repo_root / name).exists()]
+    return sorted(areas, key=lambda area: area["name"])
+
+
+def build_constitutional_center(repo_root: Path) -> list[str]:
+    anchor = "docs/architecture/system_registry.md"
+    preferred = [
+        "README.md",
+        "docs/architecture/system_registry.md",
+        "docs/roadmaps/system_roadmap.md",
+        "docs/runtime/runtime_governance.md",
+        "docs/review-actions/README.md",
+    ]
+    existing = [path for path in preferred if (repo_root / path).is_file()]
+
+    if anchor not in existing and (repo_root / anchor).is_file():
+        existing.append(anchor)
+
+    if anchor in existing:
+        existing = [anchor] + sorted({item for item in existing if item != anchor})
+    else:
+        existing = sorted(set(existing))
+
+    return existing
+
+
+def build_runtime_hotspots(runtime_files: list[Path], runtime_root: Path) -> list[dict[str, object]]:
+    hotspot_rows: list[dict[str, object]] = []
+
+    for area, keywords, note in HOTSPOT_BUCKETS:
+        count = 0
+        for file_path in runtime_files:
+            relative_name = str(file_path.relative_to(runtime_root)).lower()
+            if any(keyword in relative_name for keyword in keywords):
+                count += 1
+        if count > 0:
+            hotspot_rows.append({"area": area, "count": count, "note": note})
+
+    return hotspot_rows
+
+
+def build_operational_signals(
+    repo_root: Path,
+    root_counts: dict[str, int],
+    runtime_files: list[Path],
+    constitutional_center: list[str],
+) -> list[dict[str, str]]:
+    constitution_present = (repo_root / "docs/architecture/system_registry.md").is_file()
+    governed_surface = root_counts["runtime_modules"] > 0 and root_counts["contracts_total"] > 0
+
+    review_actions_count = 0
+    review_actions_root = repo_root / "docs/review-actions"
+    if review_actions_root.exists():
+        review_actions_count = sum(1 for p in review_actions_root.rglob("*.md") if p.is_file())
+
+    reviews_count = 0
+    reviews_root = repo_root / "docs/reviews"
+    if reviews_root.exists():
+        reviews_count = sum(1 for p in reviews_root.rglob("*.md") if p.is_file())
+
+    evidence_density = review_actions_count + reviews_count
+    docs_to_runtime_ratio = root_counts["docs"] / max(root_counts["runtime_modules"], 1)
+
+    runtime_prefixes = {file_path.stem.split("_")[0] for file_path in runtime_files}
+
+    signals = [
+        {
+            "title": "Constitution present",
+            "status": "Strong" if constitution_present else "Weak",
+            "detail": "System registry foundation is present." if constitution_present else "System registry foundation is missing.",
+        },
+        {
+            "title": "Governed execution surface",
+            "status": "Strong" if governed_surface else "Watch",
+            "detail": "Runtime and contract surfaces are both present."
+            if governed_surface
+            else "Runtime or contract surface appears incomplete.",
+        },
+        {
+            "title": "Evidence and review density",
+            "status": "Strong" if evidence_density >= 20 else "Watch" if evidence_density >= 5 else "Weak",
+            "detail": f"Review artifacts detected: {evidence_density} markdown files.",
+        },
+        {
+            "title": "Roadmap sprawl risk",
+            "status": "Watch" if docs_to_runtime_ratio >= 4 else "Strong",
+            "detail": f"Docs-to-runtime ratio: {docs_to_runtime_ratio:.2f}.",
+        },
+        {
+            "title": "Runtime concentration",
+            "status": "Watch" if len(runtime_prefixes) < 6 else "Strong",
+            "detail": f"Distinct runtime filename prefixes: {len(runtime_prefixes)}.",
+        },
+        {
+            "title": "Constitutional center coverage",
+            "status": "Strong" if len(constitutional_center) >= 3 else "Watch",
+            "detail": f"High-signal constitutional docs listed: {len(constitutional_center)}.",
+        },
+    ]
+
+    return signals
+
+
+def build_snapshot(surface: RepoSurface) -> dict[str, object]:
+    all_files = list(iter_repo_files(surface.repo_root))
+    runtime_files = sorted([p for p in surface.runtime_root.rglob("*.py") if p.is_file()]) if surface.runtime_root.exists() else []
+
+    tests_root = surface.repo_root / "tests"
+    tests_count = sum(1 for p in tests_root.rglob("test_*.py") if p.is_file()) if tests_root.exists() else 0
+
+    schemas_root = surface.repo_root / "contracts/schemas"
+    examples_root = surface.repo_root / "contracts/examples"
+    schemas_count = sum(1 for p in schemas_root.rglob("*") if p.is_file()) if schemas_root.exists() else 0
+    examples_count = sum(1 for p in examples_root.rglob("*") if p.is_file()) if examples_root.exists() else 0
+
+    run_paths = [surface.repo_root / "runs", surface.repo_root / "artifacts/runtime", surface.repo_root / "artifacts/pqx_runs"]
+    run_artifacts_count = 0
+    for run_root in run_paths:
+        if run_root.exists():
+            run_artifacts_count += sum(1 for p in run_root.rglob("*") if p.is_file())
+
+    constitutional_center = build_constitutional_center(surface.repo_root)
+    root_counts = {
+        "files_total": len(all_files),
+        "runtime_modules": len(runtime_files),
+        "tests": tests_count,
+        "contracts_total": schemas_count + examples_count,
+        "schemas": schemas_count,
+        "examples": examples_count,
+        "docs": count_docs(surface.repo_root),
+        "run_artifacts": run_artifacts_count,
+    }
+
+    return {
+        "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "repo_name": surface.repo_root.name,
+        "root_counts": root_counts,
+        "core_areas": build_core_areas(surface.repo_root, surface.runtime_root),
+        "constitutional_center": constitutional_center,
+        "runtime_hotspots": build_runtime_hotspots(runtime_files, surface.runtime_root),
+        "operational_signals": build_operational_signals(
+            surface.repo_root,
+            root_counts,
+            runtime_files,
+            constitutional_center,
+        ),
+    }
+
+
+def write_snapshot(snapshot: dict[str, object], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(snapshot, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        repo_root = discover_repo_root()
+        runtime_root = detect_runtime_root(repo_root)
+        snapshot = build_snapshot(RepoSurface(repo_root=repo_root, runtime_root=runtime_root))
+        write_snapshot(snapshot, Path(args.output))
+    except Exception as exc:  # noqa: BLE001
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(str(Path(args.output)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_generate_repo_dashboard_snapshot.py
+++ b/tests/test_generate_repo_dashboard_snapshot.py
@@ -1,0 +1,120 @@
+"""Tests for scripts/generate_repo_dashboard_snapshot.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "generate_repo_dashboard_snapshot.py"
+DEFAULT_OUTPUT = REPO_ROOT / "artifacts" / "dashboard" / "repo_snapshot.json"
+
+REQUIRED_TOP_LEVEL_KEYS = {
+    "generated_at",
+    "repo_name",
+    "root_counts",
+    "core_areas",
+    "constitutional_center",
+    "runtime_hotspots",
+    "operational_signals",
+}
+
+REQUIRED_ROOT_COUNT_KEYS = {
+    "files_total",
+    "runtime_modules",
+    "tests",
+    "contracts_total",
+    "schemas",
+    "examples",
+    "docs",
+    "run_artifacts",
+}
+
+
+def _run_generator(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), *args],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_script_exists() -> None:
+    assert SCRIPT_PATH.is_file(), "scripts/generate_repo_dashboard_snapshot.py is missing"
+
+
+def test_default_output_created_and_contract_shape() -> None:
+    _run_generator()
+    assert DEFAULT_OUTPUT.is_file(), "default snapshot output was not created"
+
+    payload = _load_json(DEFAULT_OUTPUT)
+    assert REQUIRED_TOP_LEVEL_KEYS <= set(payload.keys())
+    assert REQUIRED_ROOT_COUNT_KEYS <= set(payload["root_counts"].keys())
+
+
+def test_arrays_exist_and_are_sorted_deterministically() -> None:
+    _run_generator()
+    payload = _load_json(DEFAULT_OUTPUT)
+
+    assert isinstance(payload["core_areas"], list)
+    assert isinstance(payload["constitutional_center"], list)
+    assert isinstance(payload["runtime_hotspots"], list)
+    assert isinstance(payload["operational_signals"], list)
+
+    core_names = [entry["name"] for entry in payload["core_areas"]]
+    assert core_names == sorted(core_names)
+
+    constitutional_center = payload["constitutional_center"]
+    if constitutional_center:
+        expected_tail = sorted(constitutional_center[1:]) if constitutional_center[0] == "docs/architecture/system_registry.md" else sorted(constitutional_center)
+        observed_tail = constitutional_center[1:] if constitutional_center[0] == "docs/architecture/system_registry.md" else constitutional_center
+        assert observed_tail == expected_tail
+
+
+def test_custom_output_path_works() -> None:
+    custom_output = Path("/tmp/repo_snapshot.json")
+    if custom_output.exists():
+        custom_output.unlink()
+
+    result = _run_generator("--output", str(custom_output))
+    assert result.returncode == 0
+    assert custom_output.is_file(), "custom snapshot output was not created"
+
+    payload = _load_json(custom_output)
+    assert payload["repo_name"] == REPO_ROOT.name
+
+
+def test_counts_are_non_negative_integers() -> None:
+    _run_generator()
+    payload = _load_json(DEFAULT_OUTPUT)
+    counts = payload["root_counts"]
+
+    for key in REQUIRED_ROOT_COUNT_KEYS:
+        assert isinstance(counts[key], int), f"{key} must be int"
+        assert counts[key] >= 0, f"{key} must be non-negative"
+
+
+def test_handles_optional_directories_absent() -> None:
+    sys.path.insert(0, str(REPO_ROOT))
+    from scripts.generate_repo_dashboard_snapshot import RepoSurface, build_snapshot  # noqa: PLC0415
+
+    with tempfile.TemporaryDirectory(prefix="snapshot-minimal-") as tmpdir:
+        temp_repo = Path(tmpdir)
+        (temp_repo / "docs/architecture").mkdir(parents=True)
+        (temp_repo / "docs/architecture/system_registry.md").write_text("registry", encoding="utf-8")
+        (temp_repo / "README.md").write_text("root", encoding="utf-8")
+
+        payload = build_snapshot(RepoSurface(repo_root=temp_repo, runtime_root=temp_repo / "spectrum_systems/modules/runtime"))
+
+        assert payload["root_counts"]["runtime_modules"] == 0
+        assert payload["root_counts"]["tests"] == 0
+        assert payload["root_counts"]["contracts_total"] == 0


### PR DESCRIPTION
### Motivation
- Provide a repo-native, deterministic snapshot generator so the live dashboard can refresh from repository state without manual JSON pastes.
- Keep the output compact and aligned to the existing dashboard contract while avoiding architectural redesign, prompt logic, or an analytics framework.
- Emit a stable, auditable snapshot that fails closed on output/serialization errors and is easy to trust and extend.

### Description
- Added `scripts/generate_repo_dashboard_snapshot.py`, a CLI tool that discovers the repo root, detects the runtime surface, inventories files with cache/temp exclusions, computes `root_counts`, builds deterministic `core_areas`, `constitutional_center`, `runtime_hotspots`, and `operational_signals`, and supports `--output` for custom output paths.
- Implemented simple, deterministic hotspot and signal heuristics (path/name keyword buckets, docs-to-runtime ratio, review density, filename-prefix diversity) and ensured arrays are sorted for determinism and JSON is pretty-printed in UTC ISO-8601 for `generated_at`.
- Added tests in `tests/test_generate_repo_dashboard_snapshot.py` that validate JSON shape, presence of required keys, deterministic ordering, non-negative integer counts, custom `--output` behavior, and resilience when optional directories are absent.
- Created governance artifacts for the change: `docs/review-actions/PLAN-DASHBOARD-SNAPSHOT-01-2026-04-10.md`, `docs/reviews/RVW-DASHBOARD-SNAPSHOT-01.md` (verdict: SNAPSHOT READY), and `docs/reviews/DASHBOARD-SNAPSHOT-01-DELIVERY-REPORT.md`, and generated `artifacts/dashboard/repo_snapshot.json` from the repo state.

### Testing
- Ran `python scripts/generate_repo_dashboard_snapshot.py` and `python scripts/generate_repo_dashboard_snapshot.py --output /tmp/repo_snapshot.json` and both produced the expected snapshot files without error.
- Ran `pytest tests/test_generate_repo_dashboard_snapshot.py -q` and all tests passed (`6 passed`).
- Verified the generated snapshot artifact at `artifacts/dashboard/repo_snapshot.json` matches the required contract and contains deterministic arrays and non-negative counts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9933c5ad88329a90b7ff97bc84978)