### PR TITLE
DASHBOARD-REFRESH-01: add one-command refresh, runner, and optional watcher

### DIFF
--- a/docs/review-actions/PLAN-DASHBOARD-REFRESH-01-2026-04-11.md
+++ b/docs/review-actions/PLAN-DASHBOARD-REFRESH-01-2026-04-11.md
@@ -1,0 +1,26 @@
+# PLAN — DASHBOARD-REFRESH-01
+
+- **Prompt Type:** PLAN
+- **Batch:** DASHBOARD-REFRESH-01
+- **Umbrella:** REPO_OBSERVABILITY_LAYER
+- **Date:** 2026-04-11
+
+## Scope
+Deliver a deterministic local execution workflow that refreshes the repository snapshot artifact, stages it for dashboard consumption, emits refresh metadata, and supports optional local watch-based refresh without introducing backend services.
+
+## Execution Steps
+1. Add `scripts/refresh_dashboard.sh` to run the existing snapshot generator, write `artifacts/dashboard/repo_snapshot.json`, copy it to `dashboard/public/repo_snapshot.json`, and emit `dashboard/public/repo_snapshot_meta.json` with refresh timestamp, source path, and byte size.
+2. Add `scripts/run_dashboard.sh` to execute refresh first, enforce dashboard directory and dependency presence, then start the dashboard app for local development.
+3. Add `scripts/watch_dashboard.py` using Python standard library polling with include/exclude rules, mtime snapshot diffing, and debounce to rerun refresh only when relevant repo files change.
+4. Create review and delivery documents in `docs/reviews/` covering fail-closed behavior, optional watch-mode posture, contract preservation, and v1 boundaries.
+5. Run validation commands and record outcomes, including expected fail-closed handling where repository surfaces are absent.
+
+## Failure Rules
+- Refresh execution fails closed if snapshot generator is missing, dashboard directory is missing, copy/metadata write fails, or generator execution fails.
+- Watch mode logs refresh failure and continues watching without silent suppression.
+- Existing dashboard snapshot is not replaced when generation fails.
+
+## Out of Scope
+- No backend APIs, websockets, database state, or browser push plumbing.
+- No file-indexing framework or third-party watch dependencies.
+- No unrelated refactors outside dashboard refresh execution tooling.

--- a/docs/reviews/DASHBOARD-REFRESH-01-DELIVERY-REPORT.md
+++ b/docs/reviews/DASHBOARD-REFRESH-01-DELIVERY-REPORT.md
@@ -1,0 +1,60 @@
+# DASHBOARD-REFRESH-01 Delivery Report
+
+- **Prompt Type:** REVIEW
+- **Batch:** DASHBOARD-REFRESH-01
+- **Umbrella:** REPO_OBSERVABILITY_LAYER
+- **Date:** 2026-04-11
+
+## Files Created
+- `scripts/refresh_dashboard.sh`
+- `scripts/run_dashboard.sh`
+- `scripts/watch_dashboard.py`
+- `docs/review-actions/PLAN-DASHBOARD-REFRESH-01-2026-04-11.md`
+- `docs/reviews/RVW-DASHBOARD-REFRESH-01.md`
+- `docs/reviews/DASHBOARD-REFRESH-01-DELIVERY-REPORT.md`
+
+## Refresh Workflow
+`./scripts/refresh_dashboard.sh` now performs a single deterministic execution sequence:
+1. Validate snapshot generator exists.
+2. Validate `dashboard/` and `dashboard/public/` exist (fail closed if absent).
+3. Run `scripts/generate_repo_dashboard_snapshot.py` to write `artifacts/dashboard/repo_snapshot.json`.
+4. Copy snapshot into `dashboard/public/repo_snapshot.json`.
+5. Write `dashboard/public/repo_snapshot_meta.json`.
+
+## Metadata Behavior
+Refresh metadata is emitted as JSON with:
+- `refreshed_at` (UTC ISO-8601)
+- `snapshot_source_path` (`artifacts/dashboard/repo_snapshot.json`)
+- `snapshot_size_bytes` (integer)
+
+## Dashboard Runner Behavior
+`./scripts/run_dashboard.sh`:
+1. Executes refresh first.
+2. Verifies dashboard directory and package manifest.
+3. Runs dependency install (`npm ci` when lockfile exists, otherwise `npm install`).
+4. Starts local dashboard with `npm run dev`.
+
+## Watch Mode Behavior
+`python scripts/watch_dashboard.py` provides optional local watch execution:
+- Watches declared surfaces (`docs/`, `contracts/`, runtime module path, `tests/`, `runs/`, `artifacts/`) if present.
+- Polling + mtime snapshot compare (stdlib only).
+- Debounced refresh trigger (`--interval`, `--debounce` optional flags).
+- Excludes noisy/system/cache/temp paths and self-generated snapshot artifact to avoid refresh loops.
+- Logs: watcher started, change detected, refresh running, refresh succeeded/failed.
+- On refresh failure: logs failure and continues watching.
+
+## Validation Commands Run
+- `./scripts/refresh_dashboard.sh` (fail-closed verified for missing `dashboard/`).
+- `./scripts/refresh_dashboard.sh` (success path validated against temporary local dashboard surface).
+- Verified outputs on success path:
+  - `dashboard/public/repo_snapshot.json`
+  - `dashboard/public/repo_snapshot_meta.json`
+- `./scripts/run_dashboard.sh` (validated using temporary local dashboard app scaffold to confirm refresh + start sequence).
+- `python scripts/watch_dashboard.py --interval 0.4 --debounce 0.5` (validated change-triggered refresh and noise exclusion behavior).
+
+## V1 Intentional Non-Goals
+- No websocket/live-reload plumbing.
+- No backend APIs.
+- No database state.
+- No browser push sync.
+- No advanced file indexing framework.

--- a/docs/reviews/RVW-DASHBOARD-REFRESH-01.md
+++ b/docs/reviews/RVW-DASHBOARD-REFRESH-01.md
@@ -1,0 +1,34 @@
+# RVW-DASHBOARD-REFRESH-01
+
+- **Prompt Type:** REVIEW
+- **Batch:** DASHBOARD-REFRESH-01
+- **Umbrella:** REPO_OBSERVABILITY_LAYER
+- **Date:** 2026-04-11
+- **Verdict:** DASHBOARD REFRESH READY
+
+## 1) Did manual copy friction get removed?
+Yes. `scripts/refresh_dashboard.sh` now performs generation, copy into `dashboard/public/repo_snapshot.json`, and metadata emission in one deterministic execution.
+
+## 2) Does refresh fail closed?
+Yes. Refresh exits non-zero when the snapshot generator is missing, when `dashboard/` is missing, when `dashboard/public/` is missing, or when generation/copy/metadata steps fail.
+
+## 3) Is the base workflow simple and robust?
+Yes. The base workflow is two shell entry points:
+- `./scripts/refresh_dashboard.sh` for deterministic artifact refresh
+- `./scripts/run_dashboard.sh` for refresh + dependency install + local app start
+
+No backend services or indexing frameworks were added.
+
+## 4) Does watch mode remain optional and local-only?
+Yes. `scripts/watch_dashboard.py` is a separate opt-in command and uses polling from Python standard library only. Dashboard execution does not depend on watch mode.
+
+## 5) Does watch mode refresh on real repo changes without excessive noise?
+Yes. The watcher:
+- scopes to declared repository surfaces,
+- excludes noisy/system/cache/temp paths,
+- uses debounce,
+- excludes self-generated snapshot artifact to avoid refresh loops,
+- logs explicit watcher/refresh success/failure states.
+
+## 6) Does the implementation preserve the dashboard contract?
+Yes. Snapshot still lands at `dashboard/public/repo_snapshot.json` for UI retrieval, while metadata is additive (`dashboard/public/repo_snapshot_meta.json`) and does not alter snapshot schema.

--- a/scripts/refresh_dashboard.sh
+++ b/scripts/refresh_dashboard.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+GENERATOR_SCRIPT="${REPO_ROOT}/scripts/generate_repo_dashboard_snapshot.py"
+SNAPSHOT_ARTIFACT="${REPO_ROOT}/artifacts/dashboard/repo_snapshot.json"
+DASHBOARD_DIR="${REPO_ROOT}/dashboard"
+DASHBOARD_PUBLIC_DIR="${DASHBOARD_DIR}/public"
+DASHBOARD_SNAPSHOT="${DASHBOARD_PUBLIC_DIR}/repo_snapshot.json"
+DASHBOARD_META="${DASHBOARD_PUBLIC_DIR}/repo_snapshot_meta.json"
+
+if [[ ! -f "${GENERATOR_SCRIPT}" ]]; then
+  echo "ERROR: snapshot generator missing at ${GENERATOR_SCRIPT}" >&2
+  exit 1
+fi
+
+if [[ ! -d "${DASHBOARD_DIR}" ]]; then
+  echo "ERROR: dashboard directory missing at ${DASHBOARD_DIR}" >&2
+  exit 1
+fi
+
+if [[ ! -d "${DASHBOARD_PUBLIC_DIR}" ]]; then
+  echo "ERROR: dashboard public directory missing at ${DASHBOARD_PUBLIC_DIR}" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "${SNAPSHOT_ARTIFACT}")"
+
+python3 "${GENERATOR_SCRIPT}" --output "${SNAPSHOT_ARTIFACT}"
+
+if [[ ! -f "${SNAPSHOT_ARTIFACT}" ]]; then
+  echo "ERROR: snapshot artifact missing after generation at ${SNAPSHOT_ARTIFACT}" >&2
+  exit 1
+fi
+
+cp "${SNAPSHOT_ARTIFACT}" "${DASHBOARD_SNAPSHOT}"
+
+SNAPSHOT_SIZE_BYTES="$(wc -c < "${SNAPSHOT_ARTIFACT}" | tr -d '[:space:]')"
+REFRESHED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+SOURCE_PATH_REL="artifacts/dashboard/repo_snapshot.json"
+
+python3 - <<'PY' "${DASHBOARD_META}" "${REFRESHED_AT}" "${SOURCE_PATH_REL}" "${SNAPSHOT_SIZE_BYTES}"
+import json
+import pathlib
+import sys
+
+meta_path = pathlib.Path(sys.argv[1])
+meta = {
+    "refreshed_at": sys.argv[2],
+    "snapshot_source_path": sys.argv[3],
+    "snapshot_size_bytes": int(sys.argv[4]),
+}
+meta_path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+PY
+
+echo "Refresh complete: ${DASHBOARD_SNAPSHOT}"
+echo "Metadata written: ${DASHBOARD_META}"

--- a/scripts/run_dashboard.sh
+++ b/scripts/run_dashboard.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DASHBOARD_DIR="${REPO_ROOT}/dashboard"
+REFRESH_SCRIPT="${SCRIPT_DIR}/refresh_dashboard.sh"
+
+if [[ ! -x "${REFRESH_SCRIPT}" ]]; then
+  echo "ERROR: refresh script missing or not executable at ${REFRESH_SCRIPT}" >&2
+  exit 1
+fi
+
+if [[ ! -d "${DASHBOARD_DIR}" ]]; then
+  echo "ERROR: dashboard directory missing at ${DASHBOARD_DIR}" >&2
+  exit 1
+fi
+
+"${REFRESH_SCRIPT}"
+
+if [[ -f "${DASHBOARD_DIR}/package-lock.json" ]]; then
+  (cd "${DASHBOARD_DIR}" && npm ci)
+elif [[ -f "${DASHBOARD_DIR}/package.json" ]]; then
+  (cd "${DASHBOARD_DIR}" && npm install)
+else
+  echo "ERROR: dashboard package manifest missing at ${DASHBOARD_DIR}/package.json" >&2
+  exit 1
+fi
+
+(cd "${DASHBOARD_DIR}" && npm run dev)

--- a/scripts/watch_dashboard.py
+++ b/scripts/watch_dashboard.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Poll repository surfaces and refresh dashboard snapshot on relevant changes."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+WATCH_DIRECTORIES = [
+    "docs",
+    "contracts",
+    "spectrum_systems/modules/runtime",
+    "tests",
+    "runs",
+    "artifacts",
+]
+
+IGNORED_DIR_NAMES = {
+    ".git",
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".venv",
+    "node_modules",
+    ".next",
+}
+
+IGNORED_FILE_NAMES = {
+    ".DS_Store",
+    "Thumbs.db",
+}
+
+IGNORED_SUFFIXES = {
+    "~",
+    ".swp",
+    ".swo",
+    ".tmp",
+    ".temp",
+}
+
+SELF_GENERATED_RELATIVE_PATHS = {
+    "artifacts/dashboard/repo_snapshot.json",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Watch repo surfaces and refresh dashboard snapshot on changes.")
+    parser.add_argument("--interval", type=float, default=2.0, help="Polling interval in seconds (default: 2.0).")
+    parser.add_argument("--debounce", type=float, default=1.5, help="Debounce window in seconds (default: 1.5).")
+    return parser.parse_args()
+
+
+def should_ignore(path: Path, root: Path) -> bool:
+    try:
+        rel_parts = path.relative_to(root).parts
+    except ValueError:
+        rel_parts = path.parts
+
+    for part in rel_parts:
+        if part in IGNORED_DIR_NAMES:
+            return True
+
+    name = path.name
+    if name in IGNORED_FILE_NAMES:
+        return True
+
+    if name.startswith(".") and name not in {".env", ".env.example"}:
+        return True
+
+    return any(name.endswith(suffix) for suffix in IGNORED_SUFFIXES)
+
+
+def gather_file_state(repo_root: Path, watch_roots: list[Path]) -> dict[str, int]:
+    state: dict[str, int] = {}
+
+    for watch_root in watch_roots:
+        if not watch_root.exists() or not watch_root.is_dir():
+            continue
+
+        for path in watch_root.rglob("*"):
+            if should_ignore(path, repo_root):
+                continue
+            if not path.is_file():
+                continue
+            try:
+                stat = path.stat()
+            except FileNotFoundError:
+                continue
+            relative = str(path.relative_to(repo_root))
+            if relative in SELF_GENERATED_RELATIVE_PATHS:
+                continue
+            state[relative] = stat.st_mtime_ns
+
+    return state
+
+
+def run_refresh(repo_root: Path) -> bool:
+    refresh_script = repo_root / "scripts/refresh_dashboard.sh"
+    if not refresh_script.is_file():
+        print(f"[watch] refresh failed: missing {refresh_script}", flush=True)
+        return False
+
+    print("[watch] refresh running", flush=True)
+    result = subprocess.run([str(refresh_script)], cwd=repo_root, check=False)
+    if result.returncode == 0:
+        print("[watch] refresh succeeded", flush=True)
+        return True
+
+    print(f"[watch] refresh failed (exit={result.returncode})", flush=True)
+    return False
+
+
+def main() -> int:
+    args = parse_args()
+
+    if args.interval <= 0:
+        print("ERROR: --interval must be positive", file=sys.stderr)
+        return 1
+    if args.debounce < 0:
+        print("ERROR: --debounce must be >= 0", file=sys.stderr)
+        return 1
+
+    repo_root = Path(__file__).resolve().parents[1]
+    watch_roots = [repo_root / relative for relative in WATCH_DIRECTORIES]
+    active_roots = [path for path in watch_roots if path.exists() and path.is_dir()]
+
+    if not active_roots:
+        print("ERROR: no watchable directories found", file=sys.stderr)
+        return 1
+
+    print("[watch] watcher started", flush=True)
+    print(f"[watch] interval={args.interval:.1f}s debounce={args.debounce:.1f}s", flush=True)
+    print("[watch] roots=" + ", ".join(str(path.relative_to(repo_root)) for path in active_roots), flush=True)
+
+    previous_state = gather_file_state(repo_root, active_roots)
+    pending_change_at: float | None = None
+
+    while True:
+        time.sleep(args.interval)
+        current_state = gather_file_state(repo_root, active_roots)
+
+        if current_state != previous_state:
+            print("[watch] change detected", flush=True)
+            previous_state = current_state
+            pending_change_at = time.monotonic()
+            continue
+
+        if pending_change_at is None:
+            continue
+
+        if time.monotonic() - pending_change_at < args.debounce:
+            continue
+
+        run_refresh(repo_root)
+        pending_change_at = None
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- The repo had a snapshot generator and a dashboard app but required a manual copy step between them which was error-prone and slow. 
- Provide a simple, deterministic, repo-native developer workflow to regenerate the snapshot, stage it for the dashboard, surface basic metadata, and optionally auto-refresh during local development. 

### Description
- Add `scripts/refresh_dashboard.sh` which validates surfaces, runs `scripts/generate_repo_dashboard_snapshot.py` to emit `artifacts/dashboard/repo_snapshot.json`, copies that file to `dashboard/public/repo_snapshot.json`, and writes `dashboard/public/repo_snapshot_meta.json` containing `refreshed_at`, `snapshot_source_path`, and `snapshot_size_bytes`, and which fails closed on missing generator/dashboard surfaces or generation/copy errors. 
- Add `scripts/run_dashboard.sh` which calls the refresh, enforces dashboard presence and package manifest, installs dependencies (`npm ci` / `npm install`), and starts the local dashboard via `npm run dev`. 
- Add `scripts/watch_dashboard.py` (stdlib-only) implementing polling + mtime snapshot diffing, include/exclude rules, debounce parameters (`--interval`, `--debounce`), explicit logs (started, change detected, refresh running, refresh succeeded/failed), and exclusion of the self-generated snapshot to avoid refresh loops. 
- Add governance docs: `docs/review-actions/PLAN-DASHBOARD-REFRESH-01-2026-04-11.md`, `docs/reviews/RVW-DASHBOARD-REFRESH-01.md`, and `docs/reviews/DASHBOARD-REFRESH-01-DELIVERY-REPORT.md` describing scope, failure rules, validation, and v1 non-goals. 

### Testing
- Compiled the watcher: `python3 -m py_compile scripts/watch_dashboard.py` and the compilation succeeded. 
- Verified fail-closed path by running `./scripts/refresh_dashboard.sh` with no `dashboard/` present and confirmed it exited non-zero as expected. 
- Validated success path by creating a temporary `dashboard/public` and minimal `dashboard/package.json`, then ran `./scripts/refresh_dashboard.sh` and confirmed `dashboard/public/repo_snapshot.json` and `dashboard/public/repo_snapshot_meta.json` were written and the metadata contains `refreshed_at`, `snapshot_source_path`, and integer `snapshot_size_bytes`. 
- Validated runner and watcher by running `./scripts/run_dashboard.sh` (confirmed refresh + `npm run dev` start with the scaffold) and `python3 scripts/watch_dashboard.py --interval 0.4 --debounce 0.5` while touching files to confirm ignored noise did not trigger a refresh and relevant changes did trigger a single refresh; all automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9a1c22920832985275f91508715df)