### PR TITLE
RAX-HARDEN-CRITICAL-01: Harden roadmap realization runner to fail-closed

### DIFF
--- a/docs/review-actions/PLAN-RAX-HARDEN-CRITICAL-01-2026-04-11.md
+++ b/docs/review-actions/PLAN-RAX-HARDEN-CRITICAL-01-2026-04-11.md
@@ -1,0 +1,28 @@
+# Plan — RAX-HARDEN-CRITICAL-01 — 2026-04-11
+
+## Prompt type
+BUILD
+
+## Scope
+Harden the existing roadmap realization runner to fail closed against six known critical red-team attack classes, without broadening roadmap realization scope beyond RF-02/RF-03.
+
+## Files expected to change
+| Path | Action | Purpose |
+| --- | --- | --- |
+| `scripts/roadmap_realization_runner.py` | MODIFY | Add strict contract checks, dependency/ownership/test integrity gates, stronger forbidden-pattern detection, and fail-closed result semantics. |
+| `spectrum_systems/modules/runtime/roadmap_realization_runtime.py` | MODIFY | Tighten dependency/status transition rules with runtime-authoritative state advancement semantics. |
+| `tests/test_roadmap_realization_runner.py` | MODIFY | Add regression tests for all six critical attack classes and fail-closed semantics. |
+
+## Execution steps
+1. Add explicit contract validation for required non-empty runtime fields and prevent realization attempt on validation failure.
+2. Enforce runtime-authoritative status transitions that ignore caller-forged `realization_status` values.
+3. Enforce dependency existence/order/status checks with explicit failure reasons.
+4. Enforce owner-to-module and owner-to-test prefix policy from expansion policy before execution.
+5. Replace naive forbidden-pattern scanning with stronger static pattern heuristics scoped to target modules and runner/runtime helpers.
+6. Enforce constrained behavioral test command policy and reject weak/non-behavioral commands.
+7. Guarantee fail-closed result semantics (`overall_status`, `passed_steps`, `status_updates`) across all critical validation categories.
+8. Add targeted regression tests for dependency bypass, forbidden-pattern evasion, fake test success, status forging, ownership boundary attack, and malformed contracts.
+
+## Validation commands
+1. `pytest tests/test_roadmap_realization_runner.py -q`
+2. `pytest tests/test_roadmap_expansion_contracts.py -q`

--- a/scripts/roadmap_realization_runner.py
+++ b/scripts/roadmap_realization_runner.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import importlib
 import json
+import re
 import shlex
 import subprocess
 import sys
@@ -19,6 +20,7 @@ if str(REPO_ROOT) not in sys.path:
 from spectrum_systems.contracts import validate_artifact
 from spectrum_systems.modules.runtime.roadmap_realization_runtime import (
     RoadmapRealizationRuntimeError,
+    authoritative_start_status,
     enforce_realization_dependencies,
     next_realization_status,
 )
@@ -27,11 +29,31 @@ SUPPORTED_STEPS = ["RF-02", "RF-03"]
 BASELINE_REALIZATION_STATUS = {"RF-01": "runtime_realized"}
 DEFAULT_CONTRACT_DIR = REPO_ROOT / "artifacts" / "roadmap_contracts"
 DEFAULT_RESULT_PATH = DEFAULT_CONTRACT_DIR / "roadmap_realization_result.json"
+DEFAULT_POLICY_PATH = REPO_ROOT / "config" / "roadmap_expansion_policy.json"
 BASE_FORBIDDEN_PATTERNS = [
-    "_write_json",
-    '"status": "pass"',
-    "artifact-only",
-    "artifact_only",
+    r"\b_write_json\b",
+    r"\bjson\.dump\w*\(",
+    r"def\s+\w*(write|emit|persist|artifact)\w*\s*\(",
+    r"\"status\"\s*:\s*\"pass\"",
+    r"artifact[-_ ]only",
+    r"direct static payload",
+]
+
+APPROVED_TEST_PREFIXES = ("pytest tests/", "python -m pytest tests/")
+REJECTED_TEST_PATTERNS = [
+    re.compile(r"\bpython\s+-c\b"),
+    re.compile(r"\bpython\s+<<"),
+    re.compile(r"\btest\s+-f\b"),
+    re.compile(r"\bPath\([^)]*\)\.is_file\("),
+]
+
+CRITICAL_FAILURE_CATEGORIES = [
+    "contract_validation",
+    "dependency_validation",
+    "ownership_validation",
+    "forbidden_pattern_validation",
+    "runtime_entrypoint_validation",
+    "behavioral_test_validation",
 ]
 
 
@@ -48,12 +70,33 @@ def _contract_path(contract_dir: Path, step_id: str) -> Path:
     return contract_dir / f"{step_id}.json"
 
 
+def _load_expansion_policy(policy_path: Path = DEFAULT_POLICY_PATH) -> dict[str, Any]:
+    if not policy_path.is_file():
+        raise FileNotFoundError(f"missing expansion policy: {policy_path}")
+    return _load_json(policy_path)
+
+
+def _validate_contract_semantics(contract: dict[str, Any]) -> None:
+    def _require_non_empty_list(key: str) -> None:
+        value = contract.get(key)
+        if not isinstance(value, list) or len(value) == 0:
+            raise ValueError(f"contract field must be non-empty list: {key}")
+
+    _require_non_empty_list("target_modules")
+    _require_non_empty_list("acceptance_checks")
+
+    if contract.get("realization_mode") == "runtime_realization":
+        _require_non_empty_list("target_tests")
+        _require_non_empty_list("runtime_entrypoints")
+
+
 def _load_contract(contract_dir: Path, step_id: str) -> dict[str, Any]:
     path = _contract_path(contract_dir, step_id)
     if not path.is_file():
         raise FileNotFoundError(f"missing step contract: {path}")
     contract = _load_json(path)
     validate_artifact(contract, "roadmap_step_contract")
+    _validate_contract_semantics(contract)
     if contract["step_id"] != step_id:
         raise ValueError(f"contract step mismatch: expected {step_id}, found {contract['step_id']}")
     return contract
@@ -92,7 +135,7 @@ def _check_runtime_entrypoints(runtime_entrypoints: list[str]) -> list[dict[str,
                 if not callable(obj):
                     ok = False
                     error = "entrypoint is not callable"
-            except Exception as exc:  # pragma: no cover - exercised in tests via contract values
+            except Exception as exc:  # pragma: no cover
                 ok = False
                 error = str(exc)
         checks.append({"entrypoint": entry, "exists": ok, "error": error})
@@ -100,26 +143,48 @@ def _check_runtime_entrypoints(runtime_entrypoints: list[str]) -> list[dict[str,
 
 
 def _scan_forbidden_patterns(contract: dict[str, Any], repo_root: Path) -> list[dict[str, Any]]:
-    patterns = sorted(set(contract["forbidden_patterns"] + BASE_FORBIDDEN_PATTERNS))
-    hits: list[dict[str, Any]] = []
+    caller_patterns = [re.escape(pattern) for pattern in contract["forbidden_patterns"]]
+    patterns = [re.compile(pattern, flags=re.IGNORECASE | re.MULTILINE) for pattern in sorted(set(BASE_FORBIDDEN_PATTERNS + caller_patterns))]
+
     scoped_files = sorted(set(contract["target_modules"]))
+
+    hits: list[dict[str, Any]] = []
     for rel_path in scoped_files:
         path = repo_root / rel_path
         if not path.is_file():
             raise FileNotFoundError(f"missing target module path: {path}")
         text = path.read_text(encoding="utf-8")
         for pattern in patterns:
-            if pattern in text:
-                hits.append({"step_id": contract["step_id"], "path": rel_path, "pattern": pattern})
-        if contract["step_id"] in text and '"status": "pass"' in text:
-            hits.append(
-                {
-                    "step_id": contract["step_id"],
-                    "path": rel_path,
-                    "pattern": "direct static payload emission for target step",
-                }
-            )
+            if pattern.search(text):
+                hits.append({"step_id": contract["step_id"], "path": rel_path, "pattern": pattern.pattern})
+
     return hits
+
+
+def _validate_behavioral_test_commands(test_commands: list[str]) -> tuple[bool, list[dict[str, Any]]]:
+    checks: list[dict[str, Any]] = []
+    approved_count = 0
+    for command in test_commands:
+        approved_prefix = any(command.startswith(prefix) for prefix in APPROVED_TEST_PREFIXES)
+        rejected_reason = ""
+        for pattern in REJECTED_TEST_PATTERNS:
+            if pattern.search(command):
+                rejected_reason = f"rejected by policy pattern: {pattern.pattern}"
+                break
+        pytest_target_ok = "tests/" in command and ("-k" in command or "::" in command or "-q" in command)
+        is_approved = approved_prefix and pytest_target_ok and rejected_reason == ""
+        if is_approved:
+            approved_count += 1
+        checks.append(
+            {
+                "command": command,
+                "approved": is_approved,
+                "rejected_reason": rejected_reason,
+                "approved_prefix": approved_prefix,
+                "pytest_target_ok": pytest_target_ok,
+            }
+        )
+    return approved_count > 0 and all(item["approved"] for item in checks), checks
 
 
 def _run_behavioral_tests(test_commands: list[str], repo_root: Path) -> list[dict[str, Any]]:
@@ -154,6 +219,40 @@ def _verification_checks(contract: dict[str, Any], repo_root: Path) -> dict[str,
     }
 
 
+def _validate_ownership_boundaries(contract: dict[str, Any], policy: dict[str, Any]) -> dict[str, Any]:
+    owner_defaults = policy.get("owner_defaults", {})
+    owner = contract["owner"]
+    owner_policy = owner_defaults.get(owner)
+    if not owner_policy:
+        return {"passed": False, "reason": f"owner missing from expansion policy: {owner}"}
+
+    allowed_module_prefixes = tuple(owner_policy.get("allowed_module_prefixes", []))
+    invalid_modules = [p for p in contract["target_modules"] if not p.startswith(allowed_module_prefixes)]
+
+    allowed_test_prefixes = tuple(owner_policy.get("allowed_test_prefixes", []))
+    invalid_tests: list[str] = []
+    for cmd in contract["target_tests"]:
+        if "tests/" not in cmd:
+            invalid_tests.append(cmd)
+            continue
+        tokens = shlex.split(cmd)
+        test_tokens = [tok for tok in tokens if tok.startswith("tests/")]
+        if not test_tokens:
+            invalid_tests.append(cmd)
+            continue
+        if not all(tok.startswith(allowed_test_prefixes) for tok in test_tokens):
+            invalid_tests.append(cmd)
+
+    passed = len(invalid_modules) == 0 and len(invalid_tests) == 0
+    return {
+        "passed": passed,
+        "invalid_modules": invalid_modules,
+        "invalid_tests": invalid_tests,
+        "allowed_module_prefixes": list(allowed_module_prefixes),
+        "allowed_test_prefixes": list(allowed_test_prefixes),
+    }
+
+
 def realize_steps(
     *,
     step_ids: list[str],
@@ -165,24 +264,47 @@ def realize_steps(
         if step_id not in SUPPORTED_STEPS:
             raise ValueError(f"unsupported step: {step_id}")
 
-    contracts = {step_id: _load_contract(contract_dir, step_id) for step_id in step_ids}
-    for contract in contracts.values():
-        _validate_expansion_trace(contract, repo_root)
+    policy = _load_expansion_policy()
+    contracts: dict[str, dict[str, Any]] = {}
+    contract_validation_failures: dict[str, str] = {}
+    for step_id in step_ids:
+        try:
+            contract = _load_contract(contract_dir, step_id)
+            _validate_expansion_trace(contract, repo_root)
+            contract["_authoritative_status"] = authoritative_start_status(contract["realization_status"])
+            contracts[step_id] = contract
+        except Exception as exc:
+            contract_validation_failures[step_id] = str(exc)
 
     status_by_step = dict(BASELINE_REALIZATION_STATUS)
-    status_by_step.update({step_id: contracts[step_id]["realization_status"] for step_id in step_ids})
+    for step_id, contract in contracts.items():
+        status_by_step[step_id] = contract["_authoritative_status"]
+
     attempted_steps: list[str] = []
     passed_steps: list[str] = []
-    failed_steps: list[str] = []
+    failed_steps: list[str] = sorted(set(contract_validation_failures.keys()))
+
     forbidden_pattern_hits: dict[str, list[dict[str, Any]]] = {}
     runtime_entrypoint_checks: dict[str, list[dict[str, Any]]] = {}
     behavioral_test_results: dict[str, list[dict[str, Any]]] = {}
+    behavioral_test_policy_checks: dict[str, list[dict[str, Any]]] = {}
+    ownership_checks: dict[str, dict[str, Any]] = {}
+    dependency_failures: dict[str, str] = {}
     status_updates: list[dict[str, str]] = []
 
+    critical_failures: dict[str, dict[str, bool]] = {
+        step_id: {category: False for category in CRITICAL_FAILURE_CATEGORIES} for step_id in step_ids
+    }
+    for step_id in contract_validation_failures:
+        critical_failures[step_id]["contract_validation"] = True
+
     for step_id in step_ids:
+        if step_id in contract_validation_failures:
+            continue
         contract = contracts[step_id]
         attempted_steps.append(step_id)
 
+        dependency_passed = True
         try:
             enforce_realization_dependencies(
                 step_id=step_id,
@@ -190,28 +312,58 @@ def realize_steps(
                 attempted_steps=attempted_steps,
                 status_by_step=status_by_step,
             )
-        except RoadmapRealizationRuntimeError:
+        except RoadmapRealizationRuntimeError as exc:
+            dependency_passed = False
+            dependency_failures[step_id] = str(exc)
+            critical_failures[step_id]["dependency_validation"] = True
+
+        ownership = _validate_ownership_boundaries(contract, policy)
+        ownership_checks[step_id] = ownership
+        ownership_passed = ownership["passed"]
+        if not ownership_passed:
+            critical_failures[step_id]["ownership_validation"] = True
+        if not dependency_passed or not ownership_passed:
             failed_steps.append(step_id)
             continue
 
         step_forbidden_hits = _scan_forbidden_patterns(contract, repo_root)
         forbidden_pattern_hits[step_id] = step_forbidden_hits
+        forbidden_passed = len(step_forbidden_hits) == 0
+        if not forbidden_passed:
+            critical_failures[step_id]["forbidden_pattern_validation"] = True
 
         step_entrypoint_checks = _check_runtime_entrypoints(contract["runtime_entrypoints"])
         runtime_entrypoint_checks[step_id] = step_entrypoint_checks
+        entrypoints_passed = all(item["exists"] for item in step_entrypoint_checks)
+        if not entrypoints_passed:
+            critical_failures[step_id]["runtime_entrypoint_validation"] = True
 
-        step_behavioral_results = _run_behavioral_tests(contract["target_tests"], repo_root)
-        behavioral_test_results[step_id] = step_behavioral_results
+        test_policy_passed, test_policy_checks = _validate_behavioral_test_commands(contract["target_tests"])
+        behavioral_test_policy_checks[step_id] = test_policy_checks
+        behavioral_results: list[dict[str, Any]] = []
+        if test_policy_passed:
+            behavioral_results = _run_behavioral_tests(contract["target_tests"], repo_root)
+        behavioral_test_results[step_id] = behavioral_results
+        behavioral_passed = test_policy_passed and all(result["passed"] for result in behavioral_results)
+        if not behavioral_passed:
+            critical_failures[step_id]["behavioral_test_validation"] = True
 
         verification = _verification_checks(contract, repo_root)
-        prior_status = contract["realization_status"]
+        prior_status = status_by_step[step_id]
         next_status = next_realization_status(
             current_status=prior_status,
-            forbidden_patterns_absent=len(step_forbidden_hits) == 0,
-            runtime_entrypoints_exist=all(item["exists"] for item in step_entrypoint_checks),
-            behavioral_tests_passed=all(result["passed"] for result in step_behavioral_results),
+            dependency_checks_passed=dependency_passed,
+            ownership_checks_passed=ownership_passed,
+            forbidden_patterns_absent=forbidden_passed,
+            runtime_entrypoints_exist=entrypoints_passed,
+            behavioral_tests_passed=behavioral_passed,
             verification_checks_passed=verification["passed"],
         )
+
+        step_failed = any(critical_failures[step_id].values()) or next_status not in {"runtime_realized", "verified"}
+        if step_failed:
+            failed_steps.append(step_id)
+            continue
 
         if next_status != prior_status:
             contract["realization_status"] = next_status
@@ -219,21 +371,50 @@ def realize_steps(
             status_updates.append({"step_id": step_id, "from": prior_status, "to": next_status})
             status_by_step[step_id] = next_status
 
+        # Verified transition requires a separate invocation after runtime realization.
+        if next_status == "runtime_realized" and verification["passed"]:
+            verified_status = next_realization_status(
+                current_status=next_status,
+                dependency_checks_passed=dependency_passed,
+                ownership_checks_passed=ownership_passed,
+                forbidden_patterns_absent=forbidden_passed,
+                runtime_entrypoints_exist=entrypoints_passed,
+                behavioral_tests_passed=behavioral_passed,
+                verification_checks_passed=verification["passed"],
+            )
+            if verified_status != next_status:
+                contract["realization_status"] = verified_status
+                _write_json(_contract_path(contract_dir, step_id), contract)
+                status_updates.append({"step_id": step_id, "from": next_status, "to": verified_status})
+                status_by_step[step_id] = verified_status
+                next_status = verified_status
+
         if next_status in {"runtime_realized", "verified"}:
             passed_steps.append(step_id)
         else:
             failed_steps.append(step_id)
 
-    overall_status = "pass" if len(failed_steps) == 0 and len(step_ids) > 0 else "fail"
+    any_critical_failure = any(any(categories.values()) for categories in critical_failures.values())
+    if any_critical_failure:
+        passed_steps = [step for step in passed_steps if not any(critical_failures[step].values())]
+        status_updates = []
+
+    overall_status = "pass" if len(step_ids) > 0 and not any_critical_failure and len(failed_steps) == 0 else "fail"
+
     result = {
         "artifact_type": "roadmap_realization_result",
         "step_ids": step_ids,
         "attempted_steps": attempted_steps,
-        "passed_steps": passed_steps,
-        "failed_steps": failed_steps,
+        "passed_steps": sorted(set(passed_steps)),
+        "failed_steps": sorted(set(failed_steps)),
+        "contract_validation_failures": contract_validation_failures,
+        "dependency_failures": dependency_failures,
+        "ownership_checks": ownership_checks,
         "forbidden_pattern_hits": forbidden_pattern_hits,
         "runtime_entrypoint_checks": runtime_entrypoint_checks,
+        "behavioral_test_policy_checks": behavioral_test_policy_checks,
         "behavioral_test_results": behavioral_test_results,
+        "critical_failures": critical_failures,
         "status_updates": status_updates,
         "overall_status": overall_status,
     }

--- a/spectrum_systems/modules/runtime/roadmap_realization_runtime.py
+++ b/spectrum_systems/modules/runtime/roadmap_realization_runtime.py
@@ -12,10 +12,20 @@ ALLOWED_STATUSES = [
     "runtime_realized",
     "verified",
 ]
+RUNTIME_READY_DEPENDENCY_STATUSES = {"runtime_realized", "verified"}
 
 
 class RoadmapRealizationRuntimeError(ValueError):
     """Raised when realization checks violate fail-closed runtime rules."""
+
+
+def authoritative_start_status(status: str) -> str:
+    """Normalize caller-provided status to an authoritative runtime baseline."""
+    if status not in ALLOWED_STATUSES:
+        raise RoadmapRealizationRuntimeError(f"unknown realization status: {status}")
+    if status in {"runtime_realized", "verified"}:
+        return "planned_only"
+    return status
 
 
 def enforce_realization_dependencies(
@@ -31,21 +41,22 @@ def enforce_realization_dependencies(
     step_index = attempted.index(step_id)
 
     for dependency in depends_on:
-        if dependency in attempted:
-            if attempted.index(dependency) >= step_index:
-                raise RoadmapRealizationRuntimeError(
-                    f"dependency order violated: {step_id} cannot run before {dependency}"
-                )
+        if dependency not in status_by_step:
+            raise RoadmapRealizationRuntimeError(f"dependency {dependency} not found for {step_id}")
+        if dependency in attempted and attempted.index(dependency) >= step_index:
+            raise RoadmapRealizationRuntimeError(f"dependency order violated: {step_id} cannot run before {dependency}")
         dependency_status = status_by_step.get(dependency)
-        if dependency_status not in {"runtime_realized", "verified"}:
+        if dependency_status not in RUNTIME_READY_DEPENDENCY_STATUSES:
             raise RoadmapRealizationRuntimeError(
-                f"dependency {dependency} not runtime realized for {step_id}"
+                f"dependency {dependency} must be runtime_realized before {step_id}; found {dependency_status}"
             )
 
 
 def next_realization_status(
     *,
     current_status: str,
+    dependency_checks_passed: bool,
+    ownership_checks_passed: bool,
     forbidden_patterns_absent: bool,
     runtime_entrypoints_exist: bool,
     behavioral_tests_passed: bool,
@@ -54,10 +65,22 @@ def next_realization_status(
     if current_status not in ALLOWED_STATUSES:
         raise RoadmapRealizationRuntimeError(f"unknown realization status: {current_status}")
 
-    if not (forbidden_patterns_absent and runtime_entrypoints_exist and behavioral_tests_passed):
+    runtime_gate_passed = all(
+        (
+            dependency_checks_passed,
+            ownership_checks_passed,
+            forbidden_patterns_absent,
+            runtime_entrypoints_exist,
+            behavioral_tests_passed,
+        )
+    )
+    if not runtime_gate_passed:
         return current_status
 
-    runtime_status = "runtime_realized"
-    if verification_checks_passed:
+    if current_status in {"planned_only", "artifact_materialized", "partially_realized"}:
+        return "runtime_realized"
+
+    if current_status == "runtime_realized" and verification_checks_passed:
         return "verified"
-    return runtime_status
+
+    return current_status

--- a/tests/test_roadmap_realization_runner.py
+++ b/tests/test_roadmap_realization_runner.py
@@ -23,7 +23,7 @@ def _write_json(path: Path, payload: dict) -> None:
 
 def _base_contract(step_id: str) -> dict:
     depends = ["RF-01"] if step_id == "RF-02" else ["RF-01", "RF-02"]
-    tests = ["python -c \"raise SystemExit(0)\""]
+    tests = ["pytest tests/test_roadmap_realization_runner.py -k rf_contract_schema -q"]
     entrypoints = ["spectrum_systems.modules.runtime.roadmap_realization_runtime:next_realization_status"]
     if step_id == "RF-03":
         entrypoints.append("spectrum_systems.modules.runtime.roadmap_realization_runtime:enforce_realization_dependencies")
@@ -64,92 +64,75 @@ def _write_contracts(tmp_path: Path, rf02: dict | None = None, rf03: dict | None
     return contract_dir
 
 
-def test_rf02_rf03_contracts_pass_schema_validation() -> None:
+def test_rf_contract_schema() -> None:
     validate_artifact(json.loads(Path("artifacts/roadmap_contracts/RF-02.json").read_text()), "roadmap_step_contract")
     validate_artifact(json.loads(Path("artifacts/roadmap_contracts/RF-03.json").read_text()), "roadmap_step_contract")
 
 
-def test_rf03_dependency_order_is_enforced(tmp_path: Path) -> None:
+def test_malformed_contracts_rejected_fail_closed(tmp_path: Path) -> None:
+    rf02 = _base_contract("RF-02")
+    del rf02["target_modules"]
+    rf03 = _base_contract("RF-03")
+    rf03["acceptance_checks"] = []
+    contract_dir = _write_contracts(tmp_path, rf02=rf02, rf03=rf03)
+    result = realize_steps(step_ids=["RF-02", "RF-03"], contract_dir=contract_dir, result_path=tmp_path / "result.json", repo_root=Path("."))
+    assert result["overall_status"] == "fail"
+    assert set(result["failed_steps"]) == {"RF-02", "RF-03"}
+    assert result["attempted_steps"] == []
+    assert set(result["contract_validation_failures"]) == {"RF-02", "RF-03"}
+
+
+def test_dependency_bypass_attack_blocked(tmp_path: Path) -> None:
     contract_dir = _write_contracts(tmp_path)
-    result = realize_steps(
-        step_ids=["RF-03", "RF-02"],
-        contract_dir=contract_dir,
-        result_path=tmp_path / "result.json",
-        repo_root=Path("."),
-    )
+    result = realize_steps(step_ids=["RF-03", "RF-02"], contract_dir=contract_dir, result_path=tmp_path / "result.json", repo_root=Path("."))
     assert "RF-03" in result["failed_steps"]
+    assert "RF-03" in result["dependency_failures"]
+    assert result["overall_status"] == "fail"
 
 
-def test_forbidden_patterns_block_realization(tmp_path: Path) -> None:
+def test_forbidden_pattern_evasion_attack_blocked(tmp_path: Path) -> None:
     rf02 = _base_contract("RF-02")
     rf02["forbidden_patterns"] = ["ALLOWED_STATUSES"]
     contract_dir = _write_contracts(tmp_path, rf02=rf02)
-    result = realize_steps(
-        step_ids=["RF-02"],
-        contract_dir=contract_dir,
-        result_path=tmp_path / "result.json",
-        repo_root=Path("."),
-    )
-    assert result["failed_steps"] == ["RF-02"]
+    result = realize_steps(step_ids=["RF-02"], contract_dir=contract_dir, result_path=tmp_path / "result.json", repo_root=Path("."))
+    assert result["overall_status"] == "fail"
     assert result["forbidden_pattern_hits"]["RF-02"]
 
 
-def test_missing_runtime_entrypoint_blocks_realization(tmp_path: Path) -> None:
+def test_fake_test_success_attack_blocked(tmp_path: Path) -> None:
+    rf02 = _base_contract("RF-02")
+    rf02["target_tests"] = ["pytest tests/test_roadmap_realization_runner.py -k rf_contract_schema -q && python -c \"raise SystemExit(0)\""]
+    contract_dir = _write_contracts(tmp_path, rf02=rf02)
+    result = realize_steps(step_ids=["RF-02"], contract_dir=contract_dir, result_path=tmp_path / "result.json", repo_root=Path("."))
+    assert result["overall_status"] == "fail"
+    assert result["behavioral_test_policy_checks"]["RF-02"][0]["approved"] is False
+
+
+def test_status_forging_attack_blocked(tmp_path: Path) -> None:
+    rf02 = _base_contract("RF-02")
+    rf02["realization_status"] = "verified"
+    contract_dir = _write_contracts(tmp_path, rf02=rf02)
+    result = realize_steps(step_ids=["RF-02"], contract_dir=contract_dir, result_path=tmp_path / "result.json", repo_root=Path("."))
+    assert result["overall_status"] == "pass"
+    updates = result["status_updates"]
+    assert updates[0]["from"] == "planned_only"
+    assert json.loads((contract_dir / "RF-02.json").read_text())["realization_status"] == "verified"
+
+
+def test_ownership_boundary_attack_blocked(tmp_path: Path) -> None:
+    rf02 = _base_contract("RF-02")
+    rf02["target_modules"] = ["spectrum_systems/modules/control/illegal.py"]
+    contract_dir = _write_contracts(tmp_path, rf02=rf02)
+    result = realize_steps(step_ids=["RF-02"], contract_dir=contract_dir, result_path=tmp_path / "result.json", repo_root=Path("."))
+    assert result["overall_status"] == "fail"
+    assert result["ownership_checks"]["RF-02"]["passed"] is False
+
+
+def test_fail_closed_result_semantics_on_critical_failure(tmp_path: Path) -> None:
     rf02 = _base_contract("RF-02")
     rf02["runtime_entrypoints"] = ["spectrum_systems.modules.runtime.roadmap_realization_runtime:missing_function"]
     contract_dir = _write_contracts(tmp_path, rf02=rf02)
-    result = realize_steps(
-        step_ids=["RF-02"],
-        contract_dir=contract_dir,
-        result_path=tmp_path / "result.json",
-        repo_root=Path("."),
-    )
-    assert result["failed_steps"] == ["RF-02"]
-    assert result["runtime_entrypoint_checks"]["RF-02"][0]["exists"] is False
-
-
-def test_failing_behavioral_tests_block_status_advancement(tmp_path: Path) -> None:
-    rf02 = _base_contract("RF-02")
-    rf02["target_tests"] = ["python -c \"raise SystemExit(1)\""]
-    contract_dir = _write_contracts(tmp_path, rf02=rf02)
-    result = realize_steps(
-        step_ids=["RF-02"],
-        contract_dir=contract_dir,
-        result_path=tmp_path / "result.json",
-        repo_root=Path("."),
-    )
-    updated = json.loads((contract_dir / "RF-02.json").read_text())
-    assert result["failed_steps"] == ["RF-02"]
-    assert updated["realization_status"] == "planned_only"
-
-
-def test_passing_behavioral_tests_allow_status_advancement(tmp_path: Path) -> None:
-    contract_dir = _write_contracts(tmp_path)
-    result = realize_steps(
-        step_ids=["RF-02", "RF-03"],
-        contract_dir=contract_dir,
-        result_path=tmp_path / "result.json",
-        repo_root=Path("."),
-    )
-    rf02 = json.loads((contract_dir / "RF-02.json").read_text())
-    rf03 = json.loads((contract_dir / "RF-03.json").read_text())
-    assert result["failed_steps"] == []
-    assert rf02["realization_status"] in {"runtime_realized", "verified"}
-    assert rf03["realization_status"] in {"runtime_realized", "verified"}
-
-
-def test_result_artifact_reflects_real_outcomes(tmp_path: Path) -> None:
-    rf02 = _base_contract("RF-02")
-    rf02["target_tests"] = ["python -c \"raise SystemExit(1)\""]
-    contract_dir = _write_contracts(tmp_path, rf02=rf02)
-    result_path = tmp_path / "roadmap_realization_result.json"
-    result = realize_steps(
-        step_ids=["RF-02", "RF-03"],
-        contract_dir=contract_dir,
-        result_path=result_path,
-        repo_root=Path("."),
-    )
-    written = json.loads(result_path.read_text())
-    assert written["artifact_type"] == "roadmap_realization_result"
-    assert written["attempted_steps"] == ["RF-02", "RF-03"]
-    assert written["overall_status"] == result["overall_status"] == "fail"
+    result = realize_steps(step_ids=["RF-02"], contract_dir=contract_dir, result_path=tmp_path / "result.json", repo_root=Path("."))
+    assert result["overall_status"] == "fail"
+    assert result["passed_steps"] == []
+    assert result["status_updates"] == []


### PR DESCRIPTION
### Motivation
- Address six critical red-team failures in the roadmap realization runner by making RAX fail-closed on malformed contracts, dependency bypass, forbidden-pattern evasion, fake test success, status forging, and ownership-boundary attacks.
- Ensure runtime-authoritative status transitions and reject any caller-forged `realization_status` values before any realization attempts.
- Preserve narrow scope: harden the existing RF-02/RF-03 runner only and do not extend realization authority or add new roadmap families.

### Description
- Enforce contract semantics and schema-level requirements by rejecting contracts missing or having empty `target_modules` or `acceptance_checks`, and require non-empty `target_tests` and `runtime_entrypoints` for `runtime_realization`; malformed contracts are recorded as contract-validation failures and block realization attempts (`scripts/roadmap_realization_runner.py`).
- Make the runtime authoritative for status handling by normalizing caller-supplied statuses to a safe baseline and gating transitions via an internal `next_realization_status` that requires dependency, ownership, forbidden-pattern, entrypoint, and behavioral-test checks before moving to `runtime_realized` or `verified` (`spectrum_systems/modules/runtime/roadmap_realization_runtime.py`, `scripts/roadmap_realization_runner.py`).
- Add strict dependency and ownership enforcement: dependencies must exist, preserve ordering, and be `runtime_realized` before dependent steps run, and `target_modules`/`target_tests` are validated against owner-allowed prefixes from the expansion policy; explicit failure reasons are returned in results (`spectrum_systems/modules/runtime/roadmap_realization_runtime.py`, `scripts/roadmap_realization_runner.py`).
- Strengthen forbidden-pattern detection and behavioral-test integrity by replacing naive string matches with regex heuristics scoped to target module files, treating hits as critical failures, and allowing only approved pytest-style test commands while rejecting `python -c` and trivial file-existence checks; added regression tests and a BUILD plan artifact for the hardening batch (`scripts/roadmap_realization_runner.py`, `tests/test_roadmap_realization_runner.py`, `docs/review-actions/PLAN-RAX-HARDEN-CRITICAL-01-2026-04-11.md`).

### Testing
- Ran `pytest tests/test_roadmap_realization_runner.py -q` and verified the focused red-team regression suite passed (8 passed).
- Ran `pytest tests/test_roadmap_expansion_contracts.py -q` and verified contract expansion checks passed (9 passed).
- Test coverage demonstrates malformed contracts are rejected, dependency bypass is blocked, forbidden-pattern evasion and fake-test attacks fail, caller status forging is normalized, ownership boundary attacks fail, and fail-closed result semantics are enforced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dacf9886648329a092efc2254aa5c9)