### PR TITLE
DASHBOARD-BUILD-FIX-03: add minimal TypeScript config for Next.js app router

### DIFF
--- a/dashboard/next-env.d.ts
+++ b/dashboard/next-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />

--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["app", "components"],
+  "exclude": ["node_modules"]
+}

--- a/docs/review-actions/PLAN-DASHBOARD-BUILD-FIX-03-2026-04-11.md
+++ b/docs/review-actions/PLAN-DASHBOARD-BUILD-FIX-03-2026-04-11.md
@@ -1,0 +1,19 @@
+# PLAN-DASHBOARD-BUILD-FIX-03-2026-04-11
+
+## Primary prompt type
+PLAN
+
+## Scope
+Surgical build-enabling execution for `DASHBOARD-BUILD-FIX-03`.
+
+## Steps
+1. Create `dashboard/tsconfig.json` with minimal Next.js-compatible TypeScript compiler options for app router execution.
+2. Add `dashboard/next-env.d.ts` with standard Next.js type references.
+3. Run dashboard validation commands (`npm install`, `npm run build`) and capture outcomes.
+4. Create review artifact `docs/reviews/RVW-DASHBOARD-BUILD-FIX-03.md`.
+5. Create delivery artifact `docs/reviews/DASHBOARD-BUILD-FIX-03-DELIVERY-REPORT.md`.
+
+## Constraints
+- No component redesign or unrelated refactors.
+- Build enablement only.
+- Preserve fail-closed behavior by relying on deterministic build validation.

--- a/docs/reviews/DASHBOARD-BUILD-FIX-03-DELIVERY-REPORT.md
+++ b/docs/reviews/DASHBOARD-BUILD-FIX-03-DELIVERY-REPORT.md
@@ -1,0 +1,24 @@
+# DASHBOARD-BUILD-FIX-03 Delivery Report
+
+## Batch
+- `DASHBOARD-BUILD-FIX-03`
+
+## Umbrella
+- `REPO_OBSERVABILITY_LAYER`
+
+## Delivered artifacts
+1. `dashboard/tsconfig.json` (new)
+2. `dashboard/next-env.d.ts` (new)
+3. `docs/reviews/RVW-DASHBOARD-BUILD-FIX-03.md` (new)
+
+## Execution summary
+- Implemented a surgical build-enabling fix by adding a minimal TypeScript configuration for Next.js app router execution.
+- Added Next.js environment typings file as recommended.
+- Kept scope restricted to build configuration artifacts only.
+
+## Validation summary
+- `npm install` failed in this environment due to `403 Forbidden` from npm registry.
+- `npm run build` failed because `next` could not be resolved after failed install.
+
+## Residual risk
+Low code risk; external package registry access prevented full build certification in this execution environment.

--- a/docs/reviews/RVW-DASHBOARD-BUILD-FIX-03.md
+++ b/docs/reviews/RVW-DASHBOARD-BUILD-FIX-03.md
@@ -1,0 +1,20 @@
+# RVW-DASHBOARD-BUILD-FIX-03
+
+## Primary prompt type
+REVIEW
+
+## Scope reviewed
+- `dashboard/tsconfig.json`
+- `dashboard/next-env.d.ts`
+
+## Findings
+1. Added minimal TypeScript compiler configuration aligned to Next.js app router build requirements (`noEmit`, `jsx: preserve`, `moduleResolution: bundler`, `incremental`).
+2. Added Next.js ambient type references in `next-env.d.ts`.
+3. No dashboard component or layout artifacts were modified.
+
+## Validation evidence
+- `npm install` in `dashboard/` failed with `403 Forbidden` fetching `next` from `registry.npmjs.org` in this environment.
+- `npm run build` in `dashboard/` failed because `next` was unavailable (`sh: 1: next: not found`) after the blocked install.
+
+## Assessment
+The build-enabling configuration change is correctly scoped and complete; environment package access blocked full runtime verification.


### PR DESCRIPTION
### Motivation
- Provide a minimal TypeScript configuration so the Next.js app router in `dashboard/` builds correctly on Vercel when `.tsx` files are present.
- Prevent common Next.js build failures by supplying required compiler options (`jsx: preserve`, `moduleResolution: bundler`, `noEmit`) without changing application code.

### Description
- Added `dashboard/tsconfig.json` with minimal Next.js-compatible compiler options including `target: ES2020`, `lib`, `allowJs`, `noEmit`, `moduleResolution: "bundler"`, `jsx: "preserve"`, `incremental`, and `include: ["app","components"]`.
- Added `dashboard/next-env.d.ts` with standard Next.js ambient type references (`/// <reference types="next" />`, `/// <reference types="next/image-types/global" />`).
- Added planning and review artifacts: `docs/review-actions/PLAN-DASHBOARD-BUILD-FIX-03-2026-04-11.md`, `docs/reviews/RVW-DASHBOARD-BUILD-FIX-03.md`, and `docs/reviews/DASHBOARD-BUILD-FIX-03-DELIVERY-REPORT.md` to document scope, findings, and delivery.

### Testing
- Ran `cd dashboard && npm install`, which failed in this environment with a `403 Forbidden` error fetching `next` from `https://registry.npmjs.org/next`.
- Ran `cd dashboard && npm run build`, which failed because `next` was not available after the blocked install (`sh: 1: next: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9b46a96c883298b694d8bd5f0774d)