### PR TITLE
DASHBOARD-UI-FIX-TRUTH-INTEGRITY-01: remove selector heuristics, harden validation, and fix provenance/sync audit

### DIFF
--- a/dashboard/components/RepoDashboard.tsx
+++ b/dashboard/components/RepoDashboard.tsx
@@ -13,8 +13,6 @@ export default function RepoDashboard({ model }: { model: DashboardViewModel }) 
       ? { kind: 'renderable', snapshot: model.sections.snapshot.data }
       : { kind: model.state.kind === 'renderable' ? 'truth_violation' : model.state.kind }
 
-  const runtimeHotspots = renderGate.kind !== 'renderable' ? null : renderGate.snapshot.runtime_hotspots
-
   return (
     <main style={{ maxWidth: 1100, margin: '0 auto', padding: '20px 12px 40px' }}>
       <header>
@@ -22,7 +20,6 @@ export default function RepoDashboard({ model }: { model: DashboardViewModel }) 
         <p style={{ color: '#475569' }}>Governed execution dashboard for {model.repoName}.</p>
       </header>
 
-      {runtimeHotspots ? null : null}
 
       {renderGate.kind !== 'renderable' ? (
         <div style={{ display: 'grid', gap: 12 }}>

--- a/dashboard/lib/loaders/dashboard_publication_loader.ts
+++ b/dashboard/lib/loaders/dashboard_publication_loader.ts
@@ -7,6 +7,7 @@ import type {
   DeferredItem,
   DeferredReadiness,
   DriftRecord,
+  DashboardPublicationSyncAudit,
   HardGateState,
   RecommendationAccuracyTracker,
   RecommendationRecordCollection,
@@ -43,6 +44,7 @@ export async function loadDashboardPublication(): Promise<DashboardPublication> 
     deferredRegister,
     deferredTracker,
     recommendationRecord,
+    syncAudit,
     recommendationAccuracyTracker
   ] = await Promise.all([
     fetchJsonArtifact<Snapshot>('repo_snapshot.json'),
@@ -55,6 +57,7 @@ export async function loadDashboardPublication(): Promise<DashboardPublication> 
     fetchJsonArtifact<{ items?: DeferredItem[] }>('deferred_item_register.json'),
     fetchJsonArtifact<{ items?: DeferredReadiness[] }>('deferred_return_tracker.json'),
     fetchJsonArtifact<RecommendationRecordCollection>('next_action_recommendation_record.json'),
+    fetchJsonArtifact<DashboardPublicationSyncAudit>('dashboard_publication_sync_audit.json'),
     declaredArtifacts.has('recommendation_accuracy_tracker.json')
       ? fetchJsonArtifact<RecommendationAccuracyTracker>('recommendation_accuracy_tracker.json')
       : Promise.resolve(notLoadedArtifact('recommendation_accuracy_tracker.json') as ArtifactRecord<RecommendationAccuracyTracker>)
@@ -71,6 +74,7 @@ export async function loadDashboardPublication(): Promise<DashboardPublication> 
     deferredRegister,
     deferredTracker,
     recommendationRecord,
+    syncAudit,
     recommendationAccuracyTracker
   ].map(markValidated)
 
@@ -86,7 +90,8 @@ export async function loadDashboardPublication(): Promise<DashboardPublication> 
     deferredRegister: validatedArtifacts[7] as ArtifactRecord<{ items?: DeferredItem[] }>,
     deferredTracker: validatedArtifacts[8] as ArtifactRecord<{ items?: DeferredReadiness[] }>,
     recommendationRecord: validatedArtifacts[9] as ArtifactRecord<RecommendationRecordCollection>,
-    recommendationAccuracyTracker: validatedArtifacts[10] as ArtifactRecord<RecommendationAccuracyTracker>,
+    syncAudit: validatedArtifacts[10] as ArtifactRecord<DashboardPublicationSyncAudit>,
+    recommendationAccuracyTracker: validatedArtifacts[11] as ArtifactRecord<RecommendationAccuracyTracker>,
     allArtifacts: [manifest, ...validatedArtifacts]
   }
 }

--- a/dashboard/lib/selectors/dashboard_selectors.ts
+++ b/dashboard/lib/selectors/dashboard_selectors.ts
@@ -13,16 +13,6 @@ function makeSection<T>(title: string, data: T | null, state: SectionState, reas
   return { title, data, state, reason, provenance }
 }
 
-function truthyStatus(value?: string): boolean {
-  const v = (value ?? '').toLowerCase()
-  return ['pass', 'ready', 'good', 'healthy', 'satisfied'].some((token) => v.includes(token))
-}
-
-function blockedStatus(value?: string): boolean {
-  const v = (value ?? '').toLowerCase()
-  return ['block', 'repair', 'fail', 'risk', 'freeze'].some((token) => v.includes(token))
-}
-
 function confidenceFromScore(score?: number): 'High' | 'Medium' | 'Low' {
   if (typeof score !== 'number') return 'Low'
   if (score >= 0.8) return 'High'
@@ -30,15 +20,16 @@ function confidenceFromScore(score?: number): 'High' | 'Medium' | 'Low' {
   return 'Low'
 }
 
-function recommendationProvenanceRows(record: RecommendationRecord | null, timestamp?: string): Array<{ artifact: string; path: string; keyFields: string[]; timestamp?: string }> {
-  if (!record) {
-    return [{ artifact: 'next_action_recommendation_record.json', path: '/next_action_recommendation_record.json', keyFields: ['records'], timestamp }]
+function recommendationProvenanceRows(record: RecommendationRecord, timestamp?: string): Array<{ artifact: string; path: string; keyFields: string[]; timestamp?: string }> {
+  const basis = (record.source_basis ?? []).filter((value) => typeof value === 'string' && value.trim().length > 0)
+  if (basis.length === 0) {
+    return [{ artifact: 'next_action_recommendation_record.json', path: '/next_action_recommendation_record.json', keyFields: ['records', 'recommended_next_action'], timestamp }]
   }
 
-  return (record.source_basis ?? []).map((pathValue, index) => ({
-    artifact: `recommendation_source_${index + 1}`,
-    path: pathValue,
-    keyFields: ['source_basis', 'provenance_categories'],
+  return basis.map((pathValue) => ({
+    artifact: pathValue.split('/').pop() ?? pathValue,
+    path: pathValue.startsWith('/') ? pathValue : `/${pathValue}`,
+    keyFields: ['source_basis'],
     timestamp
   }))
 }
@@ -50,6 +41,16 @@ function classifyExplorerStatus(artifact: ArtifactRecord, declaredArtifacts: Set
   if (isDeclared && !artifact.exists) return 'declared_missing'
   if (!isDeclared && artifact.exists && !artifact.valid) return 'loaded_invalid'
   return 'loaded_undeclared'
+}
+
+function deriveHardGateUnsatisfied(readinessStatus?: string): boolean {
+  const normalized = readinessStatus ?? 'unknown'
+  return normalized !== 'ready' && normalized !== 'pass'
+}
+
+function deriveRunBlocked(currentRunStatus?: string): boolean {
+  const normalized = currentRunStatus ?? 'unknown'
+  return normalized === 'blocked' || normalized === 'repair_required' || normalized === 'failed'
 }
 
 export function selectDashboardViewModel(publication: DashboardPublication): DashboardViewModel {
@@ -77,7 +78,7 @@ export function selectDashboardViewModel(publication: DashboardPublication): Das
     const loaded = loadedByName.get(name)
     return Boolean(loaded?.exists && loaded.valid)
   }).length
-  const declaredCount = publication.manifest.data?.artifact_count ?? declaredRequired.length
+  const declaredCount = declaredRequired.length
 
   const manifestCompleteness = declaredCount === 0
     ? 'No declared artifacts'
@@ -85,13 +86,13 @@ export function selectDashboardViewModel(publication: DashboardPublication): Das
       ? `Complete (${validLoadedCount}/${declaredCount})`
       : `Incomplete (${validLoadedCount}/${declaredCount} valid declared artifacts)`
 
-  const syncAuditState = publication.manifest.data?.publication_state
-    ? `manifest:${publication.manifest.data.publication_state}`
-    : 'manifest:unknown'
+  const syncAuditState = publication.syncAudit.exists && publication.syncAudit.valid
+    ? `sync_audit:${publication.syncAudit.data?.publication_state ?? 'unknown'}`
+    : `sync_audit_unavailable:${publication.syncAudit.error ?? 'missing_or_invalid'}`
 
   const truthViolation = state.kind !== 'renderable'
-  const hardGateUnsatisfied = !truthyStatus(hardGate?.readiness_status)
-  const runBlocked = blockedStatus(runState?.current_run_status)
+  const hardGateUnsatisfied = deriveHardGateUnsatisfied(hardGate?.readiness_status)
+  const runBlocked = deriveRunBlocked(runState?.current_run_status)
 
   const recommendationRecords = publication.recommendationRecord.data?.records ?? []
   const recommendationRecord = recommendationRecords.length ? recommendationRecords[recommendationRecords.length - 1] : null
@@ -114,49 +115,31 @@ export function selectDashboardViewModel(publication: DashboardPublication): Das
         provenance: recommendationProvenanceRows(recommendationRecord, publication.recommendationRecord.timestamp),
         synthesizedFallback: false
       }
-    : truthViolation
-      ? {
-          title: 'No recommendation: fail-closed truth gate active',
-          reason: 'Critical artifacts are missing, stale, invalid, or not live-backed.',
-          confidence: 'Low' as const,
-          sourceBasis: 'truth gate',
-          why: ['UI cannot imply correctness without backed artifacts.', 'Fail-closed execution blocks operator guidance under truth violation.'],
-          whatChanges: ['Required artifacts are publish-complete.', 'Freshness and source-live checks pass.'],
-          provenance: [{ artifact: publication.recommendationRecord.name, path: publication.recommendationRecord.path, keyFields: ['records'], timestamp: publication.recommendationRecord.timestamp }],
-          synthesizedFallback: true
-        }
-      : hardGateUnsatisfied
-        ? {
-            title: `Satisfy hard gate: ${hardGate?.gate_name ?? 'active gate'}`,
-            reason: 'Promotion requires certification and hard-gate evidence closure.',
-            confidence: 'High' as const,
-            sourceBasis: 'hard gate',
-            why: ['Hard gate readiness is unsatisfied.', 'Control integrity remains blocked.'],
-            whatChanges: ['Required hard-gate evidence becomes complete.', 'Hard gate readiness moves to pass/ready.'],
-            provenance: [{ artifact: publication.hardGate.name, path: publication.hardGate.path, keyFields: ['gate_name', 'readiness_status'], timestamp: publication.hardGate.timestamp }],
-            synthesizedFallback: true
-          }
-        : runBlocked
-          ? {
-              title: `Run bounded repair for ${bottleneck?.bottleneck_name ?? 'current bottleneck'}`,
-              reason: 'Current run-state artifact indicates blocked or repair-needed execution.',
-              confidence: 'High' as const,
-              sourceBasis: 'run state',
-              why: ['Run-state indicates blocked flow.', 'Repair loop pressure should be reduced before expansion.'],
-              whatChanges: ['Run state clears from blocked/repair.', 'Repair loop pressure stabilizes.'],
-              provenance: [{ artifact: publication.runState.name, path: publication.runState.path, keyFields: ['current_run_status', 'repair_loop_count'], timestamp: publication.runState.timestamp }],
-              synthesizedFallback: true
-            }
-          : {
-              title: `Address bottleneck: ${bottleneck?.bottleneck_name ?? 'best available target'}`,
-              reason: bottleneck?.explanation ?? 'Bottleneck evidence exists in published artifacts.',
-              confidence: 'Medium' as const,
-              sourceBasis: 'bottleneck',
-              why: ['Current bottleneck artifact exists.', 'Reducing bottleneck improves execution integrity.'],
-              whatChanges: ['Hard gate becomes unsatisfied.', 'Run state becomes blocked.'],
-              provenance: [{ artifact: publication.bottleneck.name, path: publication.bottleneck.path, keyFields: ['bottleneck_name', 'explanation'], timestamp: publication.bottleneck.timestamp }],
-              synthesizedFallback: true
-            }
+    : {
+        title: truthViolation
+          ? 'No recommendation: fail-closed truth gate active'
+          : hardGateUnsatisfied
+            ? `Satisfy hard gate: ${hardGate?.gate_name ?? 'active gate'}`
+            : runBlocked
+              ? `Run bounded repair for ${bottleneck?.bottleneck_name ?? 'current bottleneck'}`
+              : `Address bottleneck: ${bottleneck?.bottleneck_name ?? 'best available target'}`,
+        reason: truthViolation
+          ? 'Critical artifacts are missing, stale, invalid, or not live-backed.'
+          : hardGateUnsatisfied
+            ? 'Promotion requires certification and hard-gate evidence closure.'
+            : runBlocked
+              ? 'Current run-state artifact indicates blocked execution.'
+              : bottleneck?.explanation ?? 'Bottleneck evidence exists in published artifacts.',
+        confidence: truthViolation || hardGateUnsatisfied || runBlocked ? 'High' as const : 'Medium' as const,
+        sourceBasis: 'labeled_fallback',
+        why: [
+          'Recommendation artifact missing or invalid; fallback branch is explicitly labeled.',
+          truthViolation ? 'Fail-closed execution blocks operator guidance under truth violation.' : 'Fallback uses explicit enum-mapped status fields.'
+        ],
+        whatChanges: ['Publish a valid next_action_recommendation_record artifact to replace fallback guidance.'],
+        provenance: [{ artifact: publication.recommendationRecord.name, path: publication.recommendationRecord.path, keyFields: ['records', 'artifact_type'], timestamp: publication.recommendationRecord.timestamp }],
+        synthesizedFallback: true
+      }
 
   const freshnessHours = snapshot ? Math.max(0, Math.floor((Date.now() - Date.parse(publication.snapshotMeta.data?.last_refreshed_time ?? '')) / (1000 * 60 * 60))) : 0
 
@@ -229,7 +212,7 @@ export function selectDashboardViewModel(publication: DashboardPublication): Das
     healthScorecards: [
       { family: 'snapshot/publication', score: publication.snapshot.exists ? 100 : 0, grade: publication.snapshot.exists ? 'A' : 'F', rule: 'artifact exists + valid' },
       { family: 'run state', score: publication.runState.exists ? 100 : 0, grade: publication.runState.exists ? 'A' : 'F', rule: 'current_run_state_record required' },
-      { family: 'hard gate', score: truthyStatus(hardGate?.readiness_status) ? 100 : 40, grade: truthyStatus(hardGate?.readiness_status) ? 'A' : 'D', rule: 'readiness_status must indicate pass/ready' },
+      { family: 'hard gate', score: hardGateUnsatisfied ? 40 : 100, grade: hardGateUnsatisfied ? 'D' : 'A', rule: 'readiness_status enum must be ready/pass' },
       { family: 'drift', score: publication.drift.exists ? 100 : 0, grade: publication.drift.exists ? 'A' : 'F', rule: 'drift artifact required' },
       { family: 'recommendation quality', score: state.kind === 'renderable' && !recommendation.synthesizedFallback ? 100 : 20, grade: state.kind === 'renderable' && !recommendation.synthesizedFallback ? 'A' : 'D', rule: 'recommendation artifact should be available and valid' },
       { family: 'constitutional alignment', score: constitution?.violations?.length ? 30 : 100, grade: constitution?.violations?.length ? 'D' : 'A', rule: 'no constitutional violations' }
@@ -248,7 +231,19 @@ export function selectDashboardViewModel(publication: DashboardPublication): Das
       path: item.path,
       status: item.exists ? (item.valid ? 'valid' : 'invalid') : 'missing',
       timestamp: item.timestamp,
-      keysUsed: ['artifact-backed']
+      keysUsed: item.name === 'repo_snapshot.json'
+        ? ['repo_name', 'root_counts', 'runtime_hotspots']
+        : item.name === 'repo_snapshot_meta.json'
+          ? ['data_source_state', 'last_refreshed_time']
+          : item.name === 'hard_gate_status_record.json'
+            ? ['gate_name', 'readiness_status']
+            : item.name === 'current_run_state_record.json'
+              ? ['current_run_status', 'repair_loop_count']
+              : item.name === 'next_action_recommendation_record.json'
+                ? ['artifact_type', 'records']
+                : item.name === 'dashboard_publication_sync_audit.json'
+                  ? ['artifact_type', 'publication_state', 'records']
+                  : ['artifact_type']
     })),
     trends: [
       { label: 'freshness', value: state.kind === 'stale' ? 'stale' : 'live' },

--- a/dashboard/lib/validation/dashboard_validation.ts
+++ b/dashboard/lib/validation/dashboard_validation.ts
@@ -4,35 +4,96 @@ function isObject(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v)
 }
 
-function hasRequiredFields(data: Record<string, unknown>, fields: string[]): boolean {
-  return fields.every((field) => data[field] !== undefined && data[field] !== null)
+function isString(v: unknown): v is string {
+  return typeof v === 'string' && v.trim().length > 0
+}
+
+function isStringArray(v: unknown): v is string[] {
+  return Array.isArray(v) && v.every((item) => typeof item === 'string')
+}
+
+function isNumber(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v)
+}
+
+function requireField(data: Record<string, unknown>, field: string, check: (value: unknown) => boolean, message: string): string | null {
+  if (!check(data[field])) return message
+  return null
 }
 
 export function validateArtifactShape(name: string, data: unknown): { valid: boolean; error?: string } {
   if (data === null || data === undefined) return { valid: false, error: `${name} is null` }
-
   if (!isObject(data)) return { valid: false, error: `${name} must be object` }
 
-  if (name === 'deferred_item_register.json' || name === 'deferred_return_tracker.json') {
-    return { valid: true }
+  if (name === 'repo_snapshot_meta.json') {
+    const err = requireField(data, 'data_source_state', (value) => value === 'live' || value === 'stale' || value === 'offline', `${name} invalid data_source_state enum`) ??
+      requireField(data, 'last_refreshed_time', isString, `${name} missing last_refreshed_time string`)
+    return err ? { valid: false, error: err } : { valid: true }
   }
 
-  if (name === 'next_action_recommendation_record.json') {
-    if (!Array.isArray(data.records)) {
-      return { valid: false, error: `${name} missing required discriminator field: records` }
+  if (name === 'hard_gate_status_record.json') {
+    const err = requireField(data, 'readiness_status', (value) => ['ready', 'pass', 'blocked', 'failed', 'unknown'].includes(String(value)), `${name} invalid readiness_status enum`)
+    return err ? { valid: false, error: err } : { valid: true }
+  }
+
+  if (name === 'current_run_state_record.json') {
+    const statusErr = requireField(data, 'current_run_status', (value) => ['healthy', 'ready', 'blocked', 'repair_required', 'failed', 'unknown'].includes(String(value)), `${name} invalid current_run_status enum`)
+    if (statusErr) return { valid: false, error: statusErr }
+    if (data.repair_loop_count !== undefined && !isNumber(data.repair_loop_count)) {
+      return { valid: false, error: `${name} repair_loop_count must be number when provided` }
     }
     return { valid: true }
   }
 
-  const requiredDiscriminatorFields: Record<string, string[]> = {
-    'repo_snapshot_meta.json': ['data_source_state', 'last_refreshed_time'],
-    'hard_gate_status_record.json': ['readiness_status'],
-    'current_run_state_record.json': ['current_run_status']
+  if (name === 'next_action_recommendation_record.json') {
+    if (data.artifact_type !== 'next_action_recommendation_record_collection') {
+      return { valid: false, error: `${name} invalid artifact_type` }
+    }
+    if (!Array.isArray(data.records) || data.records.length === 0) {
+      return { valid: false, error: `${name} records must be non-empty array` }
+    }
+    for (const [idx, record] of data.records.entries()) {
+      if (!isObject(record)) return { valid: false, error: `${name} records[${idx}] must be object` }
+      if (record.artifact_type !== 'next_action_recommendation_record') {
+        return { valid: false, error: `${name} records[${idx}] invalid artifact_type` }
+      }
+      if (!isString(record.recommended_next_action)) {
+        return { valid: false, error: `${name} records[${idx}] missing recommended_next_action string` }
+      }
+      if (record.confidence !== undefined && !isNumber(record.confidence)) {
+        return { valid: false, error: `${name} records[${idx}] confidence must be number when provided` }
+      }
+      if (record.source_basis !== undefined && !isStringArray(record.source_basis)) {
+        return { valid: false, error: `${name} records[${idx}] source_basis must be string[] when provided` }
+      }
+      if (record.provenance_categories !== undefined && !isStringArray(record.provenance_categories)) {
+        return { valid: false, error: `${name} records[${idx}] provenance_categories must be string[] when provided` }
+      }
+    }
+    return { valid: true }
   }
 
-  const required = requiredDiscriminatorFields[name]
-  if (required && !hasRequiredFields(data, required)) {
-    return { valid: false, error: `${name} missing required discriminator fields: ${required.join(', ')}` }
+  if (name === 'dashboard_publication_sync_audit.json') {
+    const err = requireField(data, 'artifact_type', (value) => value === 'dashboard_publication_sync_audit', `${name} invalid artifact_type`) ??
+      requireField(data, 'publication_state', isString, `${name} missing publication_state string`) ??
+      requireField(data, 'required_artifact_count', isNumber, `${name} missing required_artifact_count number`) ??
+      requireField(data, 'records', Array.isArray, `${name} missing records array`)
+    if (err) return { valid: false, error: err }
+    const records = data.records as unknown[]
+    for (const [idx, row] of records.entries()) {
+      if (!isObject(row)) return { valid: false, error: `${name} records[${idx}] must be object` }
+      if (!isString(row.artifact) || !isString(row.source)) {
+        return { valid: false, error: `${name} records[${idx}] missing artifact/source string` }
+      }
+    }
+    return { valid: true }
+  }
+
+  if (name === 'deferred_item_register.json' || name === 'deferred_return_tracker.json') {
+    if (data.items !== undefined && !Array.isArray(data.items)) {
+      return { valid: false, error: `${name} items must be array when provided` }
+    }
+    return { valid: true }
   }
 
   return { valid: true }

--- a/dashboard/tests/dashboard_contracts.test.js
+++ b/dashboard/tests/dashboard_contracts.test.js
@@ -54,11 +54,11 @@ test('render-state guard uses manifest coverage and prioritizes source_not_live 
   assert.ok(src.indexOf('source_not_live') < src.indexOf('stale_publication'))
 })
 
-test('manifest completeness and sync audit state are manifest-data derived', () => {
+test('manifest completeness and sync audit state are truthfully derived', () => {
   const src = read('lib/selectors/dashboard_selectors.ts')
-  assert.ok(src.includes('publication.manifest.data?.artifact_count'.replace('publication.', '')))
-  assert.ok(src.includes('manifest:'))
-  assert.ok(src.includes('publication.manifest.data?.publication_state'.replace('publication.', '')))
+  assert.ok(src.includes('const declaredCount = declaredRequired.length'))
+  assert.ok(src.includes('publication.syncAudit.exists && publication.syncAudit.valid'))
+  assert.ok(src.includes('sync_audit:'))
 })
 
 test('recommendation provenance drawer binds to recommendation provenance', () => {
@@ -68,9 +68,10 @@ test('recommendation provenance drawer binds to recommendation provenance', () =
 
 test('discriminator-aware validation rules exist for critical artifacts', () => {
   const src = read('lib/validation/dashboard_validation.ts')
-  assert.ok(src.includes("'repo_snapshot_meta.json': ['data_source_state', 'last_refreshed_time']"))
-  assert.ok(src.includes("'hard_gate_status_record.json': ['readiness_status']"))
-  assert.ok(src.includes("'current_run_state_record.json': ['current_run_status']"))
+  assert.ok(src.includes("if (name === 'repo_snapshot_meta.json')"))
+  assert.ok(src.includes("if (name === 'hard_gate_status_record.json')"))
+  assert.ok(src.includes("if (name === 'current_run_state_record.json')"))
+  assert.ok(src.includes("if (name === 'next_action_recommendation_record.json')"))
 })
 
 test('artifact explorer distinguishes declared/loaded/missing/invalid states', () => {
@@ -80,6 +81,42 @@ test('artifact explorer distinguishes declared/loaded/missing/invalid states', (
   }
 })
 
+
+
+test('selector does not use token heuristics for policy-significant status', () => {
+  const src = read('lib/selectors/dashboard_selectors.ts')
+  assert.ok(!src.includes('truthyStatus'))
+  assert.ok(!src.includes('blockedStatus'))
+  assert.ok(src.includes('deriveHardGateUnsatisfied'))
+  assert.ok(src.includes('deriveRunBlocked'))
+})
+
+test('provenance no longer uses artifact-backed placeholders', () => {
+  const src = read('lib/selectors/dashboard_selectors.ts')
+  assert.ok(!src.includes("keysUsed: ['artifact-backed']"))
+  assert.ok(src.includes("item.name === 'next_action_recommendation_record.json'"))
+})
+
+test('recommendation path is artifact-first with explicit fallback labeling', () => {
+  const src = read('lib/selectors/dashboard_selectors.ts')
+  assert.ok(src.includes('const recommendationIsArtifactBacked'))
+  assert.ok(src.includes("sourceBasis: 'recommendation artifact'"))
+  assert.ok(src.includes("sourceBasis: 'labeled_fallback'"))
+  assert.ok(src.includes('synthesizedFallback: true'))
+})
+
+test('runtime hotspots are not read before renderable branch', () => {
+  const src = read('components/RepoDashboard.tsx')
+  assert.ok(!src.includes('runtime_hotspots'))
+})
+
+test('validation rejects malformed critical artifact fields', () => {
+  const src = read('lib/validation/dashboard_validation.ts')
+  assert.ok(src.includes('invalid data_source_state enum'))
+  assert.ok(src.includes('invalid readiness_status enum'))
+  assert.ok(src.includes('invalid current_run_status enum'))
+  assert.ok(src.includes('records must be non-empty array'))
+})
 test('artifact set exists for critical publication files', () => {
   const pubDir = path.join(__dirname, '..', 'public')
   for (const artifact of ['repo_snapshot.json', 'repo_snapshot_meta.json', 'hard_gate_status_record.json', 'current_run_state_record.json', 'next_action_recommendation_record.json']) {

--- a/dashboard/types/dashboard.ts
+++ b/dashboard/types/dashboard.ts
@@ -43,15 +43,19 @@ export type DriftRecord = {
   short_recommendation?: string
 }
 
+export type HardGateReadinessStatus = 'ready' | 'pass' | 'blocked' | 'failed' | 'unknown'
+
 export type HardGateState = {
   gate_name?: string
-  readiness_status?: string
+  readiness_status?: HardGateReadinessStatus
   required_evidence?: string[]
   falsification_risks?: string[]
 }
 
+export type RunExecutionStatus = 'healthy' | 'ready' | 'blocked' | 'repair_required' | 'failed' | 'unknown'
+
 export type RunState = {
-  current_run_status?: string
+  current_run_status?: RunExecutionStatus
   last_successful_cycle?: string
   last_blocked_cycle?: string
   repair_loop_count?: number
@@ -102,6 +106,13 @@ export type RecommendationAccuracyTracker = {
   accuracy?: number
 }
 
+export type DashboardPublicationSyncAudit = {
+  artifact_type?: 'dashboard_publication_sync_audit'
+  publication_state?: string
+  required_artifact_count?: number
+  records?: Array<{ artifact?: string; source?: string; sha256?: string; size_bytes?: number }>
+}
+
 export type ExplorerCoverageStatus = 'declared_loaded_valid' | 'declared_not_loaded' | 'declared_missing' | 'loaded_invalid' | 'loaded_undeclared'
 
 export type DashboardPublication = {
@@ -116,6 +127,7 @@ export type DashboardPublication = {
   deferredRegister: ArtifactRecord<{ items?: DeferredItem[] }>
   deferredTracker: ArtifactRecord<{ items?: DeferredReadiness[] }>
   recommendationRecord: ArtifactRecord<RecommendationRecordCollection>
+  syncAudit: ArtifactRecord<DashboardPublicationSyncAudit>
   recommendationAccuracyTracker: ArtifactRecord<RecommendationAccuracyTracker>
   allArtifacts: ArtifactRecord[]
 }

--- a/docs/review-actions/PLAN-DASHBOARD-UI-FIX-TRUTH-INTEGRITY-01-2026-04-11.md
+++ b/docs/review-actions/PLAN-DASHBOARD-UI-FIX-TRUTH-INTEGRITY-01-2026-04-11.md
@@ -1,0 +1,32 @@
+# Plan — DASHBOARD-UI-FIX-TRUTH-INTEGRITY-01 — 2026-04-11
+
+## Prompt type
+BUILD
+
+## Roadmap item
+DASHBOARD-UI-FIX-TRUTH-INTEGRITY-01
+
+## Objective
+Apply surgical trust-integrity remediations for dashboard selectors, validation, provenance, sync semantics, and render-gated operational reads while preserving fail-closed render suppression.
+
+## Declared files
+
+| File | Change type | Reason |
+| --- | --- | --- |
+| docs/review-actions/PLAN-DASHBOARD-UI-FIX-TRUTH-INTEGRITY-01-2026-04-11.md | CREATE | Required written plan before multi-file BUILD updates. |
+| dashboard/types/dashboard.ts | MODIFY | Add typed sync-audit artifact and explicit status enums used by selector mapping. |
+| dashboard/lib/loaders/dashboard_publication_loader.ts | MODIFY | Load sync-audit artifact and include it in publication/allArtifacts set. |
+| dashboard/lib/validation/dashboard_validation.ts | MODIFY | Enforce discriminator-aware type/enum checks for critical artifacts and fail closed on malformed payloads. |
+| dashboard/lib/selectors/dashboard_selectors.ts | MODIFY | Remove token heuristics, use enum mapping/fallback labeling, artifact-first recommendation provenance, truthful sync semantics, and real keysUsed entries. |
+| dashboard/components/RepoDashboard.tsx | MODIFY | Remove ungated operational pre-read (`runtime_hotspots`) from top-level branch. |
+| dashboard/tests/dashboard_contracts.test.js | MODIFY | Add regression checks for heuristic removal, stronger validation, provenance truth, recommendation artifact-first/fallback labeling, and sync-audit sourcing. |
+
+## Tests that must pass after execution
+1. `pytest`
+2. `cd dashboard && npm test`
+3. `cd dashboard && npm run build`
+
+## Scope exclusions
+- No new UI features.
+- No layout/styling changes.
+- No broad refactors or surface expansion.

--- a/tests/test_dashboard_render_gate_contract.py
+++ b/tests/test_dashboard_render_gate_contract.py
@@ -24,8 +24,6 @@ def test_component_declares_discriminated_render_gate_states() -> None:
         assert token in content
 
 
-def test_runtime_hotspots_are_read_only_behind_renderable_gate() -> None:
+def test_runtime_hotspots_are_not_read_in_repo_dashboard() -> None:
     content = _read(COMPONENT_PATH)
-    assert "renderGate.kind !== 'renderable' ? null" in content
-    assert "renderGate.snapshot.runtime_hotspots" in content
-    assert "{snapshot.runtime_hotspots" not in content
+    assert "runtime_hotspots" not in content


### PR DESCRIPTION
### Motivation
- Remove UI-side token heuristics that encoded governance-significant decisions and replace them with explicit, contract-backed status interpretation to restore artifact-first trust boundaries. 
- Enforce fail-closed validation for critical artifacts so malformed payloads cannot silently influence view-model derivation. 
- Replace synthetic provenance markers and misleading sync semantics with concrete artifact-backed provenance and a true sync-audit artifact source. 

### Description
- Replaced selector heuristics by removing `truthyStatus`/`blockedStatus` and adding explicit evaluators (`deriveHardGateUnsatisfied`, `deriveRunBlocked`) and an artifact-first recommendation path in `dashboard/lib/selectors/dashboard_selectors.ts`. 
- Hardened runtime validation in `dashboard/lib/validation/dashboard_validation.ts` to perform discriminator, type and enum checks for critical artifacts including `repo_snapshot_meta.json`, `hard_gate_status_record.json`, `current_run_state_record.json`, `next_action_recommendation_record.json`, and `dashboard_publication_sync_audit.json`, and preserved `markValidated` fail-closed semantics. 
- Added typed sync-audit support in `dashboard/types/dashboard.ts` and updated `dashboard/lib/loaders/dashboard_publication_loader.ts` to load and validate `dashboard_publication_sync_audit.json`, then derive `syncAuditState` from that artifact instead of implying sync from the manifest. 
- Fixed provenance to emit artifact-specific `keysUsed` and to bind recommendation provenance to real artifact identity/path (removed `keysUsed: ['artifact-backed']` and synthetic `recommendation_source_n`), removed ungated pre-read of `runtime_hotspots` from `dashboard/components/RepoDashboard.tsx`, and added a BUILD plan document `docs/review-actions/PLAN-DASHBOARD-UI-FIX-TRUTH-INTEGRITY-01-2026-04-11.md`. 
- Updated/added regression tests in `dashboard/tests/dashboard_contracts.test.js` and `tests/test_dashboard_render_gate_contract.py` to assert heuristic removal, discriminator-aware validation, truthful provenance, artifact-first recommendation/fallback labeling, sync-audit sourcing, and that `runtime_hotspots` is not read before the renderable gate. 

### Testing
- Ran `pytest` and all Python tests passed: `6141 passed, 1 skipped` (no failures). 
- Ran `cd dashboard && npm test` and the dashboard unit assertions passed (`17/17` tests in `dashboard/tests/*.test.js`). 
- Ran `cd dashboard && npm run build` and the Next.js production build completed successfully with compilation and page generation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daac2cf9ac83298c41e070c7fc7795)