### PR TITLE
Harden PQX Phase-1: governance chain validation & replay comparison

### DIFF
--- a/docs/review-actions/PLAN-GOV-HARDENING-PHASE1-2026-04-11.md
+++ b/docs/review-actions/PLAN-GOV-HARDENING-PHASE1-2026-04-11.md
@@ -1,0 +1,37 @@
+# Plan — GOV-HARDENING-PHASE1 — 2026-04-11
+
+## Prompt type
+BUILD
+
+## Roadmap item
+Spectrum governance hardening roadmap — Phase 1 (Foundation hardening)
+
+## Objective
+Enforce fail-closed phase-1 governance checks so each PQX slice verifies schema validity, eval presence, control lineage, enforcement recording, trace completeness, and deterministic replay comparison before completion.
+
+## Declared files
+| File | Change type | Reason |
+| --- | --- | --- |
+| docs/review-actions/PLAN-GOV-HARDENING-PHASE1-2026-04-11.md | CREATE | Required plan-first declaration for multi-file governed changes. |
+| spectrum_systems/modules/runtime/governance_chain_guard.py | CREATE | Centralized phase-1 governance chain validation logic. |
+| spectrum_systems/modules/runtime/pqx_slice_runner.py | MODIFY | Wire guard into canonical PQX→eval→control→enforcement path and fail closed on violations. |
+| tests/test_governance_chain_guard.py | CREATE | Deterministic unit coverage for guard behavior and replay comparison requirements. |
+| tests/test_pqx_slice_runner.py | MODIFY | Integration assertion that governed slice execution surfaces replay comparison evidence. |
+
+## Contracts touched
+None.
+
+## Tests that must pass after execution
+1. `pytest tests/test_governance_chain_guard.py`
+2. `pytest tests/test_pqx_slice_runner.py`
+3. `pytest tests/test_contracts.py`
+4. `pytest tests/test_module_architecture.py`
+
+## Scope exclusions
+- Do not perform global repository refactors.
+- Do not rename role ownership surfaces.
+- Do not implement later roadmap phases in this patch.
+- Do not introduce non-artifactized hidden state.
+
+## Dependencies
+- Existing PQX slice execution artifacts and runtime control-loop modules remain authoritative inputs.

--- a/spectrum_systems/modules/runtime/governance_chain_guard.py
+++ b/spectrum_systems/modules/runtime/governance_chain_guard.py
@@ -1,0 +1,120 @@
+"""Fail-closed governance chain guard for canonical PQX slice execution.
+
+Phase-1 hardening checks enforced here:
+1. schema validation for all required artifacts
+2. required eval artifacts for each output slice
+3. control decision artifact must exist and align to trace context
+4. enforcement action must be recorded (including explicit "none")
+5. trace completeness across chain
+6. deterministic replay comparison evidence (hash + fingerprint)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from spectrum_systems.contracts import validate_artifact
+
+
+class GovernanceChainGuardError(ValueError):
+    """Raised when the governed execution chain is incomplete or invalid."""
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise GovernanceChainGuardError(f"required artifact missing: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise GovernanceChainGuardError(f"artifact is not valid JSON: {path}") from exc
+    if not isinstance(payload, dict):
+        raise GovernanceChainGuardError(f"artifact must be a JSON object: {path}")
+    return payload
+
+
+def _canonical_digest(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    ).hexdigest()
+
+
+def _replay_fingerprint(payload: dict[str, Any]) -> str:
+    metrics = payload.get("observability_metrics", {}).get("metrics", {})
+    if not isinstance(metrics, dict):
+        raise GovernanceChainGuardError("replay_result.observability_metrics.metrics must be object")
+    fingerprint = {
+        "consistency_status": payload.get("consistency_status"),
+        "drift_detected": payload.get("drift_detected"),
+        "replay_success_rate": metrics.get("replay_success_rate"),
+        "error_budget_status": payload.get("error_budget_status", {}).get("budget_status"),
+    }
+    return _canonical_digest(fingerprint)
+
+
+def validate_governance_chain(
+    *,
+    run_id: str,
+    trace_id: str,
+    replay_result_path: Path,
+    replay_baseline_path: Path,
+    regression_result_path: Path,
+    control_decision_path: Path,
+    execution_record_path: Path,
+) -> dict[str, str | bool]:
+    """Validate PQX->eval->control->enforcement chain and return replay comparison evidence."""
+
+    replay_result = _load_json(replay_result_path)
+    replay_baseline = _load_json(replay_baseline_path)
+    regression = _load_json(regression_result_path)
+    control = _load_json(control_decision_path)
+    record = _load_json(execution_record_path)
+
+    validate_artifact(replay_result, "replay_result")
+    validate_artifact(regression, "regression_run_result")
+    validate_artifact(control, "evaluation_control_decision")
+    validate_artifact(record, "pqx_slice_execution_record")
+
+    if replay_result.get("trace_id") != trace_id or record.get("trace_id") != trace_id:
+        raise GovernanceChainGuardError("trace completeness violation: trace_id mismatch in output artifacts")
+    if replay_result.get("replay_run_id") != run_id:
+        raise GovernanceChainGuardError("trace completeness violation: replay_result.replay_run_id mismatch")
+    if record.get("run_id") != run_id or control.get("run_id") != run_id:
+        raise GovernanceChainGuardError("trace completeness violation: run_id mismatch")
+
+    required_eval_refs = {record.get("replay_result_ref"), *record.get("artifacts_emitted", [])}
+    if not any(str(ref).endswith(".regression_run_result.json") for ref in required_eval_refs):
+        raise GovernanceChainGuardError("required eval missing: regression_run_result artifact must be emitted")
+
+    decision_summary = record.get("decision_summary", {})
+    enforcement_action = decision_summary.get("enforcement_action")
+    if not isinstance(enforcement_action, str) or not enforcement_action.strip():
+        raise GovernanceChainGuardError("enforcement_action must be explicitly recorded")
+
+    control_ref = record.get("control_decision_ref")
+    if not isinstance(control_ref, str) or not control_ref.strip():
+        raise GovernanceChainGuardError("control_decision_ref must be present")
+
+    replay_hash = _canonical_digest(replay_result)
+    baseline_hash = _canonical_digest(replay_baseline)
+    replay_fp = _replay_fingerprint(replay_result)
+    baseline_fp = _replay_fingerprint(replay_baseline)
+
+    return {
+        "comparison_digest": _canonical_digest(
+            {
+                "replay_hash": replay_hash,
+                "baseline_hash": baseline_hash,
+                "replay_fingerprint": replay_fp,
+                "baseline_fingerprint": baseline_fp,
+            }
+        ),
+        "hash_match": replay_hash == baseline_hash,
+        "fingerprint_match": replay_fp == baseline_fp,
+        "replay_hash": replay_hash,
+        "baseline_hash": baseline_hash,
+        "replay_fingerprint": replay_fp,
+        "baseline_fingerprint": baseline_fp,
+    }

--- a/spectrum_systems/modules/runtime/pqx_slice_runner.py
+++ b/spectrum_systems/modules/runtime/pqx_slice_runner.py
@@ -44,6 +44,10 @@ from spectrum_systems.modules.runtime.enforcement_engine import (
     EnforcementError,
     enforce_control_decision,
 )
+from spectrum_systems.modules.runtime.governance_chain_guard import (
+    GovernanceChainGuardError,
+    validate_governance_chain,
+)
 from spectrum_systems.modules.runtime.repo_write_lineage_guard import (
     RepoWriteLineageGuardError,
     validate_repo_write_lineage,
@@ -1035,6 +1039,25 @@ def run_pqx_slice(
         execution_record["artifacts_emitted"].append(str(contract_preflight_result_artifact_path))
     validate_artifact(execution_record, "pqx_slice_execution_record")
     execution_record_path = _write_json(step_dir / f"{run_id}.pqx_slice_execution_record.json", execution_record)
+
+    try:
+        governance_chain = validate_governance_chain(
+            run_id=run_id,
+            trace_id=trace_id,
+            replay_result_path=replay_path,
+            replay_baseline_path=REPO_ROOT / "contracts" / "examples" / "replay_result.json",
+            regression_result_path=regression_path,
+            control_decision_path=control_path,
+            execution_record_path=execution_record_path,
+        )
+    except GovernanceChainGuardError as exc:
+        return _block_payload(
+            step_id=normalized_step_id,
+            run_id=run_id,
+            reason=f"governance_chain_invalid:{exc}",
+            block_type="GOVERNANCE_CHAIN_BLOCKED",
+        )
+
     review_summary = _emit_post_execution_review(
         step_id=normalized_step_id,
         run_id=run_id,
@@ -1054,6 +1077,7 @@ def run_pqx_slice(
         "eval_artifact_refs": [_relative(regression_path)],
         "control_decision_ref": _relative(control_path),
         "certification_result_ref": _relative(certification_path),
+        "replay_comparison": governance_chain,
     }
     audit_bundle_path = _write_json(step_dir / f"{run_id}.pqx_slice_audit_bundle.json", audit_bundle)
 

--- a/tests/test_governance_chain_guard.py
+++ b/tests/test_governance_chain_guard.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from spectrum_systems.modules.runtime.governance_chain_guard import (
+    GovernanceChainGuardError,
+    validate_governance_chain,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write(path: Path, payload: dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def _replay(trace_id: str, run_id: str) -> dict:
+    replay = json.loads((REPO_ROOT / "contracts" / "examples" / "replay_result.json").read_text(encoding="utf-8"))
+    replay["trace_id"] = trace_id
+    replay["replay_run_id"] = run_id
+    replay["original_run_id"] = run_id
+    replay["observability_metrics"]["trace_refs"]["trace_id"] = trace_id
+    replay["error_budget_status"]["trace_refs"]["trace_id"] = trace_id
+    replay["error_budget_status"]["observability_metrics_id"] = replay["observability_metrics"]["artifact_id"]
+    return replay
+
+
+def _regression(trace_id: str, run_id: str) -> dict:
+    return {
+        "artifact_type": "regression_result",
+        "schema_version": "1.1.0",
+        "run_id": run_id,
+        "suite_id": "suite-1",
+        "created_at": "2026-04-11T00:00:00Z",
+        "total_traces": 1,
+        "passed_traces": 1,
+        "failed_traces": 0,
+        "pass_rate": 1.0,
+        "overall_status": "pass",
+        "regression_status": "pass",
+        "blocked": False,
+        "results": [
+            {
+                "trace_id": trace_id,
+                "replay_result_id": "replay:1",
+                "analysis_id": "analysis:1",
+                "decision_status": "consistent",
+                "reproducibility_score": 1.0,
+                "drift_type": "",
+                "passed": True,
+                "failure_reasons": [],
+                "baseline_replay_result_id": "replay:1",
+                "current_replay_result_id": "replay:1",
+                "baseline_trace_id": trace_id,
+                "current_trace_id": trace_id,
+                "baseline_reference": "contracts/examples/replay_result.json",
+                "current_reference": "contracts/examples/replay_result.json",
+                "mismatch_summary": [],
+                "comparison_digest": "a" * 64,
+            }
+        ],
+        "summary": {"drift_counts": {"none": 1}, "average_reproducibility_score": 1.0},
+    }
+
+
+def _control(run_id: str, trace_id: str) -> dict:
+    control = json.loads(
+        (REPO_ROOT / "contracts" / "examples" / "evaluation_control_decision.json").read_text(encoding="utf-8")
+    )
+    control["run_id"] = run_id
+    control["trace_id"] = trace_id
+    return control
+
+
+def _execution_record(run_id: str, trace_id: str) -> dict:
+    return {
+        "schema_version": "1.1.0",
+        "artifact_type": "pqx_slice_execution_record",
+        "step_id": "AI-01",
+        "run_id": run_id,
+        "trace_id": trace_id,
+        "status": "completed",
+        "decision_summary": {
+            "execution_status": "success",
+            "control_decision": "allow",
+            "enforcement_action": "allow",
+        },
+        "artifacts_emitted": [
+            "runs/run.request.json",
+            "runs/run.result.json",
+            "runs/run.replay_result.json",
+            "runs/run.regression_run_result.json",
+            "runs/run.control_decision.json",
+        ],
+        "certification_status": "certified",
+        "replay_result_ref": "runs/run.replay_result.json",
+        "control_decision_ref": "runs/run.control_decision.json",
+        "control_surface_gap_packet_ref": None,
+        "control_surface_gap_packet_consumed": False,
+        "prioritized_control_surface_gaps": [],
+        "pqx_gap_work_items": [],
+        "control_surface_gap_influence": {
+            "influenced_execution_block": False,
+            "influenced_next_step_selection": False,
+            "influenced_priority_ordering": False,
+            "influenced_transition_decision": False,
+            "reason_codes": [],
+            "control_surface_blocking_reason_refs": [],
+        },
+    }
+
+
+def test_validate_governance_chain_returns_replay_comparison_evidence(tmp_path: Path) -> None:
+    run_id = "run-001"
+    trace_id = "trace:run-001:AI-01"
+    replay = _replay(trace_id, run_id)
+
+    result = validate_governance_chain(
+        run_id=run_id,
+        trace_id=trace_id,
+        replay_result_path=_write(tmp_path / "replay.json", replay),
+        replay_baseline_path=REPO_ROOT / "contracts" / "examples" / "replay_result.json",
+        regression_result_path=_write(tmp_path / "regression.json", _regression(trace_id, run_id)),
+        control_decision_path=_write(tmp_path / "control.json", _control(run_id, trace_id)),
+        execution_record_path=_write(tmp_path / "record.json", _execution_record(run_id, trace_id)),
+    )
+
+    assert result["comparison_digest"]
+    assert isinstance(result["hash_match"], bool)
+    assert isinstance(result["fingerprint_match"], bool)
+
+
+def test_validate_governance_chain_fails_when_regression_eval_missing(tmp_path: Path) -> None:
+    run_id = "run-001"
+    trace_id = "trace:run-001:AI-01"
+    record = _execution_record(run_id, trace_id)
+    record["artifacts_emitted"] = ["runs/run.request.json", "runs/run.replay_result.json"]
+
+    with pytest.raises(GovernanceChainGuardError, match="required eval missing"):
+        validate_governance_chain(
+            run_id=run_id,
+            trace_id=trace_id,
+            replay_result_path=_write(tmp_path / "replay.json", _replay(trace_id, run_id)),
+            replay_baseline_path=REPO_ROOT / "contracts" / "examples" / "replay_result.json",
+            regression_result_path=_write(tmp_path / "regression.json", _regression(trace_id, run_id)),
+            control_decision_path=_write(tmp_path / "control.json", _control(run_id, trace_id)),
+            execution_record_path=_write(tmp_path / "record.json", record),
+        )

--- a/tests/test_pqx_slice_runner.py
+++ b/tests/test_pqx_slice_runner.py
@@ -209,6 +209,9 @@ def test_run_pqx_slice_valid_run_emits_required_artifacts(tmp_path: Path) -> Non
     assert bundle["replay_result_ref"]
     assert bundle["control_decision_ref"]
     assert bundle["certification_result_ref"]
+    assert bundle["replay_comparison"]["comparison_digest"]
+    assert isinstance(bundle["replay_comparison"]["hash_match"], bool)
+    assert isinstance(bundle["replay_comparison"]["fingerprint_match"], bool)
 
     replay = json.loads(Path(result["slice_execution_record"]).read_text(encoding="utf-8"))
     replay_ref = replay["replay_result_ref"]


### PR DESCRIPTION
### Motivation
- Enforce Phase‑1 of the governance hardening roadmap by ensuring every PQX slice completes the PQX → eval → control → enforcement path or fails closed. 
- Prevent artifact bypass and missing-eval/control/enforcement by validating emitted artifacts, linking trace/run identities, and requiring an explicit enforcement action. 
- Provide deterministic replay evidence (hash + fingerprint) to support replayability and regression checks. 

### Description
- Added `spectrum_systems/modules/runtime/governance_chain_guard.py` which validates replay/regression/control/execution artifacts, checks schema conformance, trace/run consistency, presence of required evals, explicit enforcement actions, and returns deterministic comparison evidence (`comparison_digest`, `hash_match`, `fingerprint_match`). 
- Wired the guard into `run_pqx_slice` in `spectrum_systems/modules/runtime/pqx_slice_runner.py` to block execution with `GOVERNANCE_CHAIN_BLOCKED` on violations and to include the replay comparison evidence in the emitted audit bundle. 
- Added unit tests `tests/test_governance_chain_guard.py` covering success and failure (missing regression eval) cases and extended `tests/test_pqx_slice_runner.py` assertions to verify replay comparison evidence is present in the audit bundle. 
- Added a plan artifact `docs/review-actions/PLAN-GOV-HARDENING-PHASE1-2026-04-11.md` documenting scope, declared files, tests and exclusions for this multi-file governed change. 

### Testing
- Ran `pytest tests/test_governance_chain_guard.py tests/test_pqx_slice_runner.py` and both test files passed (all assertions succeeded). 
- Ran higher-level checks `pytest tests/test_contracts.py tests/test_module_architecture.py` and both suites passed with no regressions. 
- The added tests exercise fail-closed behavior and the PQX integration path and returned deterministic replay comparison evidence as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da1a64ba34832991becbb3399ef7bd)