### PR TITLE
RAX-02-REAL: add RF-02/RF-03 roadmap realization runner

### DIFF
--- a/artifacts/roadmap_contracts/RF-02.json
+++ b/artifacts/roadmap_contracts/RF-02.json
@@ -1,0 +1,45 @@
+{
+  "artifact_type": "roadmap_step_contract",
+  "step_id": "RF-02",
+  "owner": "PQX",
+  "intent": "Realize roadmap contract validation and guarded dependency enforcement through runtime-backed realization checks.",
+  "depends_on": [
+    "RF-01"
+  ],
+  "target_modules": [
+    "spectrum_systems/modules/runtime/roadmap_realization_runtime.py"
+  ],
+  "target_contracts": [
+    "contracts/schemas/roadmap_step_contract.schema.json",
+    "contracts/schemas/roadmap_expansion_trace.schema.json"
+  ],
+  "target_tests": [
+    "pytest tests/test_roadmap_realization_runner.py -k rf02 -q"
+  ],
+  "runtime_entrypoints": [
+    "spectrum_systems.modules.runtime.review_cycle_record:create_review_cycle",
+    "spectrum_systems.modules.runtime.roadmap_realization_runtime:next_realization_status"
+  ],
+  "forbidden_patterns": [
+    "_write_json",
+    "artifact-only success",
+    "direct static payload"
+  ],
+  "acceptance_checks": [
+    {
+      "check_id": "rf02_contract_validation",
+      "description": "Step contract validates and target schema paths remain available.",
+      "required": true
+    },
+    {
+      "check_id": "rf02_runtime_gate",
+      "description": "Runtime gate only advances status when behavior checks pass.",
+      "required": true
+    }
+  ],
+  "realization_mode": "runtime_realization",
+  "realization_status": "verified",
+  "expansion_version": "1.0.0",
+  "expansion_policy_hash": "152968011b794af977ccdfa9813025ef2271dbd6be90a48116d5a6b665b73839",
+  "expansion_trace_ref": "contracts/examples/roadmap_expansion_trace.example.json#RF-02"
+}

--- a/artifacts/roadmap_contracts/RF-03.json
+++ b/artifacts/roadmap_contracts/RF-03.json
@@ -1,0 +1,46 @@
+{
+  "artifact_type": "roadmap_step_contract",
+  "step_id": "RF-03",
+  "owner": "PQX",
+  "intent": "Realize dependency-aware runtime checks and behavioral test gating for RF-03 under fail-closed execution.",
+  "depends_on": [
+    "RF-01",
+    "RF-02"
+  ],
+  "target_modules": [
+    "spectrum_systems/modules/runtime/roadmap_realization_runtime.py"
+  ],
+  "target_contracts": [
+    "contracts/schemas/roadmap_step_contract.schema.json",
+    "contracts/schemas/roadmap_expansion_trace.schema.json"
+  ],
+  "target_tests": [
+    "pytest tests/test_roadmap_realization_runner.py -k rf03 -q"
+  ],
+  "runtime_entrypoints": [
+    "spectrum_systems.modules.runtime.roadmap_realization_runtime:enforce_realization_dependencies",
+    "spectrum_systems.modules.runtime.roadmap_realization_runtime:next_realization_status"
+  ],
+  "forbidden_patterns": [
+    "_write_json",
+    "artifact-only success",
+    "direct static payload"
+  ],
+  "acceptance_checks": [
+    {
+      "check_id": "rf03_dependency_gate",
+      "description": "Dependency order must be enforced before RF-03 realization.",
+      "required": true
+    },
+    {
+      "check_id": "rf03_behavioral_gate",
+      "description": "Behavioral tests must pass before runtime realization is accepted.",
+      "required": true
+    }
+  ],
+  "realization_mode": "runtime_realization",
+  "realization_status": "verified",
+  "expansion_version": "1.0.0",
+  "expansion_policy_hash": "152968011b794af977ccdfa9813025ef2271dbd6be90a48116d5a6b665b73839",
+  "expansion_trace_ref": "contracts/examples/roadmap_expansion_trace.example.json#RF-03"
+}

--- a/artifacts/roadmap_contracts/roadmap_realization_result.json
+++ b/artifacts/roadmap_contracts/roadmap_realization_result.json
@@ -1,0 +1,79 @@
+{
+  "artifact_type": "roadmap_realization_result",
+  "step_ids": [
+    "RF-02",
+    "RF-03"
+  ],
+  "attempted_steps": [
+    "RF-02",
+    "RF-03"
+  ],
+  "passed_steps": [
+    "RF-02",
+    "RF-03"
+  ],
+  "failed_steps": [],
+  "forbidden_pattern_hits": {
+    "RF-02": [],
+    "RF-03": []
+  },
+  "runtime_entrypoint_checks": {
+    "RF-02": [
+      {
+        "entrypoint": "spectrum_systems.modules.runtime.review_cycle_record:create_review_cycle",
+        "exists": true,
+        "error": ""
+      },
+      {
+        "entrypoint": "spectrum_systems.modules.runtime.roadmap_realization_runtime:next_realization_status",
+        "exists": true,
+        "error": ""
+      }
+    ],
+    "RF-03": [
+      {
+        "entrypoint": "spectrum_systems.modules.runtime.roadmap_realization_runtime:enforce_realization_dependencies",
+        "exists": true,
+        "error": ""
+      },
+      {
+        "entrypoint": "spectrum_systems.modules.runtime.roadmap_realization_runtime:next_realization_status",
+        "exists": true,
+        "error": ""
+      }
+    ]
+  },
+  "behavioral_test_results": {
+    "RF-02": [
+      {
+        "command": "pytest tests/test_roadmap_realization_runner.py -k rf02 -q",
+        "returncode": 0,
+        "passed": true,
+        "stdout": ".                                                                        [100%]\n1 passed, 6 deselected in 0.11s\n",
+        "stderr": ""
+      }
+    ],
+    "RF-03": [
+      {
+        "command": "pytest tests/test_roadmap_realization_runner.py -k rf03 -q",
+        "returncode": 0,
+        "passed": true,
+        "stdout": "..                                                                       [100%]\n2 passed, 5 deselected in 0.15s\n",
+        "stderr": ""
+      }
+    ]
+  },
+  "status_updates": [
+    {
+      "step_id": "RF-02",
+      "from": "planned_only",
+      "to": "verified"
+    },
+    {
+      "step_id": "RF-03",
+      "from": "planned_only",
+      "to": "verified"
+    }
+  ],
+  "overall_status": "pass"
+}

--- a/docs/review-actions/PLAN-RAX-02-REAL-2026-04-11.md
+++ b/docs/review-actions/PLAN-RAX-02-REAL-2026-04-11.md
@@ -1,0 +1,27 @@
+# Plan — RAX-02-REAL — 2026-04-11
+
+## Prompt type
+BUILD
+
+## Scope
+Implement a thin roadmap realization execution surface for RF-02 and RF-03 only, using strict fail-closed checks backed by `roadmap_step_contract` artifacts and behavioral-test gating.
+
+## Files expected to change
+| Path | Action | Purpose |
+| --- | --- | --- |
+| `scripts/roadmap_realization_runner.py` | CREATE | Add deterministic runner for RF-02 and RF-03 contract realization checks and status updates. |
+| `artifacts/roadmap_contracts/RF-02.json` | CREATE | Add RF-02 enriched roadmap step contract instance. |
+| `artifacts/roadmap_contracts/RF-03.json` | CREATE | Add RF-03 enriched roadmap step contract instance. |
+| `spectrum_systems/modules/runtime/roadmap_realization_runtime.py` | CREATE | Add strict dependency and status transition helpers used by runner. |
+| `tests/test_roadmap_realization_runner.py` | CREATE | Add focused tests for schema validation, dependencies, forbidden patterns, entrypoint checks, and status advancement gating. |
+
+## Execution steps
+1. Implement runtime helper functions that enforce dependency order and strict status transitions.
+2. Implement `scripts/roadmap_realization_runner.py` CLI + importable functions for contract loading, schema validation, expansion trace validation, forbidden pattern scanning, entrypoint checks, behavioral test execution, and result artifact emission.
+3. Add RF-02 and RF-03 contract instances under `artifacts/roadmap_contracts/` with required fields, dependency constraints, and initial `realization_status: planned_only`.
+4. Add tests proving required fail-closed and success paths.
+5. Run focused test suites and contract validation tests.
+
+## Validation commands
+1. `pytest tests/test_roadmap_realization_runner.py -q`
+2. `pytest tests/test_roadmap_expansion_contracts.py -q`

--- a/scripts/roadmap_realization_runner.py
+++ b/scripts/roadmap_realization_runner.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Thin roadmap realization runner for RF-02 and RF-03."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from spectrum_systems.contracts import validate_artifact
+from spectrum_systems.modules.runtime.roadmap_realization_runtime import (
+    RoadmapRealizationRuntimeError,
+    enforce_realization_dependencies,
+    next_realization_status,
+)
+
+SUPPORTED_STEPS = ["RF-02", "RF-03"]
+BASELINE_REALIZATION_STATUS = {"RF-01": "runtime_realized"}
+DEFAULT_CONTRACT_DIR = REPO_ROOT / "artifacts" / "roadmap_contracts"
+DEFAULT_RESULT_PATH = DEFAULT_CONTRACT_DIR / "roadmap_realization_result.json"
+BASE_FORBIDDEN_PATTERNS = [
+    "_write_json",
+    '"status": "pass"',
+    "artifact-only",
+    "artifact_only",
+]
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def _contract_path(contract_dir: Path, step_id: str) -> Path:
+    return contract_dir / f"{step_id}.json"
+
+
+def _load_contract(contract_dir: Path, step_id: str) -> dict[str, Any]:
+    path = _contract_path(contract_dir, step_id)
+    if not path.is_file():
+        raise FileNotFoundError(f"missing step contract: {path}")
+    contract = _load_json(path)
+    validate_artifact(contract, "roadmap_step_contract")
+    if contract["step_id"] != step_id:
+        raise ValueError(f"contract step mismatch: expected {step_id}, found {contract['step_id']}")
+    return contract
+
+
+def _validate_expansion_trace(contract: dict[str, Any], repo_root: Path) -> dict[str, Any]:
+    trace_ref = contract["expansion_trace_ref"]
+    if "#" not in trace_ref:
+        raise ValueError(f"expansion_trace_ref missing fragment: {trace_ref}")
+    trace_path_raw, _fragment = trace_ref.split("#", 1)
+    trace_path = repo_root / trace_path_raw
+    if not trace_path.is_file():
+        raise FileNotFoundError(f"missing expansion trace: {trace_path}")
+    trace = _load_json(trace_path)
+    validate_artifact(trace, "roadmap_expansion_trace")
+    if trace["expansion_version"] != contract["expansion_version"]:
+        raise ValueError(f"expansion_version mismatch for {contract['step_id']}")
+    if trace["expansion_policy_hash"] != contract["expansion_policy_hash"]:
+        raise ValueError(f"expansion_policy_hash mismatch for {contract['step_id']}")
+    return trace
+
+
+def _check_runtime_entrypoints(runtime_entrypoints: list[str]) -> list[dict[str, Any]]:
+    checks: list[dict[str, Any]] = []
+    for entry in runtime_entrypoints:
+        module_name, sep, symbol = entry.partition(":")
+        ok = True
+        error = ""
+        if not sep:
+            ok = False
+            error = "invalid entrypoint format"
+        else:
+            try:
+                module = importlib.import_module(module_name)
+                obj = getattr(module, symbol)
+                if not callable(obj):
+                    ok = False
+                    error = "entrypoint is not callable"
+            except Exception as exc:  # pragma: no cover - exercised in tests via contract values
+                ok = False
+                error = str(exc)
+        checks.append({"entrypoint": entry, "exists": ok, "error": error})
+    return checks
+
+
+def _scan_forbidden_patterns(contract: dict[str, Any], repo_root: Path) -> list[dict[str, Any]]:
+    patterns = sorted(set(contract["forbidden_patterns"] + BASE_FORBIDDEN_PATTERNS))
+    hits: list[dict[str, Any]] = []
+    scoped_files = sorted(set(contract["target_modules"]))
+    for rel_path in scoped_files:
+        path = repo_root / rel_path
+        if not path.is_file():
+            raise FileNotFoundError(f"missing target module path: {path}")
+        text = path.read_text(encoding="utf-8")
+        for pattern in patterns:
+            if pattern in text:
+                hits.append({"step_id": contract["step_id"], "path": rel_path, "pattern": pattern})
+        if contract["step_id"] in text and '"status": "pass"' in text:
+            hits.append(
+                {
+                    "step_id": contract["step_id"],
+                    "path": rel_path,
+                    "pattern": "direct static payload emission for target step",
+                }
+            )
+    return hits
+
+
+def _run_behavioral_tests(test_commands: list[str], repo_root: Path) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    for command in test_commands:
+        proc = subprocess.run(
+            shlex.split(command),
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        results.append(
+            {
+                "command": command,
+                "returncode": proc.returncode,
+                "passed": proc.returncode == 0,
+                "stdout": proc.stdout,
+                "stderr": proc.stderr,
+            }
+        )
+    return results
+
+
+def _verification_checks(contract: dict[str, Any], repo_root: Path) -> dict[str, Any]:
+    contract_paths_exist = all((repo_root / path).is_file() for path in contract["target_contracts"])
+    required_checks_declared = all(check.get("required") is True for check in contract["acceptance_checks"])
+    return {
+        "contract_paths_exist": contract_paths_exist,
+        "required_checks_declared": required_checks_declared,
+        "passed": contract_paths_exist and required_checks_declared,
+    }
+
+
+def realize_steps(
+    *,
+    step_ids: list[str],
+    contract_dir: Path = DEFAULT_CONTRACT_DIR,
+    result_path: Path = DEFAULT_RESULT_PATH,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, Any]:
+    for step_id in step_ids:
+        if step_id not in SUPPORTED_STEPS:
+            raise ValueError(f"unsupported step: {step_id}")
+
+    contracts = {step_id: _load_contract(contract_dir, step_id) for step_id in step_ids}
+    for contract in contracts.values():
+        _validate_expansion_trace(contract, repo_root)
+
+    status_by_step = dict(BASELINE_REALIZATION_STATUS)
+    status_by_step.update({step_id: contracts[step_id]["realization_status"] for step_id in step_ids})
+    attempted_steps: list[str] = []
+    passed_steps: list[str] = []
+    failed_steps: list[str] = []
+    forbidden_pattern_hits: dict[str, list[dict[str, Any]]] = {}
+    runtime_entrypoint_checks: dict[str, list[dict[str, Any]]] = {}
+    behavioral_test_results: dict[str, list[dict[str, Any]]] = {}
+    status_updates: list[dict[str, str]] = []
+
+    for step_id in step_ids:
+        contract = contracts[step_id]
+        attempted_steps.append(step_id)
+
+        try:
+            enforce_realization_dependencies(
+                step_id=step_id,
+                depends_on=contract["depends_on"],
+                attempted_steps=attempted_steps,
+                status_by_step=status_by_step,
+            )
+        except RoadmapRealizationRuntimeError:
+            failed_steps.append(step_id)
+            continue
+
+        step_forbidden_hits = _scan_forbidden_patterns(contract, repo_root)
+        forbidden_pattern_hits[step_id] = step_forbidden_hits
+
+        step_entrypoint_checks = _check_runtime_entrypoints(contract["runtime_entrypoints"])
+        runtime_entrypoint_checks[step_id] = step_entrypoint_checks
+
+        step_behavioral_results = _run_behavioral_tests(contract["target_tests"], repo_root)
+        behavioral_test_results[step_id] = step_behavioral_results
+
+        verification = _verification_checks(contract, repo_root)
+        prior_status = contract["realization_status"]
+        next_status = next_realization_status(
+            current_status=prior_status,
+            forbidden_patterns_absent=len(step_forbidden_hits) == 0,
+            runtime_entrypoints_exist=all(item["exists"] for item in step_entrypoint_checks),
+            behavioral_tests_passed=all(result["passed"] for result in step_behavioral_results),
+            verification_checks_passed=verification["passed"],
+        )
+
+        if next_status != prior_status:
+            contract["realization_status"] = next_status
+            _write_json(_contract_path(contract_dir, step_id), contract)
+            status_updates.append({"step_id": step_id, "from": prior_status, "to": next_status})
+            status_by_step[step_id] = next_status
+
+        if next_status in {"runtime_realized", "verified"}:
+            passed_steps.append(step_id)
+        else:
+            failed_steps.append(step_id)
+
+    overall_status = "pass" if len(failed_steps) == 0 and len(step_ids) > 0 else "fail"
+    result = {
+        "artifact_type": "roadmap_realization_result",
+        "step_ids": step_ids,
+        "attempted_steps": attempted_steps,
+        "passed_steps": passed_steps,
+        "failed_steps": failed_steps,
+        "forbidden_pattern_hits": forbidden_pattern_hits,
+        "runtime_entrypoint_checks": runtime_entrypoint_checks,
+        "behavioral_test_results": behavioral_test_results,
+        "status_updates": status_updates,
+        "overall_status": overall_status,
+    }
+    _write_json(result_path, result)
+    return result
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("steps", nargs="*", default=SUPPORTED_STEPS)
+    parser.add_argument("--contract-dir", default=str(DEFAULT_CONTRACT_DIR))
+    parser.add_argument("--result-path", default=str(DEFAULT_RESULT_PATH))
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    result = realize_steps(
+        step_ids=list(args.steps),
+        contract_dir=Path(args.contract_dir),
+        result_path=Path(args.result_path),
+    )
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    return 0 if result["overall_status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/spectrum_systems/modules/runtime/roadmap_realization_runtime.py
+++ b/spectrum_systems/modules/runtime/roadmap_realization_runtime.py
@@ -1,0 +1,63 @@
+"""Runtime helpers for strict roadmap realization status control."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+
+ALLOWED_STATUSES = [
+    "planned_only",
+    "artifact_materialized",
+    "partially_realized",
+    "runtime_realized",
+    "verified",
+]
+
+
+class RoadmapRealizationRuntimeError(ValueError):
+    """Raised when realization checks violate fail-closed runtime rules."""
+
+
+def enforce_realization_dependencies(
+    *,
+    step_id: str,
+    depends_on: Iterable[str],
+    attempted_steps: Iterable[str],
+    status_by_step: dict[str, str],
+) -> None:
+    attempted = list(attempted_steps)
+    if step_id not in attempted:
+        raise RoadmapRealizationRuntimeError(f"step {step_id} not in attempted sequence")
+    step_index = attempted.index(step_id)
+
+    for dependency in depends_on:
+        if dependency in attempted:
+            if attempted.index(dependency) >= step_index:
+                raise RoadmapRealizationRuntimeError(
+                    f"dependency order violated: {step_id} cannot run before {dependency}"
+                )
+        dependency_status = status_by_step.get(dependency)
+        if dependency_status not in {"runtime_realized", "verified"}:
+            raise RoadmapRealizationRuntimeError(
+                f"dependency {dependency} not runtime realized for {step_id}"
+            )
+
+
+def next_realization_status(
+    *,
+    current_status: str,
+    forbidden_patterns_absent: bool,
+    runtime_entrypoints_exist: bool,
+    behavioral_tests_passed: bool,
+    verification_checks_passed: bool,
+) -> str:
+    if current_status not in ALLOWED_STATUSES:
+        raise RoadmapRealizationRuntimeError(f"unknown realization status: {current_status}")
+
+    if not (forbidden_patterns_absent and runtime_entrypoints_exist and behavioral_tests_passed):
+        return current_status
+
+    runtime_status = "runtime_realized"
+    if verification_checks_passed:
+        return "verified"
+    return runtime_status

--- a/tests/test_roadmap_realization_runner.py
+++ b/tests/test_roadmap_realization_runner.py
@@ -1,0 +1,155 @@
+"""Focused tests for RF-02/RF-03 roadmap realization runner."""
+
+from __future__ import annotations
+
+import json
+from importlib import util
+from pathlib import Path
+
+from spectrum_systems.contracts import validate_artifact
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "roadmap_realization_runner.py"
+_SPEC = util.spec_from_file_location("roadmap_realization_runner", SCRIPT_PATH)
+assert _SPEC and _SPEC.loader
+_RUNNER = util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_RUNNER)
+realize_steps = _RUNNER.realize_steps
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _base_contract(step_id: str) -> dict:
+    depends = ["RF-01"] if step_id == "RF-02" else ["RF-01", "RF-02"]
+    tests = ["python -c \"raise SystemExit(0)\""]
+    entrypoints = ["spectrum_systems.modules.runtime.roadmap_realization_runtime:next_realization_status"]
+    if step_id == "RF-03":
+        entrypoints.append("spectrum_systems.modules.runtime.roadmap_realization_runtime:enforce_realization_dependencies")
+
+    return {
+        "artifact_type": "roadmap_step_contract",
+        "step_id": step_id,
+        "owner": "PQX",
+        "intent": f"Runtime realization checks for {step_id} with fail-closed gating.",
+        "depends_on": depends,
+        "target_modules": ["spectrum_systems/modules/runtime/roadmap_realization_runtime.py"],
+        "target_contracts": [
+            "contracts/schemas/roadmap_step_contract.schema.json",
+            "contracts/schemas/roadmap_expansion_trace.schema.json",
+        ],
+        "target_tests": tests,
+        "runtime_entrypoints": entrypoints,
+        "forbidden_patterns": ["never-match-pattern"],
+        "acceptance_checks": [
+            {
+                "check_id": f"{step_id.lower().replace('-', '')}_required",
+                "description": "Required acceptance check for runner gating.",
+                "required": True,
+            }
+        ],
+        "realization_mode": "runtime_realization",
+        "realization_status": "planned_only",
+        "expansion_version": "1.0.0",
+        "expansion_policy_hash": "152968011b794af977ccdfa9813025ef2271dbd6be90a48116d5a6b665b73839",
+        "expansion_trace_ref": "contracts/examples/roadmap_expansion_trace.example.json#RF-03",
+    }
+
+
+def _write_contracts(tmp_path: Path, rf02: dict | None = None, rf03: dict | None = None) -> Path:
+    contract_dir = tmp_path / "artifacts" / "roadmap_contracts"
+    _write_json(contract_dir / "RF-02.json", rf02 or _base_contract("RF-02"))
+    _write_json(contract_dir / "RF-03.json", rf03 or _base_contract("RF-03"))
+    return contract_dir
+
+
+def test_rf02_rf03_contracts_pass_schema_validation() -> None:
+    validate_artifact(json.loads(Path("artifacts/roadmap_contracts/RF-02.json").read_text()), "roadmap_step_contract")
+    validate_artifact(json.loads(Path("artifacts/roadmap_contracts/RF-03.json").read_text()), "roadmap_step_contract")
+
+
+def test_rf03_dependency_order_is_enforced(tmp_path: Path) -> None:
+    contract_dir = _write_contracts(tmp_path)
+    result = realize_steps(
+        step_ids=["RF-03", "RF-02"],
+        contract_dir=contract_dir,
+        result_path=tmp_path / "result.json",
+        repo_root=Path("."),
+    )
+    assert "RF-03" in result["failed_steps"]
+
+
+def test_forbidden_patterns_block_realization(tmp_path: Path) -> None:
+    rf02 = _base_contract("RF-02")
+    rf02["forbidden_patterns"] = ["ALLOWED_STATUSES"]
+    contract_dir = _write_contracts(tmp_path, rf02=rf02)
+    result = realize_steps(
+        step_ids=["RF-02"],
+        contract_dir=contract_dir,
+        result_path=tmp_path / "result.json",
+        repo_root=Path("."),
+    )
+    assert result["failed_steps"] == ["RF-02"]
+    assert result["forbidden_pattern_hits"]["RF-02"]
+
+
+def test_missing_runtime_entrypoint_blocks_realization(tmp_path: Path) -> None:
+    rf02 = _base_contract("RF-02")
+    rf02["runtime_entrypoints"] = ["spectrum_systems.modules.runtime.roadmap_realization_runtime:missing_function"]
+    contract_dir = _write_contracts(tmp_path, rf02=rf02)
+    result = realize_steps(
+        step_ids=["RF-02"],
+        contract_dir=contract_dir,
+        result_path=tmp_path / "result.json",
+        repo_root=Path("."),
+    )
+    assert result["failed_steps"] == ["RF-02"]
+    assert result["runtime_entrypoint_checks"]["RF-02"][0]["exists"] is False
+
+
+def test_failing_behavioral_tests_block_status_advancement(tmp_path: Path) -> None:
+    rf02 = _base_contract("RF-02")
+    rf02["target_tests"] = ["python -c \"raise SystemExit(1)\""]
+    contract_dir = _write_contracts(tmp_path, rf02=rf02)
+    result = realize_steps(
+        step_ids=["RF-02"],
+        contract_dir=contract_dir,
+        result_path=tmp_path / "result.json",
+        repo_root=Path("."),
+    )
+    updated = json.loads((contract_dir / "RF-02.json").read_text())
+    assert result["failed_steps"] == ["RF-02"]
+    assert updated["realization_status"] == "planned_only"
+
+
+def test_passing_behavioral_tests_allow_status_advancement(tmp_path: Path) -> None:
+    contract_dir = _write_contracts(tmp_path)
+    result = realize_steps(
+        step_ids=["RF-02", "RF-03"],
+        contract_dir=contract_dir,
+        result_path=tmp_path / "result.json",
+        repo_root=Path("."),
+    )
+    rf02 = json.loads((contract_dir / "RF-02.json").read_text())
+    rf03 = json.loads((contract_dir / "RF-03.json").read_text())
+    assert result["failed_steps"] == []
+    assert rf02["realization_status"] in {"runtime_realized", "verified"}
+    assert rf03["realization_status"] in {"runtime_realized", "verified"}
+
+
+def test_result_artifact_reflects_real_outcomes(tmp_path: Path) -> None:
+    rf02 = _base_contract("RF-02")
+    rf02["target_tests"] = ["python -c \"raise SystemExit(1)\""]
+    contract_dir = _write_contracts(tmp_path, rf02=rf02)
+    result_path = tmp_path / "roadmap_realization_result.json"
+    result = realize_steps(
+        step_ids=["RF-02", "RF-03"],
+        contract_dir=contract_dir,
+        result_path=result_path,
+        repo_root=Path("."),
+    )
+    written = json.loads(result_path.read_text())
+    assert written["artifact_type"] == "roadmap_realization_result"
+    assert written["attempted_steps"] == ["RF-02", "RF-03"]
+    assert written["overall_status"] == result["overall_status"] == "fail"


### PR DESCRIPTION
### Motivation
- Implement a narrow, deterministic runtime realization layer for two concrete roadmap steps (RF-02 and RF-03) that validates enriched step contracts, enforces dependency order, scans for forbidden implementation patterns, gates promotion on behavioral tests, and emits a realization result artifact.
- Ensure strict, fail-closed status transitions so a step only advances to `runtime_realized`/`verified` when entrypoints exist, forbidden patterns are absent, and behavioral tests pass.

### Description
- Add a thin runner `scripts/roadmap_realization_runner.py` that loads and validates roadmap step contracts, verifies expansion traces, resolves runtime entrypoints, scans target modules for forbidden patterns, runs declared behavioral tests, applies strict status transition rules, and writes a `roadmap_realization_result` artifact.
- Add runtime helpers in `spectrum_systems/modules/runtime/roadmap_realization_runtime.py` with `enforce_realization_dependencies` and `next_realization_status` to enforce dependency ordering and allowed status progressions.
- Add enriched step-contract instances for `RF-02` and `RF-03` under `artifacts/roadmap_contracts/` with required fields (depends_on, target_modules, runtime_entrypoints, forbidden_patterns, acceptance_checks, expansion trace refs) and initial `realization_status` as planned-only (runner updates statuses on success).
- Add focused tests `tests/test_roadmap_realization_runner.py` covering schema validation, dependency order enforcement, forbidden-pattern blocking, missing entrypoint failure, behavioral-test gating, and result-artifact reporting, and emit the deterministic result artifact `artifacts/roadmap_contracts/roadmap_realization_result.json` on run.

### Testing
- Ran `pytest tests/test_roadmap_realization_runner.py -q` and observed `7 passed` (all runner unit cases passed).
- Ran `pytest tests/test_roadmap_expansion_contracts.py -q` and observed `9 passed` (contract/schema checks passed).
- Executed `python scripts/roadmap_realization_runner.py RF-02 RF-03` which completed with overall status `pass` and wrote `artifacts/roadmap_contracts/roadmap_realization_result.json` showing successful checks and status updates for both steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dacbc8dd088329933f47c6b326aad4)