### PR TITLE
Add RF-01 forensic review report: confirm review_cycle_record is real runtime behavior

### DIFF
--- a/docs/review-actions/RF-01-REAL-REVIEW.md
+++ b/docs/review-actions/RF-01-REAL-REVIEW.md
@@ -1,0 +1,125 @@
+# RF-01-REAL-REVIEW
+
+- **TITLE**: RF-01-REAL-REVIEW — Verify `review_cycle_record` is real runtime behavior
+- **BATCH**: RF-01-REAL-REVIEW
+- **EXECUTION_MODE**: FORENSIC REVIEW WITH FAIL-FAST REPORTING
+- **Reviewed on**: 2026-04-11
+
+## Short summary
+RF-01 is implemented as **real runtime behavior** for lifecycle creation and state transitions within `review_cycle_record.py`, is schema-backed with fail-closed validation per transition, is wired into step-1 of the RF-01 runner, and has behavioral tests that exercise transition logic (not only file existence).
+
+## Phase 1 — Runtime module review
+
+```json
+{
+  "runtime_module_real": true,
+  "missing_runtime_functions": [],
+  "fake_or_wrapper_patterns": []
+}
+```
+
+Evidence:
+- Runtime lifecycle functions are present as first-class operations: `create_review_cycle`, `advance_review_cycle`, `attach_review_result`, `attach_fix_slice`, `attach_replay_result`, `terminate_review_cycle`.
+- Functions mutate immutable copies (`deepcopy`) and re-validate on every transition via `_validate_cycle(...)`.
+- Invalid conditions raise `ReviewCycleRecordError` before state mutation (fail-closed guards).
+
+## Phase 2 — State transition review
+
+```json
+{
+  "state_transition_real": true,
+  "valid_transitions_supported": [
+    "creation (active/open at iteration 1)",
+    "iteration increment while active and <= max_iterations",
+    "attach review_result refs",
+    "attach fix_slice refs",
+    "attach replay_result refs",
+    "termination to completed/terminated/failed with non-open termination_state"
+  ],
+  "invalid_transitions_blocked": true,
+  "transition_gaps": []
+}
+```
+
+Evidence:
+- `advance_review_cycle` blocks advancement when status is non-active and when next iteration exceeds max.
+- `attach_*` methods reject empty refs and any mutation after termination.
+- `terminate_review_cycle` rejects double-termination.
+
+## Phase 3 — Schema / contract review
+
+```json
+{
+  "schema_valid": true,
+  "manifest_updated": true,
+  "example_consistent_with_runtime": true,
+  "contract_gaps": []
+}
+```
+
+Evidence:
+- Schema is strict (`additionalProperties: false`) and requires all lifecycle fields.
+- Schema enforces state coupling (`status=active => termination_state=open`; terminal statuses forbid `open`).
+- Standards manifest includes `review_cycle_record` with schema/example references.
+- Example artifact matches runtime initialization shape and field semantics.
+
+## Phase 4 — Runner integration review
+
+```json
+{
+  "runner_calls_real_runtime": true,
+  "runner_still_materializes_rf01": false,
+  "runner_integration_gaps": []
+}
+```
+
+Evidence:
+- Runner imports and calls `create_review_cycle(...)` for step-1 `review_cycle_record.json`.
+- Step-1 payload is not inline-authored as static JSON; it is generated through runtime lifecycle logic.
+
+## Phase 5 — Test quality review
+
+```json
+{
+  "tests_behavioral": true,
+  "behavioral_coverage": [
+    "cycle creation",
+    "iteration advancement",
+    "reference attachment",
+    "termination",
+    "invalid transition fail-closed",
+    "runner path invokes runtime create_review_cycle"
+  ],
+  "artifact_only_test_patterns": [
+    "Some runner tests still assert file presence/size for broad pipeline outputs (acceptable but not sufficient alone)."
+  ],
+  "test_gaps": []
+}
+```
+
+Evidence:
+- Runtime unit tests assert lifecycle transitions and transition failures via raised exceptions.
+- Runner test monkeypatches `create_review_cycle` and proves invocation by `main()`.
+
+## Phase 6 — Final verdict
+
+```json
+{
+  "rf01_state": "REAL",
+  "confidence": 0.94,
+  "strongest_evidence_it_is_real": [
+    "Dedicated runtime lifecycle module with explicit transition APIs and fail-closed guards.",
+    "Per-transition schema validation enforced through validate_artifact wrapper.",
+    "Runner step-1 delegates to create_review_cycle instead of inline artifact construction.",
+    "Behavioral tests cover transitions and invalid-transition rejection, plus runner-runtime invocation path."
+  ],
+  "remaining_fake_or_weak_seams": [
+    "Runner remains artifact-materialization-heavy for non-RF-01 steps; this does not invalidate RF-01 realism but is a broader architectural seam.",
+    "No dedicated negative test for invalid terminate status/state combinations in runtime unit tests."
+  ],
+  "next_required_fix_before_rf02": [
+    "Add explicit runtime tests for terminate_review_cycle invalid status/termination_state combinations to harden fail-closed guarantees.",
+    "Optionally migrate additional runner steps to runtime-owned lifecycle modules to reduce inline payload materialization patterns."
+  ]
+}
+```


### PR DESCRIPTION
### Motivation
- Document the forensic review that verifies `review_cycle_record` is implemented as real runtime behavior (lifecycle APIs, fail-closed transitions, schema-backed), and record the phase-by-phase findings and final verdict.

### Description
- Add `docs/review-actions/RF-01-REAL-REVIEW.md` containing the six-phase forensic review, evidence that the runtime API (`create_review_cycle`, `advance_review_cycle`, `attach_*`, `terminate_review_cycle`) is used by the RF-01 runner, schema/manifest alignment, test coverage notes, and the final verdict `RF-01: REAL`.

### Testing
- Ran `pytest -q tests/test_review_cycle_record_runtime.py tests/test_review_fix_loop_36_explicit.py` and observed `11 passed`, verifying behavioral unit tests and the runner integration test that confirms the runner calls the runtime `create_review_cycle` implementation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dabc3ff3f08329bcbcf755aab0d415)