### PR TITLE
RAX-01-REAL: Add strict roadmap expansion contracts and deterministic policy foundation

### DIFF
--- a/config/roadmap_expansion_policy.json
+++ b/config/roadmap_expansion_policy.json
@@ -1,0 +1,141 @@
+{
+  "policy_id": "roadmap-expansion-policy",
+  "policy_version": "1.0.0",
+  "description": "Deterministic mapping surface for roadmap contract expansion. This file is configuration-only and carries no execution authority.",
+  "owner_defaults": {
+    "RIL": {
+      "allowed_module_prefixes": [
+        "spectrum_systems/modules/review/"
+      ],
+      "allowed_test_prefixes": [
+        "tests/test_review"
+      ],
+      "default_contract_locations": [
+        "contracts/schemas/"
+      ],
+      "default_acceptance_check_templates": [
+        "schema_validation_passes",
+        "consumer_wiring_declared"
+      ]
+    },
+    "CDE": {
+      "allowed_module_prefixes": [
+        "spectrum_systems/modules/closure/"
+      ],
+      "allowed_test_prefixes": [
+        "tests/test_done",
+        "tests/test_promotion"
+      ],
+      "default_contract_locations": [
+        "contracts/schemas/"
+      ],
+      "default_acceptance_check_templates": [
+        "decision_authority_preserved",
+        "promotion_gate_validation"
+      ]
+    },
+    "TLC": {
+      "allowed_module_prefixes": [
+        "spectrum_systems/modules/orchestration/"
+      ],
+      "allowed_test_prefixes": [
+        "tests/test_top_level",
+        "tests/test_cycle"
+      ],
+      "default_contract_locations": [
+        "contracts/schemas/"
+      ],
+      "default_acceptance_check_templates": [
+        "orchestration_contract_alignment",
+        "deterministic_route_selection"
+      ]
+    },
+    "PQX": {
+      "allowed_module_prefixes": [
+        "spectrum_systems/modules/runtime/",
+        "spectrum_systems/modules/agent_runtime/"
+      ],
+      "allowed_test_prefixes": [
+        "tests/test_pqx",
+        "tests/test_roadmap"
+      ],
+      "default_contract_locations": [
+        "contracts/schemas/"
+      ],
+      "default_acceptance_check_templates": [
+        "schema_validation_passes",
+        "deterministic_replay_compatibility"
+      ]
+    },
+    "FRE": {
+      "allowed_module_prefixes": [
+        "spectrum_systems/modules/failure/"
+      ],
+      "allowed_test_prefixes": [
+        "tests/test_failure"
+      ],
+      "default_contract_locations": [
+        "contracts/schemas/"
+      ],
+      "default_acceptance_check_templates": [
+        "failure_surface_preserved",
+        "repair_artifact_compatibility"
+      ]
+    },
+    "SEL": {
+      "allowed_module_prefixes": [
+        "spectrum_systems/modules/control/"
+      ],
+      "allowed_test_prefixes": [
+        "tests/test_control",
+        "tests/test_policy"
+      ],
+      "default_contract_locations": [
+        "contracts/schemas/"
+      ],
+      "default_acceptance_check_templates": [
+        "fail_closed_guards_present",
+        "enforcement_contract_alignment"
+      ]
+    },
+    "PRG": {
+      "allowed_module_prefixes": [
+        "spectrum_systems/modules/program/"
+      ],
+      "allowed_test_prefixes": [
+        "tests/test_program",
+        "tests/test_roadmap"
+      ],
+      "default_contract_locations": [
+        "contracts/schemas/"
+      ],
+      "default_acceptance_check_templates": [
+        "roadmap_authority_alignment",
+        "priority_contract_consistency"
+      ]
+    }
+  },
+  "forbidden_ownership_crossings": [
+    {
+      "from_owner": "PQX",
+      "to_owner": "CDE",
+      "reason": "Execution ownership must not emit closure authority artifacts."
+    },
+    {
+      "from_owner": "FRE",
+      "to_owner": "SEL",
+      "reason": "Failure diagnosis must not perform enforcement actions."
+    },
+    {
+      "from_owner": "PRG",
+      "to_owner": "PQX",
+      "reason": "Program governance must not directly execute bounded runtime slices."
+    }
+  ],
+  "default_forbidden_patterns": [
+    "implicit_owner_inference",
+    "missing_expansion_trace_ref",
+    "execution_without_contract_validation",
+    "cross_owner_module_write"
+  ]
+}

--- a/contracts/examples/roadmap_expansion_trace.example.json
+++ b/contracts/examples/roadmap_expansion_trace.example.json
@@ -1,0 +1,29 @@
+{
+  "artifact_type": "roadmap_expansion_trace",
+  "step_id": "RF-03",
+  "expansion_version": "1.0.0",
+  "expansion_policy_hash": "152968011b794af977ccdfa9813025ef2271dbd6be90a48116d5a6b665b73839",
+  "field_trace": [
+    {
+      "field_name": "owner",
+      "source_type": "roadmap_artifact",
+      "source_ref": "docs/roadmaps/system_roadmap.md#RF-03",
+      "rule_id": "OWNER_FROM_ROADMAP",
+      "notes": "Owner copied exactly from compact roadmap artifact."
+    },
+    {
+      "field_name": "target_modules",
+      "source_type": "expansion_policy",
+      "source_ref": "config/roadmap_expansion_policy.json#owner_defaults.PQX.allowed_module_prefixes",
+      "rule_id": "MODULE_PREFIX_BY_OWNER",
+      "notes": "Module targets are constrained to policy-declared prefixes for owner PQX."
+    },
+    {
+      "field_name": "forbidden_patterns",
+      "source_type": "governance_rule",
+      "source_ref": "AGENTS.md#Canonical runtime rules",
+      "rule_id": "FAIL_CLOSED_DEFAULT_PATTERNS",
+      "notes": "Default forbidden patterns carried from deterministic policy baseline aligned to fail-closed behavior."
+    }
+  ]
+}

--- a/contracts/examples/roadmap_step_contract.example.json
+++ b/contracts/examples/roadmap_step_contract.example.json
@@ -1,0 +1,44 @@
+{
+  "artifact_type": "roadmap_step_contract",
+  "step_id": "RF-03",
+  "owner": "PQX",
+  "intent": "Establish deterministic roadmap expansion contract and trace validation artifacts for governed execution preparation.",
+  "depends_on": [
+    "RF-02"
+  ],
+  "target_modules": [
+    "spectrum_systems/modules/runtime/roadmap"
+  ],
+  "target_contracts": [
+    "contracts/schemas/roadmap_step_contract.schema.json",
+    "contracts/schemas/roadmap_expansion_trace.schema.json"
+  ],
+  "target_tests": [
+    "tests/test_roadmap_expansion_contracts.py"
+  ],
+  "runtime_entrypoints": [
+    "spectrum_systems/modules/runtime/system_cycle.py"
+  ],
+  "forbidden_patterns": [
+    "implicit_owner_inference",
+    "execution_without_contract_validation",
+    "cross_owner_module_write"
+  ],
+  "acceptance_checks": [
+    {
+      "check_id": "schema_validation_passes",
+      "description": "Roadmap contract and trace examples must validate against strict schemas.",
+      "required": true
+    },
+    {
+      "check_id": "policy_structure_valid",
+      "description": "Roadmap expansion policy must expose deterministic owner mapping structure.",
+      "required": true
+    }
+  ],
+  "realization_mode": "artifact_materialization",
+  "realization_status": "planned_only",
+  "expansion_version": "1.0.0",
+  "expansion_policy_hash": "152968011b794af977ccdfa9813025ef2271dbd6be90a48116d5a6b665b73839",
+  "expansion_trace_ref": "contracts/examples/roadmap_expansion_trace.example.json#RF-03"
+}

--- a/contracts/schemas/roadmap_expansion_trace.schema.json
+++ b/contracts/schemas/roadmap_expansion_trace.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/roadmap_expansion_trace.schema.json",
+  "title": "Roadmap Expansion Trace",
+  "description": "Strict deterministic trace artifact for roadmap step expansion field derivation.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "step_id",
+    "expansion_version",
+    "expansion_policy_hash",
+    "field_trace"
+  ],
+  "properties": {
+    "artifact_type": {
+      "type": "string",
+      "const": "roadmap_expansion_trace"
+    },
+    "step_id": {
+      "type": "string",
+      "pattern": "^[A-Z]{2,6}-[0-9]{2,4}([A-Z])?$"
+    },
+    "expansion_version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "expansion_policy_hash": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "field_trace": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "field_name",
+          "source_type",
+          "source_ref",
+          "rule_id",
+          "notes"
+        ],
+        "properties": {
+          "field_name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "source_type": {
+            "type": "string",
+            "enum": [
+              "roadmap_artifact",
+              "expansion_policy",
+              "governance_rule",
+              "manual_declaration"
+            ]
+          },
+          "source_ref": {
+            "type": "string",
+            "minLength": 1
+          },
+          "rule_id": {
+            "type": "string",
+            "pattern": "^[A-Z0-9_\\-.]{3,64}$"
+          },
+          "notes": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/contracts/schemas/roadmap_step_contract.schema.json
+++ b/contracts/schemas/roadmap_step_contract.schema.json
@@ -1,0 +1,156 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/roadmap_step_contract.schema.json",
+  "title": "Roadmap Step Contract",
+  "description": "Strict enriched roadmap step contract used for deterministic artifact expansion planning. This contract does not grant execution, sequencing, prioritization, or enforcement authority.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "step_id",
+    "owner",
+    "intent",
+    "depends_on",
+    "target_modules",
+    "target_contracts",
+    "target_tests",
+    "runtime_entrypoints",
+    "forbidden_patterns",
+    "acceptance_checks",
+    "realization_mode",
+    "realization_status",
+    "expansion_version",
+    "expansion_policy_hash",
+    "expansion_trace_ref"
+  ],
+  "properties": {
+    "artifact_type": {
+      "type": "string",
+      "const": "roadmap_step_contract"
+    },
+    "step_id": {
+      "type": "string",
+      "pattern": "^[A-Z]{2,6}-[0-9]{2,4}([A-Z])?$"
+    },
+    "owner": {
+      "type": "string",
+      "enum": [
+        "RIL",
+        "CDE",
+        "TLC",
+        "PQX",
+        "FRE",
+        "SEL",
+        "PRG"
+      ]
+    },
+    "intent": {
+      "type": "string",
+      "minLength": 10
+    },
+    "depends_on": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[A-Z]{2,6}-[0-9]{2,4}([A-Z])?$"
+      },
+      "uniqueItems": true
+    },
+    "target_modules": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "target_contracts": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "target_tests": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "runtime_entrypoints": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "forbidden_patterns": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "acceptance_checks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "check_id",
+          "description",
+          "required"
+        ],
+        "properties": {
+          "check_id": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9_\\-]{2,63}$"
+          },
+          "description": {
+            "type": "string",
+            "minLength": 5
+          },
+          "required": {
+            "type": "boolean",
+            "const": true
+          }
+        }
+      }
+    },
+    "realization_mode": {
+      "type": "string",
+      "enum": [
+        "artifact_materialization",
+        "runtime_realization",
+        "verification_only"
+      ]
+    },
+    "realization_status": {
+      "type": "string",
+      "enum": [
+        "planned_only",
+        "artifact_materialized",
+        "partially_realized",
+        "runtime_realized",
+        "verified"
+      ]
+    },
+    "expansion_version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "expansion_policy_hash": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "expansion_trace_ref": {
+      "type": "string",
+      "pattern": "^contracts/examples/roadmap_expansion_trace\\.example\\.json#[A-Za-z0-9._:-]+$"
+    }
+  }
+}

--- a/contracts/standards-manifest.json
+++ b/contracts/standards-manifest.json
@@ -1,9 +1,9 @@
 {
   "artifact_type": "standards_manifest",
   "artifact_id": "STD-CONTRACTS",
-  "artifact_version": "1.3.109",
+  "artifact_version": "1.3.110",
   "schema_version": "1.3.98",
-  "standards_version": "1.3.110",
+  "standards_version": "1.3.111",
   "record_id": "REC-STD-2026-04-09-CTX-A",
   "run_id": "run-20260409T000000Z-ctx-a",
   "created_at": "2026-04-09T00:00:00Z",
@@ -15,7 +15,7 @@
     "contact": "architecture@spectrum-systems.test"
   },
   "source_repo": "nicklasorte/spectrum-systems",
-  "source_repo_version": "1.3.109",
+  "source_repo_version": "1.3.110",
   "input_artifacts": [
     {
       "artifact_id": "STD-CONTRACTS",
@@ -3691,6 +3691,19 @@
       "notes": "RIL-002 deterministic review signal classification artifact mapping review items into bounded operational signal classes with traceable source linkage."
     },
     {
+      "artifact_type": "review_cycle_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.109",
+      "last_updated_in": "1.3.109",
+      "example_path": "contracts/examples/review_cycle_record.json",
+      "notes": "RF-01-REAL runtime-owned review/fix/replay cycle state artifact emitted by RQX lifecycle functions with fail-closed transitions."
+    },
+    {
       "artifact_type": "review_eval_generation_report",
       "artifact_class": "review",
       "schema_version": "1.0.0",
@@ -4006,6 +4019,19 @@
       "notes": "BATCH-MVP-END-TO-END deterministic full-roadmap execution report with fail-closed control-loop continuation/stop semantics."
     },
     {
+      "artifact_type": "roadmap_expansion_trace",
+      "artifact_class": "governance",
+      "schema_version": "1.0.0",
+      "status": "active",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.111",
+      "last_updated_in": "1.3.111",
+      "example_path": "contracts/examples/roadmap_expansion_trace.example.json",
+      "notes": "RAX-01-REAL deterministic field-level traceability contract for roadmap expansion auditability."
+    },
+    {
       "artifact_type": "roadmap_multi_batch_run_result",
       "artifact_class": "coordination",
       "schema_version": "1.4.0",
@@ -4121,6 +4147,19 @@
       "last_updated_in": "1.3.63",
       "example_path": "contracts/examples/roadmap_signal_bundle.json",
       "notes": "BATCH-LTV-C deterministic feeder bundle that steers roadmap priorities from drift/hotspot/coverage/replay/judgment/budget/trust signals."
+    },
+    {
+      "artifact_type": "roadmap_step_contract",
+      "artifact_class": "governance",
+      "schema_version": "1.0.0",
+      "status": "active",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.111",
+      "last_updated_in": "1.3.111",
+      "example_path": "contracts/examples/roadmap_step_contract.example.json",
+      "notes": "RAX-01-REAL strict enriched roadmap step contract for deterministic artifact-first realization planning."
     },
     {
       "artifact_type": "roadmap_step_execution_artifact",
@@ -4678,19 +4717,6 @@
       "last_updated_in": "1.0.82",
       "example_path": "contracts/examples/xrun_signal_quality_result.json",
       "notes": "VAL-06 governed validation artifact proving deterministic XRUN-01 pattern/action/signal quality and fail-closed handling under insufficient/malformed inputs."
-    },
-    {
-      "artifact_type": "review_cycle_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "stable",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.109",
-      "last_updated_in": "1.3.109",
-      "example_path": "contracts/examples/review_cycle_record.json",
-      "notes": "RF-01-REAL runtime-owned review/fix/replay cycle state artifact emitted by RQX lifecycle functions with fail-closed transitions."
     }
   ]
 }

--- a/docs/review-actions/PLAN-RAX-01-REAL-2026-04-11.md
+++ b/docs/review-actions/PLAN-RAX-01-REAL-2026-04-11.md
@@ -1,0 +1,40 @@
+# Plan — RAX-01-REAL — 2026-04-11
+
+## Prompt type
+BUILD
+
+## Roadmap item
+RAX-01-REAL
+
+## Objective
+Establish a strict, fail-closed contract and policy foundation for roadmap step expansion by adding schemas, deterministic policy config, examples, manifest registration, and focused validation tests.
+
+## Declared files
+| File | Change type | Reason |
+| --- | --- | --- |
+| contracts/schemas/roadmap_step_contract.schema.json | CREATE | Define strict enriched roadmap step contract schema. |
+| contracts/schemas/roadmap_expansion_trace.schema.json | CREATE | Define strict deterministic expansion trace schema. |
+| contracts/examples/roadmap_step_contract.example.json | CREATE | Provide a realistic valid example payload for schema validation. |
+| contracts/examples/roadmap_expansion_trace.example.json | CREATE | Provide a realistic valid expansion trace example payload. |
+| config/roadmap_expansion_policy.json | CREATE | Add deterministic mapping/config-only expansion policy foundation. |
+| contracts/standards-manifest.json | MODIFY | Register the new contract artifacts and bump standards/source versions. |
+| tests/test_roadmap_expansion_contracts.py | CREATE | Add schema + policy validation tests covering success/failure cases. |
+
+## Contracts touched
+- roadmap_step_contract (new)
+- roadmap_expansion_trace (new)
+- standards_manifest (version metadata + new contract registrations)
+
+## Tests that must pass after execution
+1. `pytest tests/test_roadmap_expansion_contracts.py`
+2. `pytest tests/test_contracts.py tests/test_contract_enforcement.py`
+3. `python scripts/run_contract_enforcement.py`
+
+## Scope exclusions
+- Do not implement roadmap realization/execution runtime logic.
+- Do not modify RF-02 or RF-03 production artifacts beyond schema examples.
+- Do not introduce LLM inference behavior or policy authority logic.
+- Do not perform unrelated refactors.
+
+## Dependencies
+- Existing canonical ownership roles in `docs/architecture/system_registry.md` must remain authoritative.

--- a/tests/test_roadmap_expansion_contracts.py
+++ b/tests/test_roadmap_expansion_contracts.py
@@ -1,0 +1,104 @@
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
+
+from spectrum_systems.contracts import load_example, load_schema, validate_artifact
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+POLICY_PATH = REPO_ROOT / "config" / "roadmap_expansion_policy.json"
+CANONICAL_OWNERS = {"RIL", "CDE", "TLC", "PQX", "FRE", "SEL", "PRG"}
+
+
+def _load_policy() -> dict:
+    return json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+
+
+def _policy_sha256() -> str:
+    payload = POLICY_PATH.read_bytes()
+    return hashlib.sha256(payload).hexdigest()
+
+
+def test_roadmap_step_contract_schema_validates_example() -> None:
+    validate_artifact(load_example("roadmap_step_contract"), "roadmap_step_contract")
+
+
+def test_roadmap_step_contract_rejects_missing_required_field() -> None:
+    instance = load_example("roadmap_step_contract")
+    instance.pop("owner", None)
+    with pytest.raises(ValidationError):
+        validate_artifact(instance, "roadmap_step_contract")
+
+
+def test_roadmap_step_contract_rejects_invalid_enums() -> None:
+    instance = load_example("roadmap_step_contract")
+    instance["realization_mode"] = "freeform_mode"
+    with pytest.raises(ValidationError):
+        validate_artifact(instance, "roadmap_step_contract")
+
+
+def test_roadmap_expansion_trace_schema_validates_example() -> None:
+    validate_artifact(load_example("roadmap_expansion_trace"), "roadmap_expansion_trace")
+
+
+def test_roadmap_expansion_trace_rejects_missing_field_trace_metadata() -> None:
+    instance = load_example("roadmap_expansion_trace")
+    instance["field_trace"][0].pop("rule_id", None)
+    with pytest.raises(ValidationError):
+        validate_artifact(instance, "roadmap_expansion_trace")
+
+
+def test_roadmap_expansion_policy_has_required_top_level_structure() -> None:
+    policy = _load_policy()
+    required_keys = {
+        "policy_id",
+        "policy_version",
+        "description",
+        "owner_defaults",
+        "forbidden_ownership_crossings",
+        "default_forbidden_patterns",
+    }
+    assert required_keys.issubset(policy.keys())
+
+
+def test_roadmap_expansion_policy_has_owner_mappings_for_canonical_owners() -> None:
+    policy = _load_policy()
+    owner_defaults = policy["owner_defaults"]
+    assert CANONICAL_OWNERS.issubset(owner_defaults.keys())
+
+    for owner in CANONICAL_OWNERS:
+        mapping = owner_defaults[owner]
+        for required_key in (
+            "allowed_module_prefixes",
+            "allowed_test_prefixes",
+            "default_contract_locations",
+            "default_acceptance_check_templates",
+        ):
+            assert required_key in mapping
+            assert isinstance(mapping[required_key], list)
+            assert mapping[required_key], f"{owner}.{required_key} must not be empty"
+
+
+def test_examples_are_consistent_with_schema_and_policy_hash() -> None:
+    step = load_example("roadmap_step_contract")
+    trace = load_example("roadmap_expansion_trace")
+
+    validate_artifact(step, "roadmap_step_contract")
+    validate_artifact(trace, "roadmap_expansion_trace")
+
+    expected_hash = _policy_sha256()
+    assert step["expansion_policy_hash"] == expected_hash
+    assert trace["expansion_policy_hash"] == expected_hash
+
+
+def test_roadmap_step_contract_schema_is_strict_no_additional_properties() -> None:
+    schema = load_schema("roadmap_step_contract")
+    validator = Draft202012Validator(schema)
+    instance = load_example("roadmap_step_contract")
+    instance["non_canonical"] = "unexpected"
+    with pytest.raises(ValidationError):
+        validator.validate(instance)


### PR DESCRIPTION
### Motivation
- Establish a strict, fail-closed contract surface for enriched roadmap steps so future expansion can be deterministic and auditable without embedding execution logic. 
- Provide a deterministic, configuration-only policy mapping to constrain owner→module/test/contract mappings and default acceptance-check templates. 
- Supply concrete examples and schema-backed tests to ensure the contract/policy surface is strict and rejects malformed or ambiguous inputs.

### Description
- Add `contracts/schemas/roadmap_step_contract.schema.json` implementing a strict roadmap step contract with `additionalProperties: false`, canonical owner enum (`RIL,CDE,TLC,PQX,FRE,SEL,PRG`), strict `realization_mode`/`realization_status` enums, and required fields such as `expansion_policy_hash` and `expansion_trace_ref`.
- Add `contracts/schemas/roadmap_expansion_trace.schema.json` implementing a strict expansion trace with required `field_trace` entries including `field_name`, `source_type`, `source_ref`, `rule_id`, and `notes` for deterministic, field-level auditability.
- Add examples `contracts/examples/roadmap_step_contract.example.json` and `contracts/examples/roadmap_expansion_trace.example.json` (concrete RF-03 planning example) and wire their `expansion_policy_hash` to the checked-in policy file.
- Add deterministic, configuration-only policy `config/roadmap_expansion_policy.json` mapping owner defaults, forbidden ownership crossings, and default forbidden patterns while explicitly avoiding any execution/authority semantics.
- Register the new artifacts in `contracts/standards-manifest.json` and bump manifest version metadata, and add an execution plan `docs/review-actions/PLAN-RAX-01-REAL-2026-04-11.md`.
- Add focused validation tests `tests/test_roadmap_expansion_contracts.py` that assert positive validation and fail-closed behavior (missing required fields, invalid enums, missing trace metadata, strict/no-additional-properties), policy shape, canonical owner mappings, and policy-hash consistency.

### Testing
- Ran `pytest tests/test_roadmap_expansion_contracts.py` (collected 9 tests) and all tests passed.
- Ran `pytest tests/test_contracts.py tests/test_contract_enforcement.py` (117 tests) and the suite passed with no regressions.
- Executed `python scripts/run_contract_enforcement.py` and the enforcement run completed with summary `failures=0 warnings=0 not_yet_enforceable=0`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dac7a944708329b7a7f6ab07a7d075)