### PR TITLE
DASHBOARD-NEXT-24-01: enforce fail-closed publication + live truth binding

### DIFF
--- a/dashboard/app/page.tsx
+++ b/dashboard/app/page.tsx
@@ -1,5 +1,11 @@
 import RepoDashboard from '../components/RepoDashboard'
 
+export const dynamic = 'force-dynamic'
+
 export default function Page() {
-  return <RepoDashboard />
+  return (
+    <main>
+      <RepoDashboard />
+    </main>
+  )
 }

--- a/dashboard/components/RepoDashboard.tsx
+++ b/dashboard/components/RepoDashboard.tsx
@@ -105,7 +105,7 @@ type NextAction = {
   whatChanges: string[]
 }
 
-type RefreshState = 'Fresh' | 'Stale' | 'Fallback' | 'Unknown'
+type RefreshState = 'Fresh' | 'Stale' | 'Unknown'
 
 type ArtifactLoad = {
   label: string
@@ -113,13 +113,6 @@ type ArtifactLoad = {
 }
 
 type ArtifactPresence = Record<string, boolean>
-
-const fallbackSnapshot: Snapshot = {
-  repo_name: 'spectrum-systems',
-  root_counts: { files_total: 0, runtime_modules: 0, tests: 0, contracts_total: 0, docs: 0, run_artifacts: 0 },
-  runtime_hotspots: [],
-  operational_signals: []
-}
 
 const NOT_AVAILABLE = 'Not available yet'
 const HISTORY_NOT_AVAILABLE = 'History not available yet'
@@ -229,7 +222,7 @@ function deriveRefreshState(meta: SnapshotMeta | null): { state: RefreshState; s
   if (!meta) return { state: 'Unknown', stalenessNote: 'Snapshot metadata not available.' }
 
   const source = (meta.data_source_state ?? '').toLowerCase()
-  if (source.includes('fallback')) return { state: 'Fallback', stalenessNote: 'Fallback snapshot is active.' }
+  if (source.includes('fallback')) return { state: 'Unknown', stalenessNote: 'Invalid source state: fallback is not allowed.' }
 
   if (isUnavailableText(meta.last_refreshed_time)) {
     return { state: 'Unknown', stalenessNote: 'Refresh timestamp not available.' }
@@ -246,7 +239,7 @@ function deriveRefreshState(meta: SnapshotMeta | null): { state: RefreshState; s
 }
 
 export default function RepoDashboard() {
-  const [snapshot, setSnapshot] = useState<Snapshot>(fallbackSnapshot)
+  const [snapshot, setSnapshot] = useState<Snapshot | null>(null)
   const [snapshotMeta, setSnapshotMeta] = useState<SnapshotMeta | null>(null)
   const [bottleneck, setBottleneck] = useState<BottleneckRecord | null>(null)
   const [drift, setDrift] = useState<DriftRecord | null>(null)
@@ -282,62 +275,54 @@ export default function RepoDashboard() {
 
       const snapshotData = await retrieveArtifact<Snapshot>('/repo_snapshot.json')
       presence.repo_snapshot = snapshotData.loaded
-      if (!cancelled) setSnapshot(snapshotData.data ?? fallbackSnapshot)
+      if (!cancelled) setSnapshot(snapshotData.data)
 
       const snapshotMetaData = await retrieveArtifact<SnapshotMeta>('/repo_snapshot_meta.json')
       presence.repo_snapshot_meta = snapshotMetaData.loaded
       if (!cancelled) setSnapshotMeta(snapshotMetaData.data)
 
-      const bottleneckData = await retrieveArtifact<BottleneckRecord>('/current_bottleneck_record.json')
-      presence.current_bottleneck_record = bottleneckData.loaded
-      if (!cancelled) setBottleneck(bottleneckData.data)
+      const loaders = await Promise.all([
+        retrieveArtifact<BottleneckRecord>('/current_bottleneck_record.json'),
+        retrieveArtifact<DriftRecord>('/drift_trend_continuity_artifact.json'),
+        retrieveArtifact<DriftRecord>('/prior_drift_trend_continuity_artifact.json'),
+        retrieveArtifact<RoadmapState>('/canonical_roadmap_state_artifact.json'),
+        retrieveArtifact<MaturityTracker>('/maturity_phase_tracker.json'),
+        retrieveArtifact<HardGateState>('/hard_gate_status_record.json'),
+        retrieveArtifact<HardGateState>('/prior_hard_gate_status_record.json'),
+        retrieveArtifact<RunState>('/current_run_state_record.json'),
+        retrieveArtifact<RunState>('/prior_current_run_state_record.json'),
+        retrieveArtifact<{ items?: DeferredItem[] }>('/deferred_item_register.json'),
+        retrieveArtifact<{ items?: DeferredReadiness[] }>('/deferred_return_tracker.json'),
+        retrieveArtifact<ConstitutionResult>('/constitutional_drift_checker_result.json'),
+        retrieveArtifact<ConstitutionResult>('/roadmap_alignment_validator_result.json'),
+        retrieveArtifact<ConstitutionResult>('/serial_bundle_validator_result.json')
+      ])
 
-      const driftData = await retrieveArtifact<DriftRecord>('/drift_trend_continuity_artifact.json')
-      presence.drift_trend_continuity = driftData.loaded
-      if (!cancelled) setDrift(driftData.data)
-
-      const previousDriftData = await retrieveArtifact<DriftRecord>('/prior_drift_trend_continuity_artifact.json')
-      if (!cancelled) setPreviousDrift(previousDriftData.data)
-
-      const roadmapData = await retrieveArtifact<RoadmapState>('/canonical_roadmap_state_artifact.json')
-      if (!cancelled) setRoadmapState(roadmapData.data)
-
-      const maturityData = await retrieveArtifact<MaturityTracker>('/maturity_phase_tracker.json')
-      if (!cancelled) setMaturityState(maturityData.data)
-
-      const hardGateData = await retrieveArtifact<HardGateState>('/hard_gate_status_record.json')
-      presence.hard_gate_status = hardGateData.loaded
-      if (!cancelled) setHardGate(hardGateData.data)
-
-      const previousHardGateData = await retrieveArtifact<HardGateState>('/prior_hard_gate_status_record.json')
-      if (!cancelled) setPreviousHardGate(previousHardGateData.data)
-
-      const runData = await retrieveArtifact<RunState>('/current_run_state_record.json')
-      presence.current_run_state = runData.loaded
-      if (!cancelled) setRunState(runData.data)
-
-      const previousRunData = await retrieveArtifact<RunState>('/prior_current_run_state_record.json')
-      if (!cancelled) setPreviousRunState(previousRunData.data)
-
-      const deferredData = await retrieveArtifact<{ items?: DeferredItem[] }>('/deferred_item_register.json')
-      presence.deferred_item_register = deferredData.loaded
-      if (!cancelled) setDeferredItems(Array.isArray(deferredData.data?.items) ? deferredData.data.items : [])
-
-      const trackerData = await retrieveArtifact<{ items?: DeferredReadiness[] }>('/deferred_return_tracker.json')
-      presence.deferred_return_tracker = trackerData.loaded
-      if (!cancelled) setDeferredTracker(Array.isArray(trackerData.data?.items) ? trackerData.data.items : [])
-
-      const constitutionData = await retrieveArtifact<ConstitutionResult>('/constitutional_drift_checker_result.json')
-      presence.constitutional_drift_checker = constitutionData.loaded
-      if (!cancelled) setConstitutionDrift(constitutionData.data)
-
-      const alignmentData = await retrieveArtifact<ConstitutionResult>('/roadmap_alignment_validator_result.json')
-      presence.roadmap_alignment_validator = alignmentData.loaded
-      if (!cancelled) setRoadmapAlignment(alignmentData.data)
-
-      const serialData = await retrieveArtifact<ConstitutionResult>('/serial_bundle_validator_result.json')
-      presence.serial_bundle_validator = serialData.loaded
-      if (!cancelled) setSerialBundle(serialData.data)
+      if (!cancelled) {
+        presence.current_bottleneck_record = loaders[0].loaded
+        setBottleneck(loaders[0].data)
+        presence.drift_trend_continuity = loaders[1].loaded
+        setDrift(loaders[1].data)
+        setPreviousDrift(loaders[2].data)
+        setRoadmapState(loaders[3].data)
+        setMaturityState(loaders[4].data)
+        presence.hard_gate_status = loaders[5].loaded
+        setHardGate(loaders[5].data)
+        setPreviousHardGate(loaders[6].data)
+        presence.current_run_state = loaders[7].loaded
+        setRunState(loaders[7].data)
+        setPreviousRunState(loaders[8].data)
+        presence.deferred_item_register = loaders[9].loaded
+        setDeferredItems(Array.isArray(loaders[9].data?.items) ? loaders[9].data.items : [])
+        presence.deferred_return_tracker = loaders[10].loaded
+        setDeferredTracker(Array.isArray(loaders[10].data?.items) ? loaders[10].data.items : [])
+        presence.constitutional_drift_checker = loaders[11].loaded
+        setConstitutionDrift(loaders[11].data)
+        presence.roadmap_alignment_validator = loaders[12].loaded
+        setRoadmapAlignment(loaders[12].data)
+        presence.serial_bundle_validator = loaders[13].loaded
+        setSerialBundle(loaders[13].data)
+      }
 
       if (!cancelled) setArtifactPresence(presence)
     }
@@ -349,7 +334,7 @@ export default function RepoDashboard() {
     }
   }, [])
 
-  const counts = useMemo(() => snapshot.root_counts ?? {}, [snapshot.root_counts])
+  const counts = useMemo(() => snapshot?.root_counts ?? {}, [snapshot?.root_counts])
 
   const deferredSignalById = useMemo(() => {
     const map = new Map<string, string>()
@@ -370,7 +355,7 @@ export default function RepoDashboard() {
 
   const artifactLoads = useMemo<ArtifactLoad[]>(
     () => [
-      { label: 'repo_snapshot', loaded: artifactPresence.repo_snapshot ?? !!snapshot.root_counts },
+      { label: 'repo_snapshot', loaded: artifactPresence.repo_snapshot ?? !!snapshot },
       { label: 'repo_snapshot_meta', loaded: artifactPresence.repo_snapshot_meta ?? !!snapshotMeta },
       { label: 'current_bottleneck_record', loaded: artifactPresence.current_bottleneck_record ?? !!bottleneck },
       { label: 'drift_trend_continuity', loaded: artifactPresence.drift_trend_continuity ?? !!drift },
@@ -382,7 +367,7 @@ export default function RepoDashboard() {
       { label: 'roadmap_alignment_validator', loaded: artifactPresence.roadmap_alignment_validator ?? !!roadmapAlignment },
       { label: 'serial_bundle_validator', loaded: artifactPresence.serial_bundle_validator ?? !!serialBundle }
     ],
-    [snapshot.root_counts, snapshotMeta, bottleneck, drift, hardGate, runState, constitutionDrift, roadmapAlignment, serialBundle, artifactPresence]
+    [snapshot, snapshotMeta, bottleneck, drift, hardGate, runState, constitutionDrift, roadmapAlignment, serialBundle, artifactPresence]
   )
 
   const refresh = useMemo(() => deriveRefreshState(snapshotMeta), [snapshotMeta])
@@ -408,7 +393,6 @@ export default function RepoDashboard() {
   }, [drift])
 
   const runBlocked = useMemo(() => isBlockedStatus(runState?.current_run_status), [runState])
-  const fallbackMode = refresh.state === 'Fallback'
   const staleData = refresh.state === 'Stale'
 
   const keyMissingForGuidance = useMemo(() => {
@@ -422,15 +406,37 @@ export default function RepoDashboard() {
     if (driftWorsening) warnings.push('Drift trend is worsening.')
     if (runBlocked) warnings.push('Last run is blocked or in repair-needed state.')
     if (constitutionViolations) warnings.push('Constitutional alignment warning detected.')
-    if (fallbackMode) warnings.push('Fallback snapshot is in use.')
+    if (!snapshot) warnings.push('Repository snapshot artifact is missing.')
     if (staleData) warnings.push('Snapshot appears stale.')
     if (keyMissingForGuidance) warnings.push('Key artifacts are missing; recommendation quality is degraded.')
     return warnings
-  }, [hardGateUnsatisfied, driftWorsening, runBlocked, constitutionViolations, fallbackMode, staleData, keyMissingForGuidance])
+  }, [hardGateUnsatisfied, driftWorsening, runBlocked, constitutionViolations, snapshot, staleData, keyMissingForGuidance])
 
   const showWarningBanner = topWarnings.length > 0
 
+  const truthViolation = useMemo(() => {
+    if (!snapshot || !snapshotMeta) return true
+    if ((snapshotMeta.data_source_state ?? '').toLowerCase() !== 'live') return true
+    const missingCritical = artifactLoads
+      .filter((item) => ['hard_gate_status', 'current_run_state', 'drift_trend_continuity', 'current_bottleneck_record'].includes(item.label))
+      .some((item) => !item.loaded)
+    if (missingCritical) return true
+    if (refresh.state === 'Stale') return true
+    return false
+  }, [snapshot, snapshotMeta, artifactLoads, refresh.state])
+
   const nextAction = useMemo<NextAction>(() => {
+    if (truthViolation) {
+      return {
+        title: 'No recommendation: fail-closed truth gate active',
+        reason: 'Critical artifacts are missing, stale, or not live-backed. Retrieve fresh governed artifacts before action.',
+        confidence: 'Low',
+        sourceBasis: 'truth gate',
+        why: ['Dashboard cannot imply correctness without evidence.', 'Fail-closed mode blocks action guidance under truth violation.'],
+        whatChanges: ['Required live artifacts are available and complete.', 'Freshness gate passes with current timestamps.']
+      }
+    }
+
     if (hardGateUnsatisfied) {
       const evidence = safeArray(hardGate?.required_evidence)[0]
       return {
@@ -489,7 +495,7 @@ export default function RepoDashboard() {
       why: ['Current view does not show a stronger immediate blocker.', 'A governed cycle refreshes evidence and state.'],
       whatChanges: ['Hard gate becomes unsatisfied.', 'Run state becomes blocked or bottleneck clarity increases.']
     }
-  }, [hardGateUnsatisfied, hardGate, runBlocked, runState, bottleneck, deferredItems, deferredSignalById, keyMissingForGuidance])
+  }, [truthViolation, hardGateUnsatisfied, hardGate, runBlocked, runState, bottleneck, deferredItems, deferredSignalById, keyMissingForGuidance])
 
   const completeness = useMemo(() => {
     const loaded = artifactLoads.filter((item) => item.loaded).map((item) => item.label)
@@ -567,27 +573,47 @@ export default function RepoDashboard() {
   const caveats = useMemo(() => {
     const items: string[] = []
     if (completeness.degraded) items.push('Recommendations are partially degraded due to missing key artifacts.')
-    if (refresh.state === 'Fallback') items.push('Snapshot is currently fallback data.')
+    if (truthViolation) items.push('Fail-closed truth gate is active until live artifact completeness is restored.')
     if (Object.values(changeSummary).every((value) => value === HISTORY_NOT_AVAILABLE)) items.push('Comparison history is not available yet.')
     if (nextAction.confidence === 'Low') items.push('Confidence is reduced due to incomplete or inferred evidence.')
     return items
-  }, [completeness.degraded, refresh.state, changeSummary, nextAction.confidence])
+  }, [completeness.degraded, truthViolation, changeSummary, nextAction.confidence])
 
   const readinessToExpand = useMemo(() => {
-    if (completeness.degraded) return 'Unknown'
+    if (truthViolation) return 'Unknown'
     if (hardGateUnsatisfied || constitutionViolations || runBlocked) return 'Tune instead'
     if (driftWorsening || nextAction.confidence === 'Low') return 'Validate with another run'
     return 'Ready for bounded expansion'
-  }, [completeness.degraded, hardGateUnsatisfied, constitutionViolations, runBlocked, driftWorsening, nextAction.confidence])
+  }, [truthViolation, hardGateUnsatisfied, constitutionViolations, runBlocked, driftWorsening, nextAction.confidence])
+
+  const systemMap = useMemo(
+    () => [
+      { name: 'RIL', status: artifactPresence.repo_snapshot ? 'online' : 'missing', provenance: '/repo_snapshot.json' },
+      { name: 'CDE', status: artifactPresence.current_bottleneck_record ? 'online' : 'missing', provenance: '/current_bottleneck_record.json' },
+      { name: 'TLC', status: artifactPresence.current_run_state ? 'online' : 'missing', provenance: '/current_run_state_record.json' },
+      { name: 'PQX', status: artifactPresence.serial_bundle_validator ? 'online' : 'missing', provenance: '/serial_bundle_validator_result.json' },
+      { name: 'FRE', status: artifactPresence.drift_trend_continuity ? 'online' : 'missing', provenance: '/drift_trend_continuity_artifact.json' },
+      { name: 'SEL', status: artifactPresence.hard_gate_status ? 'online' : 'missing', provenance: '/hard_gate_status_record.json' },
+      { name: 'PRG', status: artifactPresence.roadmap_alignment_validator ? 'online' : 'missing', provenance: '/roadmap_alignment_validator_result.json' }
+    ],
+    [artifactPresence]
+  )
 
   return (
     <main style={pageStyle}>
       <header style={{ marginBottom: 10 }}>
         <h1 style={{ margin: 0, fontSize: 30, lineHeight: 1.15 }}>Operator Control Surface</h1>
         <p style={{ margin: '8px 0 0', color: '#475569', fontSize: 15 }}>
-          Live governed execution view for <strong>{snapshot.repo_name ?? NOT_AVAILABLE}</strong>. Focus on what matters now, what to do next, and artifact integrity.
+          Live governed execution view for <strong>{snapshot?.repo_name ?? NOT_AVAILABLE}</strong>. Focus on what matters now, what to do next, and artifact integrity.
         </p>
       </header>
+
+      {truthViolation ? (
+        <section style={{ ...cardStyle, border: '1px solid #dc2626', background: '#fef2f2', marginTop: 12 }}>
+          <h2 style={{ margin: 0, fontSize: 16, color: '#991b1b' }}>Fail-closed mode</h2>
+          <p style={{ margin: '8px 0 0', color: '#7f1d1d' }}>Truth violation detected. Dashboard guidance is intentionally degraded until live artifact integrity is restored.</p>
+        </section>
+      ) : null}
 
       {showWarningBanner ? (
         <section style={{ ...cardStyle, border: '1px solid #fecaca', background: '#fff7f7', marginTop: 12 }}>
@@ -619,6 +645,17 @@ export default function RepoDashboard() {
       </section>
 
       <section style={sectionStyle}>
+        <article style={cardStyle}>
+          <h2 style={{ margin: 0, fontSize: 17 }}>Canonical system map</h2>
+          {systemMap.map((node) => (
+            <div key={node.name} style={{ marginTop: 10, display: 'flex', justifyContent: 'space-between', gap: 10 }}>
+              <span style={{ fontWeight: 700 }}>{node.name}</span>
+              <span style={{ color: node.status === 'online' ? '#166534' : '#b91c1c' }}>{node.status}</span>
+              <span style={{ color: '#64748b', fontSize: 12 }}>{node.provenance}</span>
+            </div>
+          ))}
+        </article>
+
         <article style={cardStyle}>
           <h2 style={{ margin: 0, fontSize: 17 }}>Trend strip</h2>
           <StringList items={trendStrip} emptyText={NOT_AVAILABLE} />

--- a/dashboard/components/RepoDashboard.tsx
+++ b/dashboard/components/RepoDashboard.tsx
@@ -114,6 +114,10 @@ type ArtifactLoad = {
 
 type ArtifactPresence = Record<string, boolean>
 
+type RenderGateResult =
+  | { kind: 'renderable'; reason: string; missing_artifacts: string[]; stale_artifacts: string[]; snapshot: Snapshot }
+  | { kind: 'no_data' | 'incomplete_publication' | 'stale' | 'truth_violation'; reason: string; missing_artifacts: string[]; stale_artifacts: string[] }
+
 const NOT_AVAILABLE = 'Not available yet'
 const HISTORY_NOT_AVAILABLE = 'History not available yet'
 const NO_DEFERRED_ITEMS = 'No deferred items'
@@ -507,6 +511,30 @@ export default function RepoDashboard() {
     }
   }, [artifactLoads])
 
+  const renderGate = useMemo<RenderGateResult>(() => {
+    if (!snapshot && !snapshotMeta) {
+      return { kind: 'no_data', reason: 'No publication artifacts are available for rendering.', missing_artifacts: ['repo_snapshot', 'repo_snapshot_meta'], stale_artifacts: [] }
+    }
+    const missingCritical = completeness.missing.filter((label) =>
+      ['repo_snapshot', 'repo_snapshot_meta', 'hard_gate_status', 'current_run_state', 'drift_trend_continuity', 'current_bottleneck_record'].includes(label)
+    )
+    if (missingCritical.length > 0) {
+      return { kind: 'incomplete_publication', reason: 'Required publication artifacts are incomplete.', missing_artifacts: missingCritical, stale_artifacts: [] }
+    }
+    if (refresh.state === 'Stale') {
+      return { kind: 'stale', reason: 'Dashboard publication is stale and blocked by freshness gate.', missing_artifacts: [], stale_artifacts: ['repo_snapshot'] }
+    }
+    if (!snapshot || (snapshotMeta?.data_source_state ?? '').toLowerCase() !== 'live' || truthViolation) {
+      return {
+        kind: 'truth_violation',
+        reason: 'Dashboard cannot prove live artifact truth for this render.',
+        missing_artifacts: snapshot ? [] : ['repo_snapshot'],
+        stale_artifacts: []
+      }
+    }
+    return { kind: 'renderable', reason: 'Dashboard publication is renderable.', missing_artifacts: [], stale_artifacts: [], snapshot }
+  }, [snapshot, snapshotMeta, completeness.missing, refresh.state, truthViolation])
+
   const integritySummary = useMemo(() => {
     const executionIntegrity = runBlocked ? 'At Risk' : runState ? 'Good' : 'Unknown'
     const reviewIntegrity = constitutionPanels.some(({ payload }) => payload) ? (constitutionViolations ? 'At Risk' : 'Good') : 'Unknown'
@@ -608,12 +636,19 @@ export default function RepoDashboard() {
         </p>
       </header>
 
-      {truthViolation ? (
+      {renderGate.kind !== 'renderable' ? (
         <section style={{ ...cardStyle, border: '1px solid #dc2626', background: '#fef2f2', marginTop: 12 }}>
-          <h2 style={{ margin: 0, fontSize: 16, color: '#991b1b' }}>Fail-closed mode</h2>
-          <p style={{ margin: '8px 0 0', color: '#7f1d1d' }}>Truth violation detected. Dashboard guidance is intentionally degraded until live artifact integrity is restored.</p>
+          <h2 style={{ margin: 0, fontSize: 16, color: '#991b1b' }}>Dashboard unavailable: {renderGate.kind}</h2>
+          <p style={{ margin: '8px 0 0', color: '#7f1d1d' }}>{renderGate.reason}</p>
+          <Field label='Missing artifacts' value='' />
+          <StringList items={renderGate.missing_artifacts} emptyText='No missing artifacts recorded.' />
+          <Field label='Stale artifacts' value='' />
+          <StringList items={renderGate.stale_artifacts} emptyText='No stale artifacts recorded.' />
         </section>
       ) : null}
+
+      {renderGate.kind !== 'renderable' ? null : (
+        <>
 
       {showWarningBanner ? (
         <section style={{ ...cardStyle, border: '1px solid #fecaca', background: '#fff7f7', marginTop: 12 }}>
@@ -882,8 +917,8 @@ export default function RepoDashboard() {
 
         <article style={cardStyle}>
           <h2 style={{ margin: 0, fontSize: 17 }}>Runtime hotspots</h2>
-          {snapshot.runtime_hotspots?.length ? (
-            snapshot.runtime_hotspots.map((hotspot, index) => (
+          {renderGate.snapshot.runtime_hotspots?.length ? (
+            renderGate.snapshot.runtime_hotspots.map((hotspot, index) => (
               <div key={`${hotspot.area ?? 'hotspot'}-${index}`} style={{ marginTop: index === 0 ? 10 : 14, paddingTop: index === 0 ? 0 : 12, borderTop: index === 0 ? 'none' : '1px solid #e2e8f0' }}>
                 <Field label='Area' value={hotspot.area} />
                 <Field label='Count' value={hotspot.count} />
@@ -899,8 +934,8 @@ export default function RepoDashboard() {
       <section style={sectionStyle}>
         <article style={cardStyle}>
           <h2 style={{ margin: 0, fontSize: 17 }}>Operational signals</h2>
-          {snapshot.operational_signals?.length ? (
-            snapshot.operational_signals.map((signal, index) => (
+          {renderGate.snapshot.operational_signals?.length ? (
+            renderGate.snapshot.operational_signals.map((signal, index) => (
               <div key={`${signal.title ?? 'signal'}-${index}`} style={{ marginTop: index === 0 ? 10 : 14, paddingTop: index === 0 ? 0 : 12, borderTop: index === 0 ? 'none' : '1px solid #e2e8f0' }}>
                 <Field label='Title' value={signal.title} />
                 <Field label='Status' value={signal.status} />
@@ -912,6 +947,8 @@ export default function RepoDashboard() {
           )}
         </article>
       </section>
+        </>
+      )}
     </main>
   )
 }

--- a/docs/review-actions/PLAN-DASHBOARD-FIX-NULL-RENDER-01-2026-04-11.md
+++ b/docs/review-actions/PLAN-DASHBOARD-FIX-NULL-RENDER-01-2026-04-11.md
@@ -1,0 +1,35 @@
+# Plan — DASHBOARD-FIX-NULL-RENDER-01 — 2026-04-11
+
+## Prompt type
+PLAN
+
+## Roadmap item
+DASHBOARD-FIX-NULL-RENDER-01
+
+## Objective
+Eliminate homepage null-dereference during Next.js prerender/build and enforce explicit fail-closed render gating via typed publication load states.
+
+## Declared files
+
+| File | Change type | Reason |
+| --- | --- | --- |
+| docs/review-actions/PLAN-DASHBOARD-FIX-NULL-RENDER-01-2026-04-11.md | CREATE | Required plan before multi-file dashboard/build hardening. |
+| dashboard/app/page.tsx | MODIFY | Encode explicit route rendering strategy and page boundary wrapper. |
+| dashboard/components/RepoDashboard.tsx | MODIFY | Add discriminated load-state union and renderability gate; remove nullable deref paths. |
+| tests/test_dashboard_render_gate_contract.py | CREATE | Add regression checks for render-gate state model and route strategy contract. |
+
+## Contracts touched
+None.
+
+## Tests that must pass after execution
+1. `pytest tests/test_dashboard_render_gate_contract.py`
+2. `cd dashboard && npm run build`
+3. `pytest tests/test_validate_dashboard_public_artifacts.py tests/test_refresh_dashboard_publication.py tests/test_rq_next_24_01.py`
+
+## Scope exclusions
+- Do not reintroduce fallback snapshot behavior.
+- Do not alter publication contract schemas.
+- Do not refactor unrelated dashboard sections outside null/render gate hardening.
+
+## Dependencies
+- Prior publication integrity and truth-validation flow in `scripts/refresh_dashboard.sh` and `scripts/validate_dashboard_public_artifacts.py` remains authoritative.

--- a/docs/review-actions/PLAN-DASHBOARD-NEXT-24-01-2026-04-11.md
+++ b/docs/review-actions/PLAN-DASHBOARD-NEXT-24-01-2026-04-11.md
@@ -1,0 +1,36 @@
+# Plan — DASHBOARD-NEXT-24-01 — 2026-04-11
+
+## Prompt type
+PLAN
+
+## Roadmap item
+DASHBOARD-NEXT-24-01
+
+## Objective
+Upgrade the dashboard publication and rendering flow to artifact-first, fail-closed execution with explicit truth enforcement and canonical system-map projection.
+
+## Declared files
+
+| File | Change type | Reason |
+| --- | --- | --- |
+| docs/review-actions/PLAN-DASHBOARD-NEXT-24-01-2026-04-11.md | CREATE | Required written plan before multi-file BUILD execution. |
+| scripts/refresh_dashboard.sh | MODIFY | Enforce publication integrity, manifest completeness/checksum, and fail-closed atomic publication metadata. |
+| scripts/validate_dashboard_public_artifacts.py | MODIFY | Enforce no-fallback truth policy, manifest/file completeness matching, and truth-violation fail-close gates. |
+| dashboard/components/RepoDashboard.tsx | MODIFY | Remove fallback snapshot behavior, centralize data retrieval, explicit no-data degradation, truth violation detection, and operator system map. |
+| tests/test_validate_dashboard_public_artifacts.py | MODIFY | Add deterministic validation coverage for no-fallback and publication manifest truth enforcement. |
+
+## Contracts touched
+None.
+
+## Tests that must pass after execution
+1. `pytest tests/test_validate_dashboard_public_artifacts.py`
+2. `pytest tests/test_refresh_dashboard_publication.py`
+3. `pytest tests/test_rq_next_24_01.py`
+
+## Scope exclusions
+- Do not modify unrelated governance roadmaps or architecture registries.
+- Do not change contract schemas in `contracts/schemas/`.
+- Do not refactor unrelated dashboard styling or non-dashboard modules.
+
+## Dependencies
+- Canonical runtime rules from `README.md` and `docs/architecture/system_registry.md` remain authoritative during implementation.

--- a/scripts/refresh_dashboard.sh
+++ b/scripts/refresh_dashboard.sh
@@ -151,17 +151,40 @@ audit_payload = {
 
 publication_manifest = {
     "artifact_type": "dashboard_publication_manifest",
+    "manifest_version": "1.0.0",
     "published_at": refreshed_at,
     "publication_mode": "atomic",
     "publication_state": "live",
-    "artifact_count": len(required_sources) + 3,
+    "publication_contract": "canonical_live_artifact_projection",
+    "artifact_count": len(required_sources) + 4,
     "surfaces": ["dashboard/public", "artifacts/dashboard", "artifacts/rq_master_36_01"],
-    "required_files": sorted(list(required_sources.keys()) + [
+    "required_files": sorted(set(list(required_sources.keys()) + [
         "repo_snapshot_meta.json",
         "dashboard_freshness_status.json",
         "dashboard_publication_sync_audit.json",
-    ]),
+        "dashboard_publication_manifest.json",
+    ])),
 }
+
+all_records = []
+for path in sorted(stage_dir.iterdir(), key=lambda item: item.name):
+    if path.is_file():
+        all_records.append(
+            {
+                "artifact": path.name,
+                "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+                "size_bytes": path.stat().st_size,
+                "source": str(required_sources[path.name].relative_to(repo_root)) if path.name in required_sources else f"generated:{path.name}",
+            }
+        )
+
+publication_manifest["file_records"] = {
+    row["artifact"]: {"sha256": row["sha256"], "size_bytes": row["size_bytes"], "source": row["source"]} for row in all_records
+}
+publication_manifest["completeness_sha256"] = hashlib.sha256(
+    "|".join(f"{row['artifact']}:{row['sha256']}" for row in all_records).encode("utf-8")
+).hexdigest()
+
 (stage_dir / "dashboard_publication_manifest.json").write_text(json.dumps(publication_manifest, indent=2) + "\n", encoding="utf-8")
 
 for entry in stage_dir.iterdir():

--- a/scripts/validate_dashboard_public_artifacts.py
+++ b/scripts/validate_dashboard_public_artifacts.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import sys
+import hashlib
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -129,9 +130,9 @@ def main() -> int:
 
     state = str(meta.get("data_source_state", "")).strip().lower()
     refreshed = str(meta.get("last_refreshed_time", "")).strip()
-    if state not in {"live", "fallback"}:
+    if state != "live":
         checks["freshness_metadata_valid"] = "fail"
-        return _fail("repo_snapshot_meta.data_source_state must be live or fallback", checks)
+        return _fail("repo_snapshot_meta.data_source_state must be live", checks)
     if not refreshed:
         checks["freshness_metadata_valid"] = "fail"
         return _fail("repo_snapshot_meta.last_refreshed_time is required", checks)
@@ -147,11 +148,11 @@ def main() -> int:
 
     freshness_state = str(freshness.get("status", "")).strip().lower()
     publication_state = str(freshness.get("publication_state", "")).strip().lower()
-    if freshness_state not in {"fresh", "stale", "fallback", "unknown"}:
-        return _fail("dashboard_freshness_status.status must be fresh/stale/fallback/unknown")
+    if freshness_state not in {"fresh", "stale", "unknown"}:
+        return _fail("dashboard_freshness_status.status must be fresh/stale/unknown")
 
-    if publication_state and publication_state not in {"live", "fallback"}:
-        return _fail("dashboard_freshness_status.publication_state must be live or fallback when present")
+    if publication_state and publication_state != "live":
+        return _fail("dashboard_freshness_status.publication_state must be live when present")
 
     if publication_state and publication_state != state:
         checks["fallback_live_ambiguity"] = "fail"
@@ -173,8 +174,8 @@ def main() -> int:
         return _fail(str(exc))
 
     audit_state = str(audit.get("publication_state", "")).strip().lower()
-    if audit_state not in {"live", "fallback"}:
-        return _fail("dashboard_publication_sync_audit.publication_state must be live or fallback")
+    if audit_state != "live":
+        return _fail("dashboard_publication_sync_audit.publication_state must be live")
     if audit_state != state:
         checks["fallback_live_ambiguity"] = "fail"
         return _fail("fallback/live ambiguity detected between repo_snapshot_meta and dashboard_publication_sync_audit", checks)
@@ -188,9 +189,44 @@ def main() -> int:
         checks["publication_atomic"] = "fail"
         return _fail("dashboard_publication_manifest.publication_mode must be atomic", checks)
 
-    if str(manifest.get("publication_state", "")).strip().lower() != state:
+    if str(manifest.get("publication_state", "")).strip().lower() != "live":
         checks["publication_atomic"] = "fail"
-        return _fail("dashboard_publication_manifest.publication_state must match repo_snapshot_meta", checks)
+        return _fail("dashboard_publication_manifest.publication_state must be live", checks)
+
+    required_files = manifest.get("required_files")
+    if not isinstance(required_files, list):
+        checks["publication_atomic"] = "fail"
+        return _fail("dashboard_publication_manifest.required_files must be a list", checks)
+
+    required_minimum = set(REQUIRED_PUBLIC + ["repo_snapshot_meta.json", "dashboard_freshness_status.json", "dashboard_publication_sync_audit.json", "dashboard_publication_manifest.json"])
+    missing_required = sorted(required_minimum - set(required_files))
+    if missing_required:
+        checks["publication_atomic"] = "fail"
+        return _fail(f"dashboard_publication_manifest.required_files missing required entries: {missing_required}", checks)
+
+    file_records = manifest.get("file_records")
+    if not isinstance(file_records, dict):
+        checks["publication_atomic"] = "fail"
+        return _fail("dashboard_publication_manifest.file_records must be an object", checks)
+
+    for required_name in required_files:
+        path = PUBLIC_ROOT / required_name
+        if not path.is_file():
+            checks["publication_atomic"] = "fail"
+            return _fail(f"manifest required file missing on disk: {required_name}", checks)
+        if required_name == "dashboard_publication_manifest.json":
+            continue
+        record = file_records.get(required_name)
+        if not isinstance(record, dict):
+            checks["publication_atomic"] = "fail"
+            return _fail(f"manifest missing file record for {required_name}", checks)
+        expected_hash = str(record.get("sha256", ""))
+        expected_size = int(record.get("size_bytes", -1))
+        actual_hash = hashlib.sha256(path.read_bytes()).hexdigest()
+        actual_size = path.stat().st_size
+        if expected_hash != actual_hash or expected_size != actual_size:
+            checks["publication_atomic"] = "fail"
+            return _fail(f"manifest/file mismatch for {required_name}", checks)
 
     checks["publication_atomic"] = "pass"
     recommendation = _read_json(PUBLIC_ROOT / "next_action_recommendation_record.json")
@@ -212,9 +248,6 @@ def main() -> int:
     confidence = float(accuracy.get("accuracy", 0.0))
     if confidence < 0.0 or confidence > 1.0:
         return _fail("recommendation_accuracy_tracker.accuracy must be between 0 and 1")
-
-    if state == "fallback" and confidence > 0.6:
-        return _fail("fallback mode must degrade recommendation confidence (accuracy <= 0.6)")
 
     if is_stale and state == "live":
         checks["freshness_metadata_valid"] = "fail"

--- a/tests/test_dashboard_render_gate_contract.py
+++ b/tests/test_dashboard_render_gate_contract.py
@@ -1,0 +1,31 @@
+"""Regression checks for dashboard null-safe render gate and route strategy."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PAGE_PATH = REPO_ROOT / "dashboard" / "app" / "page.tsx"
+COMPONENT_PATH = REPO_ROOT / "dashboard" / "components" / "RepoDashboard.tsx"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_page_uses_explicit_dynamic_render_strategy() -> None:
+    page = _read(PAGE_PATH)
+    assert "export const dynamic = 'force-dynamic'" in page
+
+
+def test_component_declares_discriminated_render_gate_states() -> None:
+    content = _read(COMPONENT_PATH)
+    for token in ["'renderable'", "'no_data'", "'incomplete_publication'", "'stale'", "'truth_violation'"]:
+        assert token in content
+
+
+def test_runtime_hotspots_are_read_only_behind_renderable_gate() -> None:
+    content = _read(COMPONENT_PATH)
+    assert "renderGate.kind !== 'renderable' ? null" in content
+    assert "renderGate.snapshot.runtime_hotspots" in content
+    assert "{snapshot.runtime_hotspots" not in content

--- a/tests/test_validate_dashboard_public_artifacts.py
+++ b/tests/test_validate_dashboard_public_artifacts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import hashlib
 import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
@@ -79,7 +80,7 @@ def test_validator_fails_on_atomic_publication_break() -> None:
     _write_json(MANIFEST_PATH, original_manifest)
 
 
-def test_validator_fails_on_fallback_live_ambiguity() -> None:
+def test_validator_fails_when_fallback_state_is_declared() -> None:
     _run([sys.executable, str(RQ_SCRIPT)])
 
     original_freshness = _read_json(FRESHNESS_PATH)
@@ -89,7 +90,7 @@ def test_validator_fails_on_fallback_live_ambiguity() -> None:
 
     result = subprocess.run([sys.executable, str(VALIDATOR)], cwd=str(REPO_ROOT), capture_output=True, text=True)
     assert result.returncode != 0
-    assert "ambiguity" in result.stderr.lower()
+    assert "must be live" in result.stderr.lower()
 
     _write_json(FRESHNESS_PATH, original_freshness)
 
@@ -109,9 +110,36 @@ def test_validator_fails_when_promotion_overrides_readiness() -> None:
     invalid_promotion["promotion_decision"] = "bounded_promote"
     _write_json(PROMOTION_PATH, invalid_promotion)
 
+    manifest = _read_json(MANIFEST_PATH)
+    for name in ("readiness_to_expand_validator.json", "governed_promotion_discipline_gate.json"):
+        path = PUBLIC_ROOT / name
+        payload = manifest["file_records"][name]
+        payload["sha256"] = hashlib.sha256(path.read_bytes()).hexdigest()
+        payload["size_bytes"] = path.stat().st_size
+    _write_json(MANIFEST_PATH, manifest)
+
     result = subprocess.run([sys.executable, str(VALIDATOR)], cwd=str(REPO_ROOT), capture_output=True, text=True)
     assert result.returncode != 0
     assert "bounded_promote" in result.stderr
 
     _write_json(readiness_path, original_readiness)
     _write_json(PROMOTION_PATH, original_promotion)
+
+
+def test_validator_fails_on_manifest_file_mismatch() -> None:
+    _run([sys.executable, str(RQ_SCRIPT)])
+
+    original_manifest = _read_json(MANIFEST_PATH)
+    broken_manifest = dict(original_manifest)
+    file_records = dict(broken_manifest["file_records"])
+    repo_snapshot_record = dict(file_records["repo_snapshot.json"])
+    repo_snapshot_record["sha256"] = "0" * 64
+    file_records["repo_snapshot.json"] = repo_snapshot_record
+    broken_manifest["file_records"] = file_records
+    _write_json(MANIFEST_PATH, broken_manifest)
+
+    result = subprocess.run([sys.executable, str(VALIDATOR)], cwd=str(REPO_ROOT), capture_output=True, text=True)
+    assert result.returncode != 0
+    assert "manifest/file mismatch" in result.stderr.lower()
+
+    _write_json(MANIFEST_PATH, original_manifest)


### PR DESCRIPTION
### Motivation
- Move the dashboard from a permissive artifact viewer with fallbacks to an artifact-first, fail-closed operator surface that never implies correctness without governed evidence. 
- Prevent partial/ambiguous publications by making publication manifests canonical, verifiable, and atomic. 
- Ensure UI only surfaces recommendations and system-state when backed by live, complete artifacts and explicitly surface missing/stale truth.

### Description
- Added a written plan file `docs/review-actions/PLAN-DASHBOARD-NEXT-24-01-2026-04-11.md` declaring scope, tests, and files involved. 
- Hardened `scripts/refresh_dashboard.sh` to produce a canonical `dashboard_publication_manifest.json` including `manifest_version`, `required_files`, per-file `file_records` (sha256/size/source), and a `completeness_sha256` checksum while preserving atomic staged publication. 
- Strengthened `scripts/validate_dashboard_public_artifacts.py` to require `repo_snapshot` state be `live`, to validate manifest `required_files` and `file_records` against on-disk files (hash + size), and to fail-closed on freshness/atomicity/manifest mismatches and truth violations. 
- Updated `dashboard/components/RepoDashboard.tsx` to remove the fallback snapshot pattern, centralize artifact loading, treat missing/stale/manifest-incomplete artifact sets as a `truthViolation` fail-closed gate (suppressing recommendations), and add a canonical system map panel which derives node status from artifact presence.

### Testing
- Ran `pytest tests/test_validate_dashboard_public_artifacts.py tests/test_refresh_dashboard_publication.py tests/test_rq_next_24_01.py` and all tests passed (14 passed total). 
- Ran dashboard lint with `cd dashboard && npm run lint` and received no ESLint warnings. 
- New/updated tests include manifest mismatch detection, fallback-state rejection, and promotion/readiness validation under manifest-aware tampering (`tests/test_validate_dashboard_public_artifacts.py`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da71f8f214832985df9b97cec60ce8)