### PR TITLE
DASHBOARD-AUTOLOAD-01: auto-load repo snapshot with fallback/manual source states

### DIFF
--- a/docs/governance-reports/SpectrumSystemsRepoDashboard.jsx
+++ b/docs/governance-reports/SpectrumSystemsRepoDashboard.jsx
@@ -1,0 +1,139 @@
+import React, { useEffect, useMemo, useState } from 'react';
+
+const exampleSnapshot = {
+  generated_at: '2026-04-10T00:00:00Z',
+  repo_name: 'spectrum-systems',
+  root_counts: {
+    files_total: 0,
+    runtime_modules: 0,
+    tests: 0,
+    contracts_total: 0,
+    schemas: 0,
+    examples: 0,
+    docs: 0,
+    run_artifacts: 0,
+  },
+  core_areas: [],
+  constitutional_center: [
+    'README.md',
+    'docs/architecture/system_registry.md',
+    'docs/roadmaps/system_roadmap.md',
+  ],
+  runtime_hotspots: [],
+  operational_signals: [],
+};
+
+const SNAPSHOT_SOURCE = {
+  AUTO: 'auto',
+  MANUAL: 'manual',
+  FALLBACK: 'fallback',
+};
+
+function sourceLabel(mode) {
+  if (mode === SNAPSHOT_SOURCE.AUTO) {
+    return 'Using auto-loaded snapshot';
+  }
+  if (mode === SNAPSHOT_SOURCE.MANUAL) {
+    return 'Using manual snapshot';
+  }
+  return 'Using fallback example snapshot';
+}
+
+export function SpectrumSystemsRepoDashboard() {
+  const fallbackText = useMemo(() => JSON.stringify(exampleSnapshot, null, 2), []);
+  const [sourceMode, setSourceMode] = useState(SNAPSHOT_SOURCE.FALLBACK);
+  const [snapshotText, setSnapshotText] = useState(fallbackText);
+  const [loadStatusMessage, setLoadStatusMessage] = useState('');
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadSnapshot() {
+      try {
+        const response = await fetch('/artifacts/dashboard/repo_snapshot.json');
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+
+        const payload = await response.json();
+        const prettyPayload = JSON.stringify(payload, null, 2);
+        if (!active) {
+          return;
+        }
+
+        setSnapshotText(prettyPayload);
+        setSourceMode(SNAPSHOT_SOURCE.AUTO);
+        setLoadStatusMessage('Auto-loaded snapshot from /artifacts/dashboard/repo_snapshot.json');
+      } catch (_) {
+        if (!active) {
+          return;
+        }
+
+        setSnapshotText(fallbackText);
+        setSourceMode(SNAPSHOT_SOURCE.FALLBACK);
+        setLoadStatusMessage('Snapshot file not found; using fallback example');
+      }
+    }
+
+    loadSnapshot();
+
+    return () => {
+      active = false;
+    };
+  }, [fallbackText]);
+
+  const parseResult = useMemo(() => {
+    try {
+      return { parsedSnapshot: JSON.parse(snapshotText), parseError: '' };
+    } catch (error) {
+      return {
+        parsedSnapshot: null,
+        parseError: error instanceof Error ? error.message : 'Invalid JSON',
+      };
+    }
+  }, [snapshotText]);
+
+  const { parsedSnapshot, parseError } = parseResult;
+
+  const rootCountEntries = parsedSnapshot?.root_counts
+    ? Object.entries(parsedSnapshot.root_counts)
+    : [];
+
+  return (
+    <section>
+      <h2>Spectrum Systems Repo Dashboard</h2>
+      <p>{sourceLabel(sourceMode)}</p>
+      {loadStatusMessage ? <p>{loadStatusMessage}</p> : null}
+      {parseError ? <p>Parse error: {parseError}</p> : null}
+
+      <label htmlFor="repo-snapshot-input">Snapshot JSON</label>
+      <textarea
+        id="repo-snapshot-input"
+        rows={20}
+        value={snapshotText}
+        onChange={(event) => {
+          setSnapshotText(event.target.value);
+          setSourceMode(SNAPSHOT_SOURCE.MANUAL);
+        }}
+      />
+
+      {parsedSnapshot ? (
+        <>
+          <h3>{parsedSnapshot.repo_name ?? 'Unknown repo'}</h3>
+          <p>Generated at: {parsedSnapshot.generated_at ?? 'unknown'}</p>
+
+          <h4>Root counts</h4>
+          <ul>
+            {rootCountEntries.map(([key, value]) => (
+              <li key={key}>
+                <strong>{key}:</strong> {String(value)}
+              </li>
+            ))}
+          </ul>
+        </>
+      ) : null}
+    </section>
+  );
+}
+
+export default SpectrumSystemsRepoDashboard;

--- a/docs/review-actions/PLAN-DASHBOARD-AUTOLOAD-01-2026-04-10.md
+++ b/docs/review-actions/PLAN-DASHBOARD-AUTOLOAD-01-2026-04-10.md
@@ -1,0 +1,28 @@
+# PLAN — DASHBOARD-AUTOLOAD-01
+
+- **Prompt Type:** PLAN
+- **Batch:** DASHBOARD-AUTOLOAD-01
+- **Umbrella:** REPO_OBSERVABILITY_LAYER
+- **Date:** 2026-04-10
+
+## Scope
+Harden the live repository dashboard component so it auto-loads the generated snapshot from `/artifacts/dashboard/repo_snapshot.json`, preserves fallback behavior with `exampleSnapshot`, and keeps manual textarea editing with explicit source-state visibility.
+
+## Execution Steps
+1. Update the React dashboard component (`SpectrumSystemsRepoDashboard`) to attempt `fetch('/artifacts/dashboard/repo_snapshot.json')` on initial render.
+2. Add state for snapshot source mode, snapshot text, and optional load status messaging while preserving parse-error handling and manual textarea workflow.
+3. Keep `exampleSnapshot` as the fallback contract example and use it when auto-load is absent or invalid.
+4. Add compact UI copy indicating one of: auto-loaded snapshot, manual / pasted snapshot, or fallback example snapshot.
+5. Create `docs/reviews/RVW-DASHBOARD-AUTOLOAD-01.md` with required review answers and verdict.
+6. Create `docs/reviews/DASHBOARD-AUTOLOAD-01-DELIVERY-REPORT.md` with changed files and delivery details.
+
+## Failure Rules
+- Fail closed to fallback example when auto-load fetch fails or returned JSON is invalid.
+- Do not crash the dashboard on load/parse errors.
+- Preserve textarea content on manual parse failure and keep parse-error visibility.
+
+## Out of Scope
+- No dashboard redesign.
+- No backend/API expansion or external dependencies.
+- No snapshot contract changes.
+- No unrelated refactors.

--- a/docs/reviews/DASHBOARD-AUTOLOAD-01-DELIVERY-REPORT.md
+++ b/docs/reviews/DASHBOARD-AUTOLOAD-01-DELIVERY-REPORT.md
@@ -1,0 +1,38 @@
+# DASHBOARD-AUTOLOAD-01 Delivery Report
+
+- **Prompt Type:** REVIEW
+- **Batch:** DASHBOARD-AUTOLOAD-01
+- **Umbrella:** REPO_OBSERVABILITY_LAYER
+- **Date:** 2026-04-11
+
+## Files Changed
+- `docs/governance-reports/SpectrumSystemsRepoDashboard.jsx`
+- `docs/review-actions/PLAN-DASHBOARD-AUTOLOAD-01-2026-04-10.md`
+- `docs/reviews/RVW-DASHBOARD-AUTOLOAD-01.md`
+- `docs/reviews/DASHBOARD-AUTOLOAD-01-DELIVERY-REPORT.md`
+
+## Auto-load Behavior Added
+- Added mount-time load attempt from `/artifacts/dashboard/repo_snapshot.json`.
+- On successful fetch + JSON parse, the dashboard:
+  - hydrates textarea with fetched snapshot JSON
+  - renders from fetched data
+  - marks source as auto-loaded.
+
+## Fallback Behavior Preserved
+- `exampleSnapshot` remains in the component as fallback contract example.
+- If snapshot load fails or JSON is invalid, the dashboard:
+  - uses fallback example
+  - hydrates textarea with fallback JSON
+  - shows fallback source-state messaging.
+
+## Manual Override Preserved
+- Textarea remains editable for paste/edit workflow.
+- User edits switch source mode to manual and parse/render from textarea content.
+- Invalid JSON keeps textarea content and shows parse error without crashing.
+
+## Source-State Indicator
+- Added compact source indicator with these states:
+  - `Using auto-loaded snapshot`
+  - `Using manual snapshot`
+  - `Using fallback example snapshot`
+- Added compact load status copy for fallback cases (`Snapshot file not found; using fallback example`).

--- a/docs/reviews/RVW-DASHBOARD-AUTOLOAD-01.md
+++ b/docs/reviews/RVW-DASHBOARD-AUTOLOAD-01.md
@@ -1,0 +1,27 @@
+# RVW-DASHBOARD-AUTOLOAD-01
+
+- **Prompt Type:** REVIEW
+- **Batch:** DASHBOARD-AUTOLOAD-01
+- **Umbrella:** REPO_OBSERVABILITY_LAYER
+- **Date:** 2026-04-11
+- **Verdict:** AUTOLOAD READY
+
+## 1) Does the dashboard now auto-load the generated snapshot by default?
+Yes. On mount, the dashboard performs `fetch('/artifacts/dashboard/repo_snapshot.json')`, parses JSON, and if valid, populates both textarea and rendered dashboard content from that payload.
+
+## 2) Does it preserve fallback behavior safely?
+Yes. If fetch fails (missing file/non-200) or JSON parsing fails, the component fails closed to the in-file `exampleSnapshot`, populates the textarea with fallback JSON, and keeps the UI functional.
+
+## 3) Does manual paste/edit still work?
+Yes. The textarea remains editable and any user change updates the render attempt from current text while preserving parse-error behavior for invalid JSON.
+
+## 4) Is the source state clear in the UI?
+Yes. A compact source indicator shows one of:
+- `Using auto-loaded snapshot`
+- `Using manual snapshot`
+- `Using fallback example snapshot`
+
+A compact load message is also surfaced when fallback is active.
+
+## 5) Was the change kept simple and non-fragile?
+Yes. The change stays local to the dashboard component, uses built-in React state/hooks only, keeps the existing manual workflow, and avoids backend or dependency expansion.


### PR DESCRIPTION
### Motivation

- Make the live dashboard load the generated repo snapshot automatically from `/artifacts/dashboard/repo_snapshot.json` while preserving the existing manual textarea workflow as the primary operator escape hatch. 
- Ensure the component fails closed to the in-file `exampleSnapshot` when the auto-load path is absent or invalid and surface a clear, compact source-state indicator in the UI. 
- Keep the change small, local to the dashboard code, and avoid adding backend complexity or new dependencies.

### Description

- Added a dashboard component at `docs/governance-reports/SpectrumSystemsRepoDashboard.jsx` that attempts `fetch('/artifacts/dashboard/repo_snapshot.json')` on mount and, on success, hydrates the textarea and rendered dashboard from the fetched JSON. 
- If fetch or parsing fails the component falls back to the built-in `exampleSnapshot`, populates the textarea with the pretty-printed fallback, and shows a compact load-status message such as `Snapshot file not found; using fallback example`. 
- The textarea remains editable and any user edits switch the source mode to manual (`SNAPSHOT_SOURCE.MANUAL`), with parse errors preserved and surfaced without destroying textarea contents. 
- Added a compact source-state indicator with the three states `Using auto-loaded snapshot`, `Using manual snapshot`, and `Using fallback example snapshot`, and created supporting docs `docs/review-actions/PLAN-DASHBOARD-AUTOLOAD-01-2026-04-10.md`, `docs/reviews/RVW-DASHBOARD-AUTOLOAD-01.md`, and `docs/reviews/DASHBOARD-AUTOLOAD-01-DELIVERY-REPORT.md`.

### Testing

- Ran `pytest -q tests/test_generate_repo_dashboard_snapshot.py` which completed successfully (`6 passed`).
- Performed repository checks (`git diff --check`) and basic local validation of the component behavior via the added load/fallback logic; no new frontend/component tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9953612048329871e4e487b16099e)