### PR TITLE
RF-01-REAL: runtime-backed review_cycle_record lifecycle for step 1

### DIFF
--- a/contracts/examples/review_cycle_record.json
+++ b/contracts/examples/review_cycle_record.json
@@ -1,0 +1,23 @@
+{
+  "artifact_type": "review_cycle_record",
+  "artifact_version": "1.0.0",
+  "schema_version": "1.0.0",
+  "standards_version": "1.0.0",
+  "cycle_id": "rcy-1bbcd47ea4d95b32",
+  "parent_batch_id": "REVIEW-FIX-LOOP-36-EXPLICIT",
+  "parent_umbrella_id": "UMBRELLA-REVIEW-FIX-36",
+  "iteration_number": 1,
+  "max_iterations": 3,
+  "termination_state": "open",
+  "status": "active",
+  "review_request_ref": "review_request_artifact:rf-01-initial",
+  "review_result_refs": [],
+  "fix_slice_refs": [],
+  "replay_result_refs": [],
+  "lineage": [
+    "review_loop_entry:REVIEW-FIX-LOOP-36-EXPLICIT",
+    "owner:RQX"
+  ],
+  "created_at": "2026-04-11T00:00:00Z",
+  "updated_at": "2026-04-11T00:00:00Z"
+}

--- a/contracts/schemas/review_cycle_record.schema.json
+++ b/contracts/schemas/review_cycle_record.schema.json
@@ -1,0 +1,176 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/review_cycle_record.schema.json",
+  "title": "Review Cycle Record",
+  "description": "RQX runtime-owned review/fix/replay cycle state artifact with explicit lifecycle transitions.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_version",
+    "schema_version",
+    "standards_version",
+    "cycle_id",
+    "parent_batch_id",
+    "parent_umbrella_id",
+    "iteration_number",
+    "max_iterations",
+    "termination_state",
+    "status",
+    "review_request_ref",
+    "review_result_refs",
+    "fix_slice_refs",
+    "replay_result_refs",
+    "lineage",
+    "created_at",
+    "updated_at"
+  ],
+  "properties": {
+    "artifact_type": {
+      "type": "string",
+      "const": "review_cycle_record"
+    },
+    "artifact_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "standards_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "cycle_id": {
+      "type": "string",
+      "pattern": "^rcy-[a-f0-9]{16}$"
+    },
+    "parent_batch_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "parent_umbrella_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "iteration_number": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "max_iterations": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "termination_state": {
+      "type": "string",
+      "enum": [
+        "open",
+        "completed",
+        "max_iterations_reached",
+        "terminated_by_policy",
+        "failed"
+      ]
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "active",
+        "completed",
+        "terminated",
+        "failed"
+      ]
+    },
+    "review_request_ref": {
+      "type": "string",
+      "pattern": "^review_request_artifact:.+"
+    },
+    "review_result_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^review_result_artifact:.+"
+      }
+    },
+    "fix_slice_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^review_fix_slice_artifact:.+"
+      }
+    },
+    "replay_result_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^replay_execution_record:.+"
+      }
+    },
+    "lineage": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "const": "active"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "termination_state": {
+            "const": "open"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "enum": [
+              "completed",
+              "terminated",
+              "failed"
+            ]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "termination_state": {
+            "not": {
+              "const": "open"
+            }
+          }
+        }
+      }
+    },
+    {
+      "properties": {
+        "iteration_number": true,
+        "max_iterations": true
+      },
+      "required": [
+        "iteration_number",
+        "max_iterations"
+      ]
+    }
+  ]
+}

--- a/contracts/standards-manifest.json
+++ b/contracts/standards-manifest.json
@@ -1,9 +1,9 @@
 {
   "artifact_type": "standards_manifest",
   "artifact_id": "STD-CONTRACTS",
-  "artifact_version": "1.3.108",
+  "artifact_version": "1.3.109",
   "schema_version": "1.3.98",
-  "standards_version": "1.3.109",
+  "standards_version": "1.3.110",
   "record_id": "REC-STD-2026-04-09-CTX-A",
   "run_id": "run-20260409T000000Z-ctx-a",
   "created_at": "2026-04-09T00:00:00Z",
@@ -15,7 +15,7 @@
     "contact": "architecture@spectrum-systems.test"
   },
   "source_repo": "nicklasorte/spectrum-systems",
-  "source_repo_version": "1.3.108",
+  "source_repo_version": "1.3.109",
   "input_artifacts": [
     {
       "artifact_id": "STD-CONTRACTS",
@@ -4678,6 +4678,19 @@
       "last_updated_in": "1.0.82",
       "example_path": "contracts/examples/xrun_signal_quality_result.json",
       "notes": "VAL-06 governed validation artifact proving deterministic XRUN-01 pattern/action/signal quality and fail-closed handling under insufficient/malformed inputs."
+    },
+    {
+      "artifact_type": "review_cycle_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.109",
+      "last_updated_in": "1.3.109",
+      "example_path": "contracts/examples/review_cycle_record.json",
+      "notes": "RF-01-REAL runtime-owned review/fix/replay cycle state artifact emitted by RQX lifecycle functions with fail-closed transitions."
     }
   ]
 }

--- a/docs/review-actions/PLAN-RF-01-REAL-2026-04-11.md
+++ b/docs/review-actions/PLAN-RF-01-REAL-2026-04-11.md
@@ -1,0 +1,22 @@
+# PLAN-RF-01-REAL-2026-04-11
+
+## Prompt type
+BUILD
+
+## Scope
+Implement RF-01 runtime-backed `review_cycle_record` support for `REVIEW-FIX-LOOP-36-EXPLICIT` step 1 with strict fail-closed transitions and contract validation.
+
+## Serial execution plan
+1. Inspect current review-fix loop runner and identify synthetic step-1 emission path.
+2. Add canonical `review_cycle_record` schema + example contract and register it in standards manifest.
+3. Implement runtime module under `spectrum_systems/modules/runtime/` with real lifecycle functions:
+   - `create_review_cycle`
+   - `advance_review_cycle`
+   - `attach_review_result`
+   - `attach_fix_slice`
+   - `attach_replay_result`
+   - `terminate_review_cycle`
+4. Wire runner step 1 to call the runtime module (no direct static JSON for cycle state).
+5. Add focused tests for lifecycle behavior and fail-closed transitions.
+6. Update runner tests to prove step 1 uses real runtime implementation path.
+7. Run targeted tests + contract checks required by touched surfaces.

--- a/scripts/run_review_fix_loop_36_explicit.py
+++ b/scripts/run_review_fix_loop_36_explicit.py
@@ -4,11 +4,17 @@
 from __future__ import annotations
 
 import json
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from spectrum_systems.modules.runtime.review_cycle_record import create_review_cycle
+
 ARTIFACT_ROOT = REPO_ROOT / "artifacts" / "review_fix_loop_36_explicit"
 TRACE_PATH = REPO_ROOT / "artifacts" / "rdx_runs" / "REVIEW-FIX-LOOP-36-EXPLICIT-artifact-trace.json"
 BATCH_ID = "REVIEW-FIX-LOOP-36-EXPLICIT"
@@ -93,6 +99,16 @@ def _write_json(path: Path, payload: dict[str, Any]) -> None:
 
 
 def _base_payload(step: dict[str, Any], generated_at: str) -> dict[str, Any]:
+    if step["file"] == "review_cycle_record.json":
+        return create_review_cycle(
+            parent_batch_id=BATCH_ID,
+            parent_umbrella_id="UMBRELLA-REVIEW-FIX-36",
+            max_iterations=3,
+            review_request_ref="review_request_artifact:REVIEW-FIX-LOOP-36-EXPLICIT:initial",
+            lineage=["review_loop_entry:REVIEW-FIX-LOOP-36-EXPLICIT", "owner:RQX"],
+            created_at=generated_at,
+        )
+
     payload: dict[str, Any] = {
         "artifact_type": step["file"].removesuffix(".json"),
         "batch_id": BATCH_ID,
@@ -102,18 +118,7 @@ def _base_payload(step: dict[str, Any], generated_at: str) -> dict[str, Any]:
         "generated_at": generated_at,
     }
 
-    if step["file"] == "review_cycle_record.json":
-        payload.update(
-            {
-                "cycle_id": "RFCYCLE-36-01",
-                "iteration_number": 1,
-                "max_iterations": 3,
-                "termination_state": "continue_until_checkpoint_failure_or_completion",
-                "parent_batch_id": BATCH_ID,
-                "parent_umbrella_id": "UMBRELLA-REVIEW-FIX-36",
-            }
-        )
-    elif step["file"] == "review_pass_classification.json":
+    if step["file"] == "review_pass_classification.json":
         payload.update(
             {
                 "first_pass": True,

--- a/spectrum_systems/modules/runtime/review_cycle_record.py
+++ b/spectrum_systems/modules/runtime/review_cycle_record.py
@@ -1,0 +1,153 @@
+"""Runtime lifecycle support for review_cycle_record artifacts."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timezone
+from typing import Any
+
+from spectrum_systems.contracts import validate_artifact
+from spectrum_systems.utils.deterministic_id import deterministic_id
+
+
+class ReviewCycleRecordError(ValueError):
+    """Raised when review-cycle lifecycle operations violate fail-closed rules."""
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _validate_cycle(record: dict[str, Any]) -> None:
+    try:
+        validate_artifact(record, "review_cycle_record")
+    except Exception as exc:  # pragma: no cover - wrapper
+        raise ReviewCycleRecordError(f"invalid review_cycle_record: {exc}") from exc
+
+
+def _next_unique(existing: list[str], new_ref: str) -> list[str]:
+    if new_ref in existing:
+        return list(existing)
+    return [*existing, new_ref]
+
+
+def create_review_cycle(
+    *,
+    parent_batch_id: str,
+    parent_umbrella_id: str,
+    max_iterations: int,
+    review_request_ref: str,
+    lineage: list[str],
+    created_at: str | None = None,
+    cycle_id: str | None = None,
+) -> dict[str, Any]:
+    if not parent_batch_id:
+        raise ReviewCycleRecordError("parent_batch_id is required")
+    if not parent_umbrella_id:
+        raise ReviewCycleRecordError("parent_umbrella_id is required")
+    if max_iterations < 1:
+        raise ReviewCycleRecordError("max_iterations must be >= 1")
+    if not review_request_ref:
+        raise ReviewCycleRecordError("review_request_ref is required")
+    if not lineage:
+        raise ReviewCycleRecordError("lineage must include at least one ref")
+
+    now = created_at or _utc_now_iso()
+    resolved_cycle_id = cycle_id or deterministic_id(
+        prefix="rcy",
+        namespace="review_cycle_record",
+        payload=[parent_batch_id, parent_umbrella_id, review_request_ref, max_iterations, lineage],
+    )
+    record = {
+        "artifact_type": "review_cycle_record",
+        "artifact_version": "1.0.0",
+        "schema_version": "1.0.0",
+        "standards_version": "1.0.0",
+        "cycle_id": resolved_cycle_id,
+        "parent_batch_id": parent_batch_id,
+        "parent_umbrella_id": parent_umbrella_id,
+        "iteration_number": 1,
+        "max_iterations": max_iterations,
+        "termination_state": "open",
+        "status": "active",
+        "review_request_ref": review_request_ref,
+        "review_result_refs": [],
+        "fix_slice_refs": [],
+        "replay_result_refs": [],
+        "lineage": list(lineage),
+        "created_at": now,
+        "updated_at": now,
+    }
+    _validate_cycle(record)
+    return record
+
+
+def advance_review_cycle(record: dict[str, Any], *, updated_at: str | None = None) -> dict[str, Any]:
+    if record.get("status") != "active":
+        raise ReviewCycleRecordError("cannot advance terminated review cycle")
+    next_iteration = int(record["iteration_number"]) + 1
+    if next_iteration > int(record["max_iterations"]):
+        raise ReviewCycleRecordError("cannot advance beyond max_iterations")
+
+    advanced = deepcopy(record)
+    advanced["iteration_number"] = next_iteration
+    advanced["updated_at"] = updated_at or _utc_now_iso()
+    _validate_cycle(advanced)
+    return advanced
+
+
+def attach_review_result(record: dict[str, Any], *, review_result_ref: str, updated_at: str | None = None) -> dict[str, Any]:
+    if record.get("status") != "active":
+        raise ReviewCycleRecordError("cannot attach review_result_ref to terminated review cycle")
+    if not review_result_ref:
+        raise ReviewCycleRecordError("review_result_ref is required")
+
+    updated = deepcopy(record)
+    updated["review_result_refs"] = _next_unique(list(record["review_result_refs"]), review_result_ref)
+    updated["updated_at"] = updated_at or _utc_now_iso()
+    _validate_cycle(updated)
+    return updated
+
+
+def attach_fix_slice(record: dict[str, Any], *, fix_slice_ref: str, updated_at: str | None = None) -> dict[str, Any]:
+    if record.get("status") != "active":
+        raise ReviewCycleRecordError("cannot attach fix_slice_ref to terminated review cycle")
+    if not fix_slice_ref:
+        raise ReviewCycleRecordError("fix_slice_ref is required")
+
+    updated = deepcopy(record)
+    updated["fix_slice_refs"] = _next_unique(list(record["fix_slice_refs"]), fix_slice_ref)
+    updated["updated_at"] = updated_at or _utc_now_iso()
+    _validate_cycle(updated)
+    return updated
+
+
+def attach_replay_result(record: dict[str, Any], *, replay_result_ref: str, updated_at: str | None = None) -> dict[str, Any]:
+    if record.get("status") != "active":
+        raise ReviewCycleRecordError("cannot attach replay_result_ref to terminated review cycle")
+    if not replay_result_ref:
+        raise ReviewCycleRecordError("replay_result_ref is required")
+
+    updated = deepcopy(record)
+    updated["replay_result_refs"] = _next_unique(list(record["replay_result_refs"]), replay_result_ref)
+    updated["updated_at"] = updated_at or _utc_now_iso()
+    _validate_cycle(updated)
+    return updated
+
+
+def terminate_review_cycle(
+    record: dict[str, Any],
+    *,
+    termination_state: str,
+    status: str,
+    updated_at: str | None = None,
+) -> dict[str, Any]:
+    if record.get("status") != "active":
+        raise ReviewCycleRecordError("review cycle already terminated")
+
+    terminated = deepcopy(record)
+    terminated["termination_state"] = termination_state
+    terminated["status"] = status
+    terminated["updated_at"] = updated_at or _utc_now_iso()
+    _validate_cycle(terminated)
+    return terminated

--- a/tests/test_review_cycle_record_runtime.py
+++ b/tests/test_review_cycle_record_runtime.py
@@ -1,0 +1,83 @@
+"""Runtime tests for review_cycle_record lifecycle behavior."""
+
+from __future__ import annotations
+
+import pytest
+from jsonschema.exceptions import ValidationError
+
+from spectrum_systems.contracts import validate_artifact
+from spectrum_systems.modules.runtime.review_cycle_record import (
+    ReviewCycleRecordError,
+    advance_review_cycle,
+    attach_fix_slice,
+    attach_replay_result,
+    attach_review_result,
+    create_review_cycle,
+    terminate_review_cycle,
+)
+
+
+def _create() -> dict:
+    return create_review_cycle(
+        parent_batch_id="REVIEW-FIX-LOOP-36-EXPLICIT",
+        parent_umbrella_id="UMBRELLA-REVIEW-FIX-36",
+        max_iterations=3,
+        review_request_ref="review_request_artifact:rf-01-initial",
+        lineage=["review_loop_entry:REVIEW-FIX-LOOP-36-EXPLICIT", "owner:RQX"],
+        created_at="2026-04-11T00:00:00Z",
+    )
+
+
+def test_create_review_cycle_from_real_function_call() -> None:
+    cycle = _create()
+    assert cycle["artifact_type"] == "review_cycle_record"
+    assert cycle["iteration_number"] == 1
+    assert cycle["status"] == "active"
+    assert cycle["termination_state"] == "open"
+
+
+def test_iteration_increment_behavior() -> None:
+    cycle = _create()
+    cycle = advance_review_cycle(cycle, updated_at="2026-04-11T00:10:00Z")
+    assert cycle["iteration_number"] == 2
+    assert cycle["updated_at"] == "2026-04-11T00:10:00Z"
+
+
+def test_attach_review_fix_replay_references() -> None:
+    cycle = _create()
+    cycle = attach_review_result(cycle, review_result_ref="review_result_artifact:r1")
+    cycle = attach_fix_slice(cycle, fix_slice_ref="review_fix_slice_artifact:f1")
+    cycle = attach_replay_result(cycle, replay_result_ref="replay_execution_record:p1")
+    assert cycle["review_result_refs"] == ["review_result_artifact:r1"]
+    assert cycle["fix_slice_refs"] == ["review_fix_slice_artifact:f1"]
+    assert cycle["replay_result_refs"] == ["replay_execution_record:p1"]
+
+
+def test_termination_behavior_blocks_future_mutation() -> None:
+    cycle = _create()
+    terminated = terminate_review_cycle(
+        cycle,
+        termination_state="completed",
+        status="completed",
+        updated_at="2026-04-11T00:20:00Z",
+    )
+    assert terminated["status"] == "completed"
+    assert terminated["termination_state"] == "completed"
+
+    with pytest.raises(ReviewCycleRecordError):
+        advance_review_cycle(terminated)
+
+
+def test_invalid_transitions_fail_closed() -> None:
+    cycle = _create()
+    cycle = advance_review_cycle(cycle)
+    cycle = advance_review_cycle(cycle)
+    with pytest.raises(ReviewCycleRecordError):
+        advance_review_cycle(cycle)
+
+
+def test_missing_required_fields_fail_validation() -> None:
+    cycle = _create()
+    cycle.pop("review_request_ref")
+    with pytest.raises(ValidationError):
+        validate_artifact(cycle, "review_cycle_record")

--- a/tests/test_review_fix_loop_36_explicit.py
+++ b/tests/test_review_fix_loop_36_explicit.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+from importlib import util
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -95,3 +96,39 @@ def test_registry_alignment_cross_checks_all_pass() -> None:
     summary = _load_json(ARTIFACT_ROOT / "checkpoint_summary.json")
     assert len(summary["checkpoints"]) == 12
     assert all(status == "pass" for status in summary["checkpoints"].values())
+
+
+def test_step_1_uses_runtime_review_cycle_creation(monkeypatch) -> None:
+    spec = util.spec_from_file_location("rf36_runner", SCRIPT_PATH)
+    assert spec and spec.loader
+    module = util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    called = {"value": False}
+
+    def _fake_create_review_cycle(**kwargs):
+        called["value"] = True
+        return {
+            "artifact_type": "review_cycle_record",
+            "artifact_version": "1.0.0",
+            "schema_version": "1.0.0",
+            "standards_version": "1.0.0",
+            "cycle_id": "rcy-aaaaaaaaaaaaaaaa",
+            "parent_batch_id": kwargs["parent_batch_id"],
+            "parent_umbrella_id": kwargs["parent_umbrella_id"],
+            "iteration_number": 1,
+            "max_iterations": kwargs["max_iterations"],
+            "termination_state": "open",
+            "status": "active",
+            "review_request_ref": kwargs["review_request_ref"],
+            "review_result_refs": [],
+            "fix_slice_refs": [],
+            "replay_result_refs": [],
+            "lineage": list(kwargs["lineage"]),
+            "created_at": kwargs["created_at"],
+            "updated_at": kwargs["created_at"],
+        }
+
+    monkeypatch.setattr(module, "create_review_cycle", _fake_create_review_cycle)
+    module.main()
+    assert called["value"] is True


### PR DESCRIPTION
### Motivation

- Provide a real runtime implementation for `review_cycle_record` as the FIRST step of REVIEW-FIX-LOOP-36-EXPLICIT, replacing the previous synthetic JSON emission.
- Ensure the cycle is a fail-closed, schema-validated runtime artifact (owned by RQX) that can be advanced and updated by downstream review/fix/replay steps.
- Keep changes surgical: wire only step 1 to real runtime, add strict contract/schema, and prove behavior with tests.

### Description

- Added a runtime module `spectrum_systems/modules/runtime/review_cycle_record.py` implementing lifecycle primitives: `create_review_cycle`, `advance_review_cycle`, `attach_review_result`, `attach_fix_slice`, `attach_replay_result`, and `terminate_review_cycle`, and fail-closed validation wrappers.
- Added a canonical schema `contracts/schemas/review_cycle_record.schema.json` and example `contracts/examples/review_cycle_record.json`, and registered the contract in `contracts/standards-manifest.json` (manifest version bumped).
- Wired the RF-01 runner so step 1 calls the real runtime constructor (`create_review_cycle`) in `scripts/run_review_fix_loop_36_explicit.py` instead of synthesizing static JSON fields.
- Added tests: `tests/test_review_cycle_record_runtime.py` to validate lifecycle behavior and `tests/test_review_fix_loop_36_explicit.py` was extended with a monkeypatch-based test proving the runner invokes `create_review_cycle`; and added a plan document `docs/review-actions/PLAN-RF-01-REAL-2026-04-11.md` per repo rules.

### Testing

- Ran unit tests for the new lifecycle and runner: `pytest tests/test_review_cycle_record_runtime.py tests/test_review_fix_loop_36_explicit.py` and all tests passed.
- Ran full contract validation: `pytest tests/test_contracts.py tests/test_contract_enforcement.py` and `python scripts/run_contract_enforcement.py`, and these succeeded with zero enforcement failures.
- Executed the contract-boundary audit script `.codex/skills/contract-boundary-audit/run.sh`; it completed but emits repository-wide warnings (pre-existing) that are informational and unrelated to the new `review_cycle_record` contract.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dab86f74b483298b8bec2e5762f5f2)