### PR TITLE
fix(dashboard): align RepoDashboard data shape with repo_snapshot contract

### DIFF
--- a/dashboard/components/RepoDashboard.tsx
+++ b/dashboard/components/RepoDashboard.tsx
@@ -2,11 +2,41 @@
 
 import { useEffect, useMemo, useState, type CSSProperties } from 'react'
 
+type RootCounts = {
+  files_total?: number
+  runtime_modules?: number
+  tests?: number
+  contracts_total?: number
+  schemas?: number
+  examples?: number
+  docs?: number
+  run_artifacts?: number
+}
+
+type RuntimeHotspot = {
+  area?: string
+  count?: number
+  note?: string
+}
+
+type OperationalSignal = {
+  title?: string
+  status?: string
+  detail?: string
+}
+
+type CoreArea = {
+  name?: string
+  description?: string
+}
+
 type Snapshot = {
   repo_name?: string
-  root_counts?: Record<string, number>
-  runtime_hotspots?: string[]
-  operational_signals?: string[]
+  root_counts?: RootCounts
+  core_areas?: CoreArea[]
+  constitutional_center?: string[]
+  runtime_hotspots?: RuntimeHotspot[]
+  operational_signals?: OperationalSignal[]
 }
 
 type SnapshotMeta = {
@@ -77,7 +107,18 @@ type ConstitutionResult = {
 
 const fallbackSnapshot: Snapshot = {
   repo_name: 'spectrum-systems',
-  root_counts: { files: 0, modules: 0, tests: 0, contracts: 0 },
+  root_counts: {
+    files_total: 0,
+    runtime_modules: 0,
+    tests: 0,
+    contracts_total: 0,
+    schemas: 0,
+    examples: 0,
+    docs: 0,
+    run_artifacts: 0
+  },
+  core_areas: [],
+  constitutional_center: [],
   runtime_hotspots: [],
   operational_signals: []
 }
@@ -253,10 +294,12 @@ export default function RepoDashboard() {
       <section style={{ ...gridStyle, marginBottom: 12 }}>
         <article style={cardStyle}>
           <h2 style={sectionTitleStyle}>Repository snapshot</h2>
-          <Field label='Files' value={counts.files ?? 0} />
-          <Field label='Modules' value={counts.modules ?? 0} />
+          <Field label='Files' value={counts.files_total ?? 0} />
+          <Field label='Runtime modules' value={counts.runtime_modules ?? 0} />
           <Field label='Tests' value={counts.tests ?? 0} />
-          <Field label='Contracts' value={counts.contracts ?? 0} />
+          <Field label='Contracts' value={counts.contracts_total ?? 0} />
+          <Field label='Docs' value={counts.docs ?? 0} />
+          <Field label='Run artifacts' value={counts.run_artifacts ?? 0} />
         </article>
 
         <article style={cardStyle}>
@@ -368,11 +411,31 @@ export default function RepoDashboard() {
       <section style={gridStyle}>
         <article style={cardStyle}>
           <h2 style={sectionTitleStyle}>Runtime hotspots</h2>
-          <StringList items={safeArray(snapshot.runtime_hotspots)} />
+          {snapshot.runtime_hotspots?.length ? (
+            snapshot.runtime_hotspots.map((hotspot, index) => (
+              <div key={`${hotspot.area ?? 'hotspot'}-${index}`} style={{ marginBottom: 10 }}>
+                <Field label='Area' value={hotspot.area} />
+                <Field label='Count' value={hotspot.count} />
+                <Field label='Note' value={hotspot.note} />
+              </div>
+            ))
+          ) : (
+            <p style={{ margin: '6px 0', color: '#64748b' }}>{notAvailable}</p>
+          )}
         </article>
         <article style={cardStyle}>
           <h2 style={sectionTitleStyle}>Operational signals</h2>
-          <StringList items={safeArray(snapshot.operational_signals)} />
+          {snapshot.operational_signals?.length ? (
+            snapshot.operational_signals.map((signal, index) => (
+              <div key={`${signal.title ?? 'signal'}-${index}`} style={{ marginBottom: 10 }}>
+                <Field label='Title' value={signal.title} />
+                <Field label='Status' value={signal.status} />
+                <Field label='Detail' value={signal.detail} />
+              </div>
+            ))
+          ) : (
+            <p style={{ margin: '6px 0', color: '#64748b' }}>{notAvailable}</p>
+          )}
         </article>
       </section>
     </main>

--- a/docs/review-actions/PLAN-DASHBOARD-DATA-SHAPE-FIX-01-2026-04-11.md
+++ b/docs/review-actions/PLAN-DASHBOARD-DATA-SHAPE-FIX-01-2026-04-11.md
@@ -1,0 +1,34 @@
+# Plan — DASHBOARD-DATA-SHAPE-FIX-01 — 2026-04-11
+
+## Prompt type
+PLAN
+
+## Roadmap item
+REPO_OBSERVABILITY_LAYER
+
+## Objective
+Align dashboard snapshot typing and rendering to the emitted `repo_snapshot.json` artifact contract without changing layout, loading model, or backend behavior.
+
+## Declared files
+
+| File | Change type | Reason |
+| --- | --- | --- |
+| dashboard/components/RepoDashboard.tsx | MODIFY | Correct snapshot data types, fallback shape, and object-list rendering for hotspots/signals. |
+| docs/reviews/RVW-DASHBOARD-DATA-SHAPE-FIX-01.md | CREATE | Record required review answers and verdict for this batch. |
+| docs/reviews/DASHBOARD-DATA-SHAPE-FIX-01-DELIVERY-REPORT.md | CREATE | Record delivery outcomes and validation evidence. |
+
+## Contracts touched
+None.
+
+## Tests that must pass after execution
+1. `cd dashboard && npm install`
+2. `cd dashboard && npm run build`
+
+## Scope exclusions
+- Do not redesign dashboard layout or panel structure.
+- Do not add dependencies or backend/API services.
+- Do not change fetch artifact paths or loading behavior.
+- Do not modify non-dashboard runtime/governance logic.
+
+## Dependencies
+None.

--- a/docs/reviews/DASHBOARD-DATA-SHAPE-FIX-01-DELIVERY-REPORT.md
+++ b/docs/reviews/DASHBOARD-DATA-SHAPE-FIX-01-DELIVERY-REPORT.md
@@ -1,0 +1,25 @@
+# DASHBOARD-DATA-SHAPE-FIX-01 — DELIVERY REPORT
+
+## Prompt type
+VALIDATE
+
+## Batch
+- **TITLE:** DASHBOARD-DATA-SHAPE-FIX-01 — Align dashboard UI with snapshot artifact contract
+- **BATCH:** DASHBOARD-DATA-SHAPE-FIX-01
+- **UMBRELLA:** REPO_OBSERVABILITY_LAYER
+
+## Delivery summary
+- Snapshot types corrected to match the contract (`RootCounts`, `RuntimeHotspot`, `OperationalSignal`, `CoreArea`, and `Snapshot`).
+- Fallback snapshot corrected to canonical keys (`files_total`, `runtime_modules`, `tests`, `contracts_total`, `schemas`, `examples`, `docs`, `run_artifacts`).
+- Repository snapshot count rendering corrected to contract keys.
+- Runtime hotspots and operational signals rendering corrected from string-list rendering to object-field rendering.
+- Graceful fallback retained via `Not available yet` when hotspot/signal arrays are absent or empty.
+
+## Validation commands run
+1. `cd dashboard && npm install`
+2. `cd dashboard && npm run build`
+
+## Validation result
+- `npm install` failed with `403 Forbidden` when fetching `next` from `registry.npmjs.org` in this environment.
+- `npm run build` could not complete because `next` is unavailable (`sh: 1: next: not found`) after the failed install.
+- Dashboard fallback shape and rendering paths are contract-aligned in code review, with graceful `Not available yet` handling preserved.

--- a/docs/reviews/RVW-DASHBOARD-DATA-SHAPE-FIX-01.md
+++ b/docs/reviews/RVW-DASHBOARD-DATA-SHAPE-FIX-01.md
@@ -1,0 +1,23 @@
+# RVW-DASHBOARD-DATA-SHAPE-FIX-01
+
+## Prompt type
+REVIEW
+
+## Scope
+`dashboard/components/RepoDashboard.tsx`
+
+## Review answers
+1. **Does the dashboard now match the snapshot contract?**
+   - Yes. Snapshot typing now matches the artifact contract fields for `root_counts`, `core_areas`, `constitutional_center`, `runtime_hotspots`, and `operational_signals`.
+
+2. **Are counts correct?**
+   - Yes. The repository snapshot card now uses `files_total`, `runtime_modules`, `tests`, and `contracts_total`, and also shows `docs` and `run_artifacts`.
+
+3. **Do hotspots and signals render correctly?**
+   - Yes. Runtime hotspots now render as object fields (`area`, `count`, `note`) and operational signals render as object fields (`title`, `status`, `detail`).
+
+4. **Was the fix surgical and non-disruptive?**
+   - Yes. The change is constrained to snapshot data shape typing, fallback keys, and rendering logic for the two affected panels while preserving layout and fetch behavior.
+
+## Verdict
+**DATA SHAPE FIX READY**


### PR DESCRIPTION
### Motivation

- The dashboard UI types and render logic were not aligned with the emitted `repo_snapshot.json` artifact, causing incorrect counts and mis-rendered lists for hotspots and signals while preserving layout and loading behavior is required.
- This change makes the UI a surgical data-shape fix to match the contract without adding dependencies or altering backend behavior.

### Description

- Introduce typed shapes to match the contract: `RootCounts`, `RuntimeHotspot`, `OperationalSignal`, `CoreArea`, and update `Snapshot` to include `root_counts`, `core_areas`, `constitutional_center`, `runtime_hotspots`, and `operational_signals` (file: `dashboard/components/RepoDashboard.tsx`).
- Replace the loose `fallbackSnapshot` with a contract-aligned fallback that contains canonical `root_counts` keys (`files_total`, `runtime_modules`, `tests`, `contracts_total`, `schemas`, `examples`, `docs`, `run_artifacts`) and empty arrays for `core_areas` and `constitutional_center`.
- Render repository counts from canonical keys (`files_total`, `runtime_modules`, `tests`, `contracts_total`) and include `Docs` and `Run artifacts`, and replace `StringList` usage for `runtime_hotspots` and `operational_signals` with explicit object-field rendering (area/count/note and title/status/detail) while preserving the existing layout and fallbacks (file: `dashboard/components/RepoDashboard.tsx`).
- Add governance artifacts required by the plan: `docs/review-actions/PLAN-DASHBOARD-DATA-SHAPE-FIX-01-2026-04-11.md`, `docs/reviews/RVW-DASHBOARD-DATA-SHAPE-FIX-01.md`, and `docs/reviews/DASHBOARD-DATA-SHAPE-FIX-01-DELIVERY-REPORT.md` documenting the change and review verdict.

### Testing

- Ran `cd dashboard && npm install`, which failed in this environment with `403 Forbidden` fetching `next` from `registry.npmjs.org` so dependencies could not be installed. 
- Ran `cd dashboard && npm run build`, which could not execute because `next` was not available after the failed install (`sh: 1: next: not found`).
- The behavioral fixes (fallback keys and explicit rendering for hotspots and signals) were validated by code inspection and review, and preserved the `Not available yet` graceful fallback for absent arrays.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9b27e7d8c8329bbdf9490ffae1e00)