### PR TITLE
Harden RAX runner against dependency bypass, forbidden-pattern evasion, and forged statuses

### DIFF
--- a/scripts/roadmap_realization_runner.py
+++ b/scripts/roadmap_realization_runner.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import ast
 import importlib
 import json
 import re
@@ -38,6 +39,14 @@ BASE_FORBIDDEN_PATTERNS = [
     r"artifact[-_ ]only",
     r"direct static payload",
 ]
+FORGED_REALIZATION_STATUSES = {"runtime_realized", "verified"}
+NORMALIZED_FORBIDDEN_SIGNATURES = (
+    "writejson",
+    "jsondump",
+    "statuspass",
+    "artifactonly",
+    "directstaticpayload",
+)
 
 APPROVED_TEST_PREFIXES = ("pytest tests/", "python -m pytest tests/")
 APPROVED_PYTEST_TARGET_PATTERNS = (
@@ -155,21 +164,86 @@ def _check_runtime_entrypoints(runtime_entrypoints: list[str]) -> list[dict[str,
 
 def _scan_forbidden_patterns(contract: dict[str, Any], repo_root: Path) -> list[dict[str, Any]]:
     caller_patterns = [re.escape(pattern) for pattern in contract["forbidden_patterns"]]
-    patterns = [re.compile(pattern, flags=re.IGNORECASE | re.MULTILINE) for pattern in sorted(set(BASE_FORBIDDEN_PATTERNS + caller_patterns))]
+    regex_patterns = [
+        re.compile(pattern, flags=re.IGNORECASE | re.MULTILINE) for pattern in sorted(set(BASE_FORBIDDEN_PATTERNS + caller_patterns))
+    ]
+    normalized_signatures = set(NORMALIZED_FORBIDDEN_SIGNATURES)
+    normalized_signatures.update(_normalize_forbidden_text(pattern) for pattern in contract["forbidden_patterns"])
+    normalized_signatures.discard("")
 
-    scoped_files = sorted(set(contract["target_modules"]))
+    scoped_files = _resolve_forbidden_scan_scope(contract=contract, repo_root=repo_root)
 
     hits: list[dict[str, Any]] = []
     for rel_path in scoped_files:
         path = repo_root / rel_path
         if not path.is_file():
-            raise FileNotFoundError(f"missing target module path: {path}")
+            raise FileNotFoundError(f"missing target/helper module path: {path}")
         text = path.read_text(encoding="utf-8")
-        for pattern in patterns:
+        normalized_text = _normalize_forbidden_text(text)
+        for pattern in regex_patterns:
             if pattern.search(text):
-                hits.append({"step_id": contract["step_id"], "path": rel_path, "pattern": pattern.pattern})
+                hits.append({"step_id": contract["step_id"], "path": rel_path, "pattern": pattern.pattern, "match_mode": "regex"})
+        for signature in sorted(normalized_signatures):
+            if signature and signature in normalized_text:
+                hits.append(
+                    {
+                        "step_id": contract["step_id"],
+                        "path": rel_path,
+                        "pattern": signature,
+                        "match_mode": "normalized_signature",
+                    }
+                )
 
-    return hits
+    deduped_hits = {
+        (item["step_id"], item["path"], item["pattern"], item["match_mode"]): item for item in hits
+    }
+    return list(deduped_hits.values())
+
+
+def _normalize_forbidden_text(text: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", text.lower())
+
+
+def _entrypoint_to_repo_path(entrypoint: str) -> str | None:
+    module_name, sep, _symbol = entrypoint.partition(":")
+    if not sep or not module_name.startswith("spectrum_systems."):
+        return None
+    return f"{module_name.replace('.', '/')}.py"
+
+
+def _extract_local_import_paths(path: Path, repo_root: Path) -> set[str]:
+    text = path.read_text(encoding="utf-8")
+    tree = ast.parse(text)
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                module_name = alias.name
+                if module_name.startswith("spectrum_systems."):
+                    imports.add(f"{module_name.replace('.', '/')}.py")
+        elif isinstance(node, ast.ImportFrom):
+            module_name = node.module or ""
+            if module_name.startswith("spectrum_systems."):
+                imports.add(f"{module_name.replace('.', '/')}.py")
+    return {candidate for candidate in imports if (repo_root / candidate).is_file()}
+
+
+def _resolve_forbidden_scan_scope(*, contract: dict[str, Any], repo_root: Path) -> list[str]:
+    scoped_files: set[str] = set(contract["target_modules"])
+    for entrypoint in contract["runtime_entrypoints"]:
+        entrypoint_path = _entrypoint_to_repo_path(entrypoint)
+        if entrypoint_path:
+            scoped_files.add(entrypoint_path)
+
+    helper_files: set[str] = set()
+    for rel_path in sorted(scoped_files):
+        path = repo_root / rel_path
+        if not path.is_file():
+            raise FileNotFoundError(f"missing target/helper module path: {path}")
+        helper_files.update(_extract_local_import_paths(path, repo_root))
+
+    scoped_files.update(helper_files)
+    return sorted(scoped_files)
 
 
 def _extract_pytest_targets(command: str) -> list[str]:
@@ -394,14 +468,23 @@ def realize_steps(
     policy = _load_expansion_policy()
     contracts: dict[str, dict[str, Any]] = {}
     contract_validation_failures: dict[str, str] = {}
+    forged_status_failures: dict[str, str] = {}
     for step_id in step_ids:
         try:
             contract = _load_contract(contract_dir, step_id)
             _validate_expansion_trace(contract, repo_root)
+            incoming_status = contract["realization_status"]
+            if incoming_status in FORGED_REALIZATION_STATUSES:
+                raise RoadmapRealizationRuntimeError(
+                    "incoming realization_status is forged for standard realization execution "
+                    f"({incoming_status}); authoritative prior-run verification artifact required"
+                )
             contract["_authoritative_status"] = authoritative_start_status(contract["realization_status"])
             contracts[step_id] = contract
         except Exception as exc:
             contract_validation_failures[step_id] = str(exc)
+            if "incoming realization_status is forged" in str(exc):
+                forged_status_failures[step_id] = str(exc)
 
     status_by_step = dict(BASELINE_REALIZATION_STATUS)
     for step_id, contract in contracts.items():
@@ -524,8 +607,12 @@ def realize_steps(
             failed_steps.append(step_id)
 
     any_critical_failure = any(any(categories.values()) for categories in critical_failures.values())
-    if any_critical_failure:
-        passed_steps = [step for step in passed_steps if not any(critical_failures[step].values())]
+    invocation_dependency_blocked = len(dependency_failures) > 0 and len(step_ids) > 1
+    if any_critical_failure or invocation_dependency_blocked:
+        if invocation_dependency_blocked:
+            for step_id in attempted_steps:
+                critical_failures[step_id]["dependency_validation"] = True
+        passed_steps = []
         status_updates = []
 
     overall_status = "pass" if len(step_ids) > 0 and not any_critical_failure and len(failed_steps) == 0 else "fail"
@@ -538,6 +625,7 @@ def realize_steps(
         "failed_steps": sorted(set(failed_steps)),
         "contract_validation_failures": contract_validation_failures,
         "dependency_failures": dependency_failures,
+        "forged_status_failures": forged_status_failures,
         "ownership_checks": ownership_checks,
         "forbidden_pattern_hits": forbidden_pattern_hits,
         "runtime_entrypoint_checks": runtime_entrypoint_checks,

--- a/tests/test_roadmap_realization_runner.py
+++ b/tests/test_roadmap_realization_runner.py
@@ -100,15 +100,77 @@ def test_dependency_bypass_attack_blocked(tmp_path: Path) -> None:
     assert "RF-03" in result["failed_steps"]
     assert "RF-03" in result["dependency_failures"]
     assert result["overall_status"] == "fail"
+    assert result["passed_steps"] == []
+    assert result["status_updates"] == []
+
+
+def test_dependency_bypass_with_rf02_planned_only_blocked(tmp_path: Path) -> None:
+    rf02 = _base_contract("RF-02")
+    rf02["realization_status"] = "planned_only"
+    contract_dir = _write_contracts(tmp_path, rf02=rf02)
+    result = realize_steps(step_ids=["RF-03"], contract_dir=contract_dir, result_path=tmp_path / "result.json", repo_root=Path("."))
+    assert result["overall_status"] == "fail"
+    assert result["passed_steps"] == []
+    assert result["status_updates"] == []
+
+
+def test_dependency_bypass_with_rf02_artifact_materialized_blocked(tmp_path: Path) -> None:
+    rf02 = _base_contract("RF-02")
+    rf02["realization_status"] = "artifact_materialized"
+    contract_dir = _write_contracts(tmp_path, rf02=rf02)
+    result = realize_steps(step_ids=["RF-03"], contract_dir=contract_dir, result_path=tmp_path / "result.json", repo_root=Path("."))
+    assert result["overall_status"] == "fail"
+    assert result["passed_steps"] == []
+    assert result["status_updates"] == []
 
 
 def test_forbidden_pattern_evasion_attack_blocked(tmp_path: Path) -> None:
     rf02 = _base_contract("RF-02")
-    rf02["forbidden_patterns"] = ["ALLOWED_STATUSES"]
-    contract_dir = _write_contracts(tmp_path, rf02=rf02)
-    result = realize_steps(step_ids=["RF-02"], contract_dir=contract_dir, result_path=tmp_path / "result.json", repo_root=Path("."))
-    assert result["overall_status"] == "fail"
-    assert result["forbidden_pattern_hits"]["RF-02"]
+    helper_path = Path("spectrum_systems/modules/runtime/_rax_forbidden_pattern_helper.py")
+    helper_content = """
+def helper_wrapper_write(payload):
+    status = {"status" : "pass"}
+    return status
+
+def direct_writer(payload):
+    return _write_json(payload)
+
+def static_payload_helper():
+    return "direct static payload"
+
+def artifact_only_helper():
+    return "artifact-only success"
+"""
+    try:
+        helper_path.write_text(helper_content, encoding="utf-8")
+        rf02["target_modules"] = [
+            "spectrum_systems/modules/runtime/roadmap_realization_runtime.py",
+            helper_path.as_posix(),
+        ]
+        contract_dir = _write_contracts(tmp_path, rf02=rf02)
+        variants = [
+            "  _ WRITE __ JSON  ",
+            "helper wrapper write",
+            "static payload helper",
+            "\"status\" : \"pass\"",
+            "artifact only helper",
+        ]
+        for variant in variants:
+            rf02["forbidden_patterns"] = [variant]
+            _write_json(contract_dir / "RF-02.json", rf02)
+            result = realize_steps(
+                step_ids=["RF-02"],
+                contract_dir=contract_dir,
+                result_path=tmp_path / f"result-{variant}.json",
+                repo_root=Path("."),
+            )
+            assert result["overall_status"] == "fail"
+            assert result["forbidden_pattern_hits"]["RF-02"]
+            assert result["passed_steps"] == []
+            assert result["status_updates"] == []
+    finally:
+        if helper_path.exists():
+            helper_path.unlink()
 
 
 def test_fake_test_success_attack_blocked(tmp_path: Path) -> None:
@@ -125,10 +187,23 @@ def test_status_forging_attack_blocked(tmp_path: Path) -> None:
     rf02["realization_status"] = "verified"
     contract_dir = _write_contracts(tmp_path, rf02=rf02)
     result = realize_steps(step_ids=["RF-02"], contract_dir=contract_dir, result_path=tmp_path / "result.json", repo_root=Path("."))
-    assert result["overall_status"] == "pass"
-    updates = result["status_updates"]
-    assert updates[0]["from"] == "planned_only"
-    assert json.loads((contract_dir / "RF-02.json").read_text())["realization_status"] == "runtime_realized"
+    assert result["overall_status"] == "fail"
+    assert result["passed_steps"] == []
+    assert result["status_updates"] == []
+    assert "RF-02" in result["forged_status_failures"]
+    assert "incoming realization_status is forged" in result["forged_status_failures"]["RF-02"]
+
+
+def test_status_forging_attack_with_runtime_realized_blocked(tmp_path: Path) -> None:
+    rf02 = _base_contract("RF-02")
+    rf02["realization_status"] = "runtime_realized"
+    contract_dir = _write_contracts(tmp_path, rf02=rf02)
+    result = realize_steps(step_ids=["RF-02"], contract_dir=contract_dir, result_path=tmp_path / "result.json", repo_root=Path("."))
+    assert result["overall_status"] == "fail"
+    assert result["passed_steps"] == []
+    assert result["status_updates"] == []
+    assert "RF-02" in result["forged_status_failures"]
+    assert "incoming realization_status is forged" in result["forged_status_failures"]["RF-02"]
 
 
 def test_ownership_boundary_attack_blocked(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Tests and red-team evidence showed three remaining critical failure modes: dependency bypass in mixed-step invocations, forbidden-pattern evasion, and incoming forged `realization_status` values.  
- The runner must enforce fail-closed semantics so no partial passes, status updates, or `runtime_realized`/`verified` transitions leak when those failures occur.  
- This change scope is surgical: fix only those three seams and add regression tests to lock them in.  

### Description
- Modified `scripts/roadmap_realization_runner.py` to reject forged incoming statuses by treating incoming `runtime_realized` or `verified` as validation failures and recording them in `forged_status_failures`.  
- Hardened forbidden-pattern scanning by adding normalized signature matching, scoped scan expansion to include runtime entrypoint modules and locally-imported helper modules, regex + normalized-text match modes, and deduplicated hit reporting.  
- Enforced invocation-level dependency fail-closed behavior so mixed-step dependency failures mark dependency validation on attempted steps and clear `passed_steps` and `status_updates` for the whole invocation.  
- Added focused regression tests in `tests/test_roadmap_realization_runner.py` covering RF-03-before-RF-02, RF-03 with RF-02 in `planned_only`/`artifact_materialized`, five forbidden-pattern evasion variants, and both `verified` and `runtime_realized` forged-status inputs.  

### Testing
- Ran `pytest tests/test_roadmap_realization_runner.py -q` and all tests passed (16 passed).  
- The new regression tests assert the fail-closed contract: `overall_status == "fail"`, `passed_steps == []`, and `status_updates == []` for the covered attack variants.  
- No other test files or CI workflows were modified as part of this surgical fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daf56590608329ac9d852d6e59cf45)