### PR TITLE
RAX-HARDEN-SEMANTIC-24-02: close semantic assurance gaps in RAX

### DIFF
--- a/docs/review-actions/PLAN-RAX-HARDEN-SEMANTIC-24-02-2026-04-12.md
+++ b/docs/review-actions/PLAN-RAX-HARDEN-SEMANTIC-24-02-2026-04-12.md
@@ -1,0 +1,35 @@
+# Plan — RAX-HARDEN-SEMANTIC-24-02 — 2026-04-12
+
+## Prompt type
+BUILD
+
+## Roadmap item
+RAX-HARDEN-SEMANTIC-24-02
+
+## Objective
+Harden only the RAX semantic assurance layer so semantically weak, contradictory, lossy, drifted, or forged signals fail closed with explicit failure classification and evidence.
+
+## Declared files
+
+| File | Change type | Reason |
+| --- | --- | --- |
+| docs/review-actions/PLAN-RAX-HARDEN-SEMANTIC-24-02-2026-04-12.md | CREATE | Required written plan for >2 file surgical hardening change. |
+| spectrum_systems/modules/runtime/rax_model.py | MODIFY | Add semantic intent checks and normalization ambiguity signaling. |
+| spectrum_systems/modules/runtime/rax_assurance.py | MODIFY | Harden input/output assurance, trace/version checks, acceptance strength, regression, evidence, and derived stop conditions. |
+| tests/test_rax_interface_assurance.py | MODIFY | Add focused tests for each hardened semantic seam. |
+
+## Contracts touched
+None.
+
+## Tests that must pass after execution
+1. `pytest tests/test_rax_interface_assurance.py`
+2. `pytest tests/test_roadmap_expansion_contracts.py`
+
+## Scope exclusions
+- Do not redesign RAX expansion architecture.
+- Do not broaden to roadmap realization or unrelated modules.
+- Do not modify schema contracts unless strictly required.
+- Do not change ownership definitions in architecture docs.
+
+## Dependencies
+- Existing canonical ownership and role semantics in `docs/architecture/system_registry.md`.

--- a/spectrum_systems/modules/runtime/rax_assurance.py
+++ b/spectrum_systems/modules/runtime/rax_assurance.py
@@ -3,16 +3,49 @@
 from __future__ import annotations
 
 import importlib
+import json
 from pathlib import Path
 from typing import Any
 
 from spectrum_systems.contracts import validate_artifact
+
 INPUT_FAILURE_CLASSES = {
     "invalid_input",
     "dependency_blocked",
     "stale_reference",
     "trace_tampering",
     "ownership_violation",
+}
+
+_TRACE_REQUIRED_FIELDS = {
+    "target_modules",
+    "target_tests",
+    "acceptance_checks",
+    "forbidden_patterns",
+    "downstream_compatibility",
+}
+
+_OWNER_INTENT_FORBIDDEN_PHRASES = {
+    "PRG": ("runtime execution", "execute runtime", "directly execute", "runtime entrypoint"),
+    "PQX": ("promotion decision", "closure decision", "readiness decision"),
+    "RIL": ("enforce policy", "execute runtime", "repair plan generation"),
+    "SEL": ("repair plan generation", "program prioritization"),
+}
+
+_WEAK_ACCEPTANCE_LANGUAGE = (
+    "todo",
+    "tbd",
+    "placeholder",
+    "maybe",
+    "etc",
+    "nice to have",
+    "if possible",
+)
+
+_VERIFICATION_TERMS = ("must", "verify", "validated", "enforce", "deterministic", "fail", "prove")
+
+_DEFAULT_SOURCE_VERSION_AUTHORITY = {
+    "docs/roadmaps/system_roadmap.md#RAX-INTERFACE-24-01": "1.3.112",
 }
 
 
@@ -31,6 +64,71 @@ def _resolve_entrypoint(spec: str) -> bool:
     return hasattr(module, attribute)
 
 
+def _is_semantically_sufficient_intent(intent: str) -> bool:
+    normalized = " ".join(intent.lower().split())
+    tokens = [piece for piece in normalized.replace("-", " ").split(" ") if piece]
+    if len(tokens) < 4:
+        return False
+
+    generic_placeholders = {"todo", "tbd", "placeholder", "generic", "misc", "none", "n/a", "lorem", "ipsum", "asdf"}
+    if normalized in generic_placeholders:
+        return False
+    if len(set(tokens)) == 1:
+        return False
+    if all(token in generic_placeholders for token in tokens):
+        return False
+
+    meaningful_tokens = [token for token in tokens if len(token) >= 4 and token not in generic_placeholders]
+    return len(meaningful_tokens) >= 3
+
+
+def _validate_owner_intent_semantics(owner: str, intent: str) -> str | None:
+    lowered = intent.lower()
+    for phrase in _OWNER_INTENT_FORBIDDEN_PHRASES.get(owner, ()):
+        if phrase in lowered:
+            return f"owner-intent contradiction: owner={owner} cannot claim '{phrase}'"
+    return None
+
+
+def _validate_expansion_trace(trace: dict[str, Any], *, expected_policy_hash: str, step_id: str) -> list[str]:
+    issues: list[str] = []
+    try:
+        validate_artifact(trace, "roadmap_expansion_trace")
+    except Exception as exc:
+        issues.append(f"trace schema validation failed: {exc}")
+        return issues
+
+    if trace.get("expansion_policy_hash") != expected_policy_hash:
+        issues.append("trace expansion policy hash mismatch")
+
+    if trace.get("step_id") != step_id:
+        issues.append("trace step_id mismatch")
+
+    field_trace = trace.get("field_trace", [])
+    traced_fields = {entry.get("field_name") for entry in field_trace if isinstance(entry, dict)}
+    missing_fields = sorted(_TRACE_REQUIRED_FIELDS - traced_fields)
+    if missing_fields:
+        issues.append(f"trace missing required derived field coverage: {', '.join(missing_fields)}")
+    return issues
+
+
+def _load_authoritative_source_versions(repo_root: Path) -> dict[str, str]:
+    authority = dict(_DEFAULT_SOURCE_VERSION_AUTHORITY)
+    example_path = repo_root / "contracts" / "examples" / "rax_upstream_input_envelope.example.json"
+    if not example_path.exists():
+        return authority
+    try:
+        example = json.loads(example_path.read_text(encoding="utf-8"))
+    except Exception:
+        return authority
+
+    source_ref = example.get("source_authority_ref")
+    source_version = example.get("source_version")
+    if isinstance(source_ref, str) and isinstance(source_version, str):
+        authority[source_ref] = source_version
+    return authority
+
+
 def assure_rax_input(
     payload: dict[str, Any],
     *,
@@ -39,11 +137,12 @@ def assure_rax_input(
     trace: dict[str, Any] | None = None,
     freshness_records: dict[str, dict[str, Any]] | None = None,
     provenance_records: dict[str, dict[str, Any]] | None = None,
+    repo_root: Path | None = None,
+    source_version_authority: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Validate upstream payload and classify fail-closed input conditions."""
     details: list[str] = []
     failure_classification = "none"
-    stop_condition_triggered = False
 
     try:
         validate_artifact(payload, "rax_upstream_input_envelope")
@@ -51,6 +150,18 @@ def assure_rax_input(
     except Exception as exc:  # fail-closed by classifying invalid input
         failure_classification = "invalid_input"
         details.append(f"schema validation failed: {exc}")
+
+    if failure_classification == "none":
+        intent = payload["intent"]
+        if not _is_semantically_sufficient_intent(intent):
+            failure_classification = "invalid_input"
+            details.append("semantic_intent_insufficient: intent content is placeholder-like or too weak")
+
+    if failure_classification == "none":
+        owner_contradiction = _validate_owner_intent_semantics(payload["owner"], payload["intent"])
+        if owner_contradiction:
+            failure_classification = "ownership_violation"
+            details.append(f"owner_intent_contradiction: {owner_contradiction}")
 
     if failure_classification == "none":
         if payload["owner"] not in policy.get("owner_defaults", {}):
@@ -61,6 +172,12 @@ def assure_rax_input(
         if payload["step_id"] in payload["depends_on"]:
             failure_classification = "dependency_blocked"
             details.append("step cannot depend on itself")
+
+    if failure_classification == "none":
+        normalized_dependencies = [dep.strip() for dep in payload["depends_on"]]
+        if len(normalized_dependencies) != len(set(normalized_dependencies)):
+            failure_classification = "invalid_input"
+            details.append("normalization_ambiguity: depends_on would collapse during canonical normalization")
 
     if failure_classification == "none" and freshness_records is not None:
         fresh = freshness_records.get(payload["input_freshness_ref"], {}).get("is_fresh", False)
@@ -74,27 +191,88 @@ def assure_rax_input(
             failure_classification = "stale_reference"
             details.append("provenance reference missing or untrusted")
 
-    if failure_classification == "none" and trace is not None:
-        if trace.get("expansion_policy_hash") != expected_policy_hash:
-            failure_classification = "trace_tampering"
-            details.append("trace expansion policy hash mismatch")
+    if failure_classification == "none":
+        authoritative_versions = source_version_authority
+        if authoritative_versions is None:
+            root = repo_root or Path(__file__).resolve().parents[3]
+            authoritative_versions = _load_authoritative_source_versions(root)
+        expected_source_version = authoritative_versions.get(payload["source_authority_ref"])
+        if expected_source_version is None:
+            failure_classification = "stale_reference"
+            details.append("source_version authority record missing for source_authority_ref")
+        elif payload["source_version"] != expected_source_version:
+            failure_classification = "stale_reference"
+            details.append(
+                f"source_version_drift: payload={payload['source_version']} authority={expected_source_version}"
+            )
 
-    if failure_classification != "none":
-        stop_condition_triggered = True
+    if failure_classification == "none":
+        if trace is None:
+            failure_classification = "trace_tampering"
+            details.append("missing_required_expansion_trace")
+        else:
+            trace_issues = _validate_expansion_trace(trace, expected_policy_hash=expected_policy_hash, step_id=payload["step_id"])
+            if trace_issues:
+                failure_classification = "trace_tampering"
+                details.extend(trace_issues)
 
     passed = failure_classification == "none"
     return {
         "passed": passed,
         "details": details,
         "failure_classification": failure_classification,
-        "stop_condition_triggered": stop_condition_triggered,
+        "stop_condition_triggered": not passed,
     }
 
 
-def assure_rax_output(step_contract: dict[str, Any], *, repo_root: Path) -> dict[str, Any]:
+def _check_acceptance_strength(step_contract: dict[str, Any], policy: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+    checks = step_contract.get("acceptance_checks", [])
+    owner = step_contract.get("owner")
+
+    allowed_ids: set[str] = set(policy.get("acceptance_check_templates", {}).keys())
+    owner_defaults = policy.get("owner_defaults", {}).get(owner, {})
+    allowed_ids.update(owner_defaults.get("default_acceptance_check_templates", []))
+
+    for index, check in enumerate(checks):
+        check_id = str(check.get("check_id", ""))
+        description = str(check.get("description", ""))
+        description_lower = description.lower()
+
+        check_id_is_recognized = check_id in allowed_ids or check_id.endswith("_valid") or check_id.endswith("_passes") or check_id.endswith("_resolvable")
+        if not check_id_is_recognized:
+            failures.append(f"weak_acceptance_check[{index}]: unapproved check_id '{check_id}'")
+
+        if len(description.strip()) < 20:
+            failures.append(f"weak_acceptance_check[{index}]: description too short")
+
+        if any(term in description_lower for term in _WEAK_ACCEPTANCE_LANGUAGE):
+            failures.append(f"weak_acceptance_check[{index}]: weak language detected")
+
+        if not any(term in description_lower for term in _VERIFICATION_TERMS):
+            failures.append(f"weak_acceptance_check[{index}]: missing verification semantics")
+
+        if check.get("required") is not True:
+            failures.append(f"weak_acceptance_check[{index}]: check must be required=true")
+
+    return failures
+
+
+def _is_target_in_allowed_prefixes(targets: list[str], allowed_prefixes: list[str]) -> bool:
+    return any(any(target.startswith(prefix) for prefix in allowed_prefixes) for target in targets)
+
+
+def assure_rax_output(
+    step_contract: dict[str, Any],
+    *,
+    repo_root: Path,
+    policy: dict[str, Any] | None = None,
+    prior_accepted_baseline: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     """Validate downstream contract readiness and next-system compatibility."""
     details: list[str] = []
     failure_classification = "none"
+    policy = policy or {}
 
     try:
         validate_artifact(step_contract, "roadmap_step_contract")
@@ -135,6 +313,35 @@ def assure_rax_output(step_contract: dict[str, Any], *, repo_root: Path) -> dict
                 details.append("target paths must not contain parent-directory traversal")
                 break
 
+    if failure_classification == "none":
+        owner_policy = policy.get("owner_defaults", {}).get(step_contract.get("owner"), {})
+        allowed_module_prefixes = owner_policy.get("allowed_module_prefixes", [])
+        allowed_test_prefixes = owner_policy.get("allowed_test_prefixes", [])
+
+        if allowed_module_prefixes and not _is_target_in_allowed_prefixes(step_contract.get("target_modules", []), allowed_module_prefixes):
+            failure_classification = "downstream_incompatible"
+            details.append("owner_target_contradiction: target_modules inconsistent with owner policy")
+
+        if failure_classification == "none" and allowed_test_prefixes and not _is_target_in_allowed_prefixes(
+            step_contract.get("target_tests", []), allowed_test_prefixes
+        ):
+            failure_classification = "downstream_incompatible"
+            details.append("owner_target_contradiction: target_tests inconsistent with owner policy")
+
+    if failure_classification == "none":
+        acceptance_failures = _check_acceptance_strength(step_contract, policy)
+        if acceptance_failures:
+            failure_classification = "invalid_output"
+            details.extend(acceptance_failures)
+
+    if failure_classification == "none" and prior_accepted_baseline is not None:
+        baseline_checks = {check["check_id"] for check in prior_accepted_baseline.get("acceptance_checks", []) if "check_id" in check}
+        current_checks = {check["check_id"] for check in step_contract.get("acceptance_checks", []) if "check_id" in check}
+        missing_baseline = sorted(baseline_checks - current_checks)
+        if missing_baseline:
+            failure_classification = "downstream_incompatible"
+            details.append(f"regression_detected: missing baseline acceptance checks {missing_baseline}")
+
     passed = failure_classification == "none"
     return {
         "passed": passed,
@@ -173,6 +380,15 @@ def build_rax_assurance_audit_record(
         repairability = "repairable"
         status_transition = "illegal"
 
+    counter_evidence: list[str] = []
+    if failure_classification != "none":
+        counter_evidence.extend(str(item) for item in input_assurance.get("details", []) if item)
+        counter_evidence.extend(str(item) for item in output_assurance.get("details", []) if item)
+        if not counter_evidence:
+            counter_evidence.append(f"failure_detected:{failure_classification}")
+
+    stop_condition_triggered = failure_classification != "none"
+
     audit = {
         "artifact_type": "rax_assurance_audit_record",
         "roadmap_id": roadmap_id,
@@ -185,7 +401,7 @@ def build_rax_assurance_audit_record(
             "passed": bool(output_assurance.get("passed", False)),
             "details": output_assurance.get("details", []),
         },
-        "counter_evidence": [],
+        "counter_evidence": counter_evidence,
         "freshness_result": {
             "passed": bool(input_assurance.get("passed", False)),
             "details": ["freshness evaluated as part of input assurance"],
@@ -196,7 +412,7 @@ def build_rax_assurance_audit_record(
         },
         "failure_classification": failure_classification,
         "repairability_classification": repairability,
-        "stop_condition_triggered": bool(input_assurance.get("stop_condition_triggered") or output_assurance.get("stop_condition_triggered")),
+        "stop_condition_triggered": stop_condition_triggered,
         "acceptance_decision": decision,
         "status_transition_result": status_transition,
     }

--- a/spectrum_systems/modules/runtime/rax_model.py
+++ b/spectrum_systems/modules/runtime/rax_model.py
@@ -34,6 +34,36 @@ def _require_non_empty_string(value: Any, field_name: str) -> str:
     return value.strip()
 
 
+def _is_semantically_sufficient_intent(intent: str) -> bool:
+    normalized = " ".join(intent.lower().split())
+    tokens = [piece for piece in normalized.replace("-", " ").split(" ") if piece]
+    if len(tokens) < 4:
+        return False
+
+    generic_placeholders = {
+        "todo",
+        "tbd",
+        "placeholder",
+        "generic",
+        "misc",
+        "n/a",
+        "none",
+        "lorem",
+        "ipsum",
+        "asdf",
+    }
+    if normalized in generic_placeholders:
+        return False
+    if all(token in generic_placeholders for token in tokens):
+        return False
+
+    if len(set(tokens)) == 1:
+        return False
+
+    meaningful_tokens = [token for token in tokens if len(token) >= 4 and token not in generic_placeholders]
+    return len(meaningful_tokens) >= 3
+
+
 def load_compact_roadmap_step(payload: dict[str, Any]) -> CanonicalRoadmapStep:
     """Load and schema-validate a compact roadmap envelope before normalization."""
     validate_artifact(payload, "rax_upstream_input_envelope")
@@ -62,14 +92,21 @@ def normalize_compact_roadmap_step(payload: dict[str, Any]) -> CanonicalRoadmapS
     if not isinstance(depends_on_raw, list):
         raise RAXModelError("depends_on must be a list")
 
-    normalized_dependencies = tuple(sorted({_require_non_empty_string(dep, "depends_on[]") for dep in depends_on_raw}))
+    raw_dependencies = [_require_non_empty_string(dep, "depends_on[]") for dep in depends_on_raw]
+    normalized_dependencies = tuple(sorted(set(raw_dependencies)))
+    if len(raw_dependencies) != len(normalized_dependencies):
+        raise RAXModelError("depends_on normalization ambiguity: lossy dependency collapse detected")
+
+    intent = _require_non_empty_string(payload["intent"], "intent")
+    if not _is_semantically_sufficient_intent(intent):
+        raise RAXModelError("intent semantic insufficiency: content is too weak or placeholder-like")
 
     return CanonicalRoadmapStep(
         roadmap_id=_require_non_empty_string(payload["roadmap_id"], "roadmap_id"),
         roadmap_group=_require_non_empty_string(payload["roadmap_group"], "roadmap_group"),
         step_id=_require_non_empty_string(payload["step_id"], "step_id"),
         owner=_require_non_empty_string(payload["owner"], "owner"),
-        intent=_require_non_empty_string(payload["intent"], "intent"),
+        intent=intent,
         depends_on=normalized_dependencies,
         source_authority_ref=_require_non_empty_string(payload["source_authority_ref"], "source_authority_ref"),
         source_version=_require_non_empty_string(payload["source_version"], "source_version"),

--- a/tests/test_rax_interface_assurance.py
+++ b/tests/test_rax_interface_assurance.py
@@ -26,9 +26,63 @@ def _policy_hash() -> str:
     return hashlib.sha256(POLICY_PATH.read_bytes()).hexdigest()
 
 
+def _valid_input_assurance_kwargs(upstream: dict) -> dict:
+    return {
+        "policy": _load_policy(),
+        "expected_policy_hash": _policy_hash(),
+        "trace": {
+            "artifact_type": "roadmap_expansion_trace",
+            "step_id": upstream["step_id"],
+            "expansion_version": "1.1.0",
+            "expansion_policy_hash": _policy_hash(),
+            "field_trace": [
+                {
+                    "field_name": "target_modules",
+                    "source_type": "expansion_policy",
+                    "source_ref": "config/roadmap_expansion_policy.json#owner_defaults.PQX.allowed_module_prefixes",
+                    "rule_id": "MODULE_PREFIX_BY_OWNER",
+                    "notes": "Module targets are constrained to policy-declared prefixes.",
+                },
+                {
+                    "field_name": "target_tests",
+                    "source_type": "expansion_policy",
+                    "source_ref": "config/roadmap_expansion_policy.json#owner_defaults.PQX.allowed_test_prefixes",
+                    "rule_id": "TEST_PREFIX_BY_OWNER",
+                    "notes": "Test targets are constrained to policy-declared prefixes.",
+                },
+                {
+                    "field_name": "acceptance_checks",
+                    "source_type": "expansion_policy",
+                    "source_ref": "config/roadmap_expansion_policy.json#acceptance_check_templates",
+                    "rule_id": "ACCEPTANCE_BY_TEMPLATE",
+                    "notes": "Acceptance checks are derived from approved templates.",
+                },
+                {
+                    "field_name": "forbidden_patterns",
+                    "source_type": "governance_rule",
+                    "source_ref": "AGENTS.md#Canonical runtime rules",
+                    "rule_id": "FAIL_CLOSED_DEFAULT_PATTERNS",
+                    "notes": "Forbidden patterns include fail-closed defaults.",
+                },
+                {
+                    "field_name": "downstream_compatibility",
+                    "source_type": "expansion_policy",
+                    "source_ref": "config/roadmap_expansion_policy.json#default_downstream_compatibility",
+                    "rule_id": "DOWNSTREAM_COMPATIBILITY_DEFAULTS",
+                    "notes": "Compatibility defaults are policy-bound.",
+                },
+            ],
+        },
+        "freshness_records": {upstream["input_freshness_ref"]: {"is_fresh": True}},
+        "provenance_records": {upstream["input_provenance_ref"]: {"trusted": True}},
+        "source_version_authority": {upstream["source_authority_ref"]: upstream["source_version"]},
+        "repo_root": REPO_ROOT,
+    }
+
+
 def test_canonical_model_normalization_is_deterministic() -> None:
     upstream = load_example("rax_upstream_input_envelope")
-    upstream["depends_on"] = ["RAX-INTERFACE-24-02", "RAX-INTERFACE-24-00", "RAX-INTERFACE-24-00"]
+    upstream["depends_on"] = ["RAX-INTERFACE-24-02", "RAX-INTERFACE-24-00"]
     model = normalize_compact_roadmap_step(upstream)
     assert model.depends_on == ("RAX-INTERFACE-24-00", "RAX-INTERFACE-24-02")
 
@@ -37,6 +91,13 @@ def test_canonical_model_fails_closed_for_missing_required_field() -> None:
     upstream = load_example("rax_upstream_input_envelope")
     upstream.pop("intent", None)
     with pytest.raises(RAXModelError):
+        normalize_compact_roadmap_step(upstream)
+
+
+def test_canonical_model_rejects_lossy_dependency_normalization() -> None:
+    upstream = load_example("rax_upstream_input_envelope")
+    upstream["depends_on"] = ["RAX-INTERFACE-24-00", " RAX-INTERFACE-24-00 "]
+    with pytest.raises(RAXModelError, match="normalization ambiguity"):
         normalize_compact_roadmap_step(upstream)
 
 
@@ -78,37 +139,106 @@ def test_every_derived_field_has_trace_entry() -> None:
 
 def test_input_assurance_classifies_stale_reference() -> None:
     upstream = load_example("rax_upstream_input_envelope")
-    result = assure_rax_input(
-        upstream,
-        policy=_load_policy(),
-        expected_policy_hash=_policy_hash(),
-        freshness_records={},
-        provenance_records={upstream["input_provenance_ref"]: {"trusted": True}},
-    )
+    kwargs = _valid_input_assurance_kwargs(upstream)
+    kwargs["freshness_records"] = {}
+    result = assure_rax_input(upstream, **kwargs)
     assert result["passed"] is False
     assert result["failure_classification"] == "stale_reference"
 
 
-def test_input_assurance_classifies_trace_tampering() -> None:
+def test_input_assurance_rejects_weak_intent_and_blocks_pass() -> None:
     upstream = load_example("rax_upstream_input_envelope")
-    result = assure_rax_input(
-        upstream,
-        policy=_load_policy(),
-        expected_policy_hash=_policy_hash(),
-        trace={"expansion_policy_hash": "0" * 64},
-        freshness_records={upstream["input_freshness_ref"]: {"is_fresh": True}},
-        provenance_records={upstream["input_provenance_ref"]: {"trusted": True}},
-    )
+    upstream["intent"] = "todo todo todo todo"
+    result = assure_rax_input(upstream, **_valid_input_assurance_kwargs(upstream))
+    assert result["passed"] is False
+    assert result["failure_classification"] == "invalid_input"
+    assert any("semantic_intent_insufficient" in detail for detail in result["details"])
+
+
+def test_input_assurance_rejects_owner_intent_contradiction() -> None:
+    upstream = load_example("rax_upstream_input_envelope")
+    upstream["owner"] = "PRG"
+    upstream["intent"] = "Directly execute runtime entrypoint changes in production for this batch."
+    result = assure_rax_input(upstream, **_valid_input_assurance_kwargs(upstream))
+    assert result["passed"] is False
+    assert result["failure_classification"] == "ownership_violation"
+    assert any("owner_intent_contradiction" in detail for detail in result["details"])
+
+
+def test_input_assurance_requires_trace_presence() -> None:
+    upstream = load_example("rax_upstream_input_envelope")
+    kwargs = _valid_input_assurance_kwargs(upstream)
+    kwargs["trace"] = None
+    result = assure_rax_input(upstream, **kwargs)
     assert result["passed"] is False
     assert result["failure_classification"] == "trace_tampering"
+    assert "missing_required_expansion_trace" in result["details"]
+
+
+def test_input_assurance_rejects_invalid_trace_contents() -> None:
+    upstream = load_example("rax_upstream_input_envelope")
+    kwargs = _valid_input_assurance_kwargs(upstream)
+    kwargs["trace"]["field_trace"] = kwargs["trace"]["field_trace"][:-1]
+    result = assure_rax_input(upstream, **kwargs)
+    assert result["passed"] is False
+    assert result["failure_classification"] == "trace_tampering"
+
+
+def test_input_assurance_detects_source_version_drift() -> None:
+    upstream = load_example("rax_upstream_input_envelope")
+    kwargs = _valid_input_assurance_kwargs(upstream)
+    kwargs["source_version_authority"] = {upstream["source_authority_ref"]: "9.9.9"}
+    result = assure_rax_input(upstream, **kwargs)
+    assert result["passed"] is False
+    assert result["failure_classification"] == "stale_reference"
+    assert any("source_version_drift" in detail for detail in result["details"])
 
 
 def test_output_assurance_rejects_unresolvable_runtime_entrypoint() -> None:
     step_contract = load_example("roadmap_step_contract")
     step_contract["runtime_entrypoints"] = ["spectrum_systems.modules.runtime.rax_model:missing_func"]
-    result = assure_rax_output(step_contract, repo_root=REPO_ROOT)
+    result = assure_rax_output(step_contract, repo_root=REPO_ROOT, policy=_load_policy())
     assert result["passed"] is False
     assert result["failure_classification"] == "downstream_incompatible"
+
+
+def test_output_assurance_rejects_owner_target_contradiction() -> None:
+    step_contract = load_example("roadmap_step_contract")
+    step_contract["owner"] = "PRG"
+    step_contract["runtime_entrypoints"] = ["spectrum_systems.modules.runtime.rax_model:load_compact_roadmap_step"]
+    step_contract["target_modules"] = ["spectrum_systems/modules/runtime/rax_assurance.py"]
+    result = assure_rax_output(step_contract, repo_root=REPO_ROOT, policy=_load_policy())
+    assert result["passed"] is False
+    assert result["failure_classification"] == "downstream_incompatible"
+    assert any("owner_target_contradiction" in detail for detail in result["details"])
+
+
+def test_output_assurance_rejects_weak_acceptance_checks() -> None:
+    step_contract = load_example("roadmap_step_contract")
+    step_contract["runtime_entrypoints"] = ["spectrum_systems.modules.runtime.rax_model:load_compact_roadmap_step"]
+    step_contract["acceptance_checks"] = [{"check_id": "schema_validation_passes", "description": "TODO maybe", "required": True}]
+    result = assure_rax_output(step_contract, repo_root=REPO_ROOT, policy=_load_policy())
+    assert result["passed"] is False
+    assert result["failure_classification"] == "invalid_output"
+    assert any("weak_acceptance_check" in detail for detail in result["details"])
+
+
+def test_output_assurance_detects_regression_against_baseline() -> None:
+    step_contract = load_example("roadmap_step_contract")
+    baseline = load_example("roadmap_step_contract")
+    step_contract["runtime_entrypoints"] = ["spectrum_systems.modules.runtime.rax_model:load_compact_roadmap_step"]
+    baseline["runtime_entrypoints"] = ["spectrum_systems.modules.runtime.rax_model:load_compact_roadmap_step"]
+    baseline["acceptance_checks"].append(
+        {
+            "check_id": "runtime_entrypoints_resolvable",
+            "description": "Runtime entrypoints must be validated as resolvable for deterministic execution safety.",
+            "required": True,
+        }
+    )
+    result = assure_rax_output(step_contract, repo_root=REPO_ROOT, policy=_load_policy(), prior_accepted_baseline=baseline)
+    assert result["passed"] is False
+    assert result["failure_classification"] == "downstream_incompatible"
+    assert any("regression_detected" in detail for detail in result["details"])
 
 
 def test_assurance_audit_record_is_complete_and_outcome_enum_bound() -> None:
@@ -124,9 +254,32 @@ def test_assurance_audit_record_is_complete_and_outcome_enum_bound() -> None:
     validate_artifact(audit, "rax_assurance_audit_record")
 
 
+def test_assurance_audit_requires_counter_evidence_when_failure_exists() -> None:
+    input_assurance = {
+        "passed": False,
+        "details": ["owner_intent_contradiction: owner=PRG cannot claim runtime execution"],
+        "failure_classification": "ownership_violation",
+        "stop_condition_triggered": False,
+    }
+    output_assurance = {
+        "passed": True,
+        "details": [],
+        "failure_classification": "none",
+        "stop_condition_triggered": False,
+    }
+    audit = build_rax_assurance_audit_record(
+        roadmap_id="SYSTEM-ROADMAP-2026",
+        step_id="RAX-INTERFACE-24-01",
+        input_assurance=input_assurance,
+        output_assurance=output_assurance,
+    )
+    assert audit["counter_evidence"]
+    assert audit["stop_condition_triggered"] is True
+
+
 def test_weak_output_fails_closed() -> None:
     step_contract = load_example("roadmap_step_contract")
     step_contract["acceptance_checks"] = []
-    result = assure_rax_output(step_contract, repo_root=REPO_ROOT)
+    result = assure_rax_output(step_contract, repo_root=REPO_ROOT, policy=_load_policy())
     assert result["passed"] is False
     assert result["stop_condition_triggered"] is True


### PR DESCRIPTION
### Motivation

- Harden RAX semantic assurance so syntactically-valid but semantically-weak inputs fail closed and produce actionable evidence. 
- Close precise weak-seam classes: intent quality, owner/intent/target contradictions, lossy normalization, mandatory expansion trace, authoritative `source_version` drift, acceptance-check strength, regression detection, and derived stop conditions. 
- Keep scope surgical to the RAX semantic assurance surface and focused tests; do not redesign RAX expansion or alter roadmap authority semantics.

### Description

- Added structured semantic intent validation and lossy-normalization detection in `spectrum_systems/modules/runtime/rax_model.py` so weak/placeholder intent and collapsed dependencies raise `RAXModelError` instead of silently passing. 
- Hardened input assurance in `spectrum_systems/modules/runtime/rax_assurance.py` to enforce semantic-intent sufficiency, detect owner-intent contradictions, reject normalization ambiguity, require and fully validate expansion trace, and check `source_version` against an authoritative mapping. 
- Hardened output assurance in `spectrum_systems/modules/runtime/rax_assurance.py` to enforce owner→target consistency, add a stronger acceptance-check strength policy (recognized IDs/patterns, minimum description quality, weak-language detection, verification-term requirement), and add a regression gate against a prior accepted baseline. 
- Made audit outcomes deterministic and evidenceful by deriving `stop_condition_triggered` from failure state and populating `counter_evidence` whenever failures exist; added a PLAN artifact and updated `tests/test_rax_interface_assurance.py` with focused tests covering all hardened seams.

### Testing

- Ran `pytest tests/test_rax_interface_assurance.py tests/test_roadmap_expansion_contracts.py` and received all tests passing (`35 passed`).
- Added/updated focused unit tests in `tests/test_rax_interface_assurance.py` that exercise weak-intent rejection, owner-intent contradiction, lossy dependency normalization, missing/invalid trace, source_version drift, weak acceptance checks, owner-target contradictions, regression detection, and audit `counter_evidence`/stop-condition behavior.
- Validation includes schema checks via existing contract examples and policy fixtures; updated test harness confirms no regressions in roadmap expansion contracts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daf908780083298d3b24f3dc2e742c)