### PR TITLE
fix(dashboard): add TypeScript devDependencies required by Vercel

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -10,5 +10,11 @@
     "next": "14.2.3",
     "react": "18.2.0",
     "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5",
+    "@types/react": "^18.2.66",
+    "@types/react-dom": "^18.2.22",
+    "@types/node": "^20.12.7"
   }
 }


### PR DESCRIPTION
### Motivation
- Vercel TypeScript validation failed because `dashboard/package.json` did not include the required TypeScript packages (`typescript`, `@types/react`, `@types/node`).

### Description
- Added a `devDependencies` block to `dashboard/package.json` with `typescript@^5.4.5`, `@types/react@^18.2.66`, `@types/react-dom@^18.2.22`, and `@types/node@^20.12.7`.

### Testing
- Parsed `dashboard/package.json` with `node -e "JSON.parse(require('fs').readFileSync('dashboard/package.json','utf8'))"` which succeeded and confirmed valid JSON.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9b6f7fa6083299f716c3f32d7963e)