### PR TITLE
RAX-REDTEAM-ARCH-01: add architecture-level adversarial harness & report

### DIFF
--- a/docs/reviews/rax_redteam_arch_report.json
+++ b/docs/reviews/rax_redteam_arch_report.json
@@ -1,0 +1,338 @@
+{
+  "artifact_type": "rax_redteam_arch_report",
+  "batch": "RAX-REDTEAM-ARCH-01",
+  "execution_mode": "FORENSIC + INVARIANT-DRIVEN + FAIL-FAST",
+  "attacks_attempted": [
+    "01:no_readiness_artifact_present",
+    "02:readiness_missing_required_eval_signals",
+    "03:readiness_contradictory_eval_signals",
+    "04:externally_forged_readiness_inputs",
+    "05:eval_passes_but_readiness_missing",
+    "06:eval_partial_readiness_claims_complete",
+    "07:eval_failure_readiness_says_ready",
+    "08:eval_indeterminate_cannot_be_ready",
+    "09:missing_trace_evidence",
+    "10:missing_lineage_evidence",
+    "11:missing_dependency_integrity",
+    "12:missing_version_authority",
+    "13:unknown_state_missing_signal",
+    "14:schema_valid_meaningless_intent",
+    "15:owner_intent_contradiction",
+    "16:semantically_wrong_target_modules",
+    "17:over_expanded_output",
+    "18:weak_acceptance_checks",
+    "19:rax_implies_promotion_or_advancement",
+    "20:rax_emits_decision_beyond_readiness",
+    "21:rax_bypasses_control_layer",
+    "22:same_input_different_readiness",
+    "23:same_tests_different_eval_signals",
+    "24:same_eval_different_readiness",
+    "25:schema_valid_but_semantic_contract_invalid",
+    "26:artifact_not_fully_trace_linked",
+    "27:artifact_lineage_incomplete",
+    "28:novel_adversarial_pattern",
+    "29:combined_weak_signals_simulate_valid",
+    "30:edge_case_schema_valid_borderline_semantics"
+  ],
+  "attacks_blocked": [
+    "no_readiness_artifact_present",
+    "readiness_missing_required_eval_signals",
+    "readiness_contradictory_eval_signals",
+    "externally_forged_readiness_inputs",
+    "eval_passes_but_readiness_missing",
+    "eval_partial_readiness_claims_complete",
+    "eval_failure_readiness_says_ready",
+    "eval_indeterminate_cannot_be_ready",
+    "missing_trace_evidence",
+    "missing_lineage_evidence",
+    "missing_dependency_integrity",
+    "missing_version_authority",
+    "unknown_state_missing_signal",
+    "schema_valid_meaningless_intent",
+    "owner_intent_contradiction",
+    "semantically_wrong_target_modules",
+    "over_expanded_output",
+    "weak_acceptance_checks",
+    "rax_implies_promotion_or_advancement",
+    "rax_emits_decision_beyond_readiness",
+    "rax_bypasses_control_layer",
+    "same_input_different_readiness",
+    "same_tests_different_eval_signals",
+    "same_eval_different_readiness",
+    "schema_valid_but_semantic_contract_invalid",
+    "artifact_not_fully_trace_linked",
+    "artifact_lineage_incomplete",
+    "combined_weak_signals_simulate_valid",
+    "edge_case_schema_valid_borderline_semantics"
+  ],
+  "attacks_that_succeeded": [
+    "novel_adversarial_pattern"
+  ],
+  "invariant_violations": [],
+  "readiness_gate_failures": [],
+  "eval_chain_failures": [],
+  "semantic_failures": [
+    "novel_adversarial_pattern"
+  ],
+  "trace_lineage_failures": [],
+  "replay_failures": [],
+  "control_boundary_violations": [],
+  "overall_verdict": "FAIL",
+  "strongest_blocked_attacks": [
+    "no_readiness_artifact_present",
+    "externally_forged_readiness_inputs",
+    "missing_trace_evidence",
+    "same_tests_different_eval_signals",
+    "rax_bypasses_control_layer"
+  ],
+  "remaining_weak_seams": [
+    "novel_adversarial_pattern"
+  ],
+  "next_required_fixes": [
+    "Harden readiness enforcement for every succeeded attack before control consumption.",
+    "Close all semantic acceptance paths that allowed architecturally invalid outputs.",
+    "Add stricter replay freeze behavior where inconsistency was observed."
+  ],
+  "attack_results": [
+    {
+      "attack_id": 1,
+      "name": "no_readiness_artifact_present",
+      "blocked": true,
+      "succeeded": false,
+      "category": "readiness_gate_failures",
+      "evidence": "{'allowed': False, 'decision': 'block', 'ready_for_control': False, 'blocking_reasons': ['missing_control_readiness_artifact']}"
+    },
+    {
+      "attack_id": 2,
+      "name": "readiness_missing_required_eval_signals",
+      "blocked": true,
+      "succeeded": false,
+      "category": "readiness_gate_failures",
+      "evidence": "{'artifact_type': 'rax_control_readiness_record', 'schema_version': '1.0.0', 'batch': 'RAX-REDTEAM-ARCH-01', 'target_ref': 'roadmap_step_contract:RAX-INTERFACE-24-01', 'ready_for_control': False, 'decision': 'block', 'blocking_reasons': ['missing_eval:rax_trace_integrity', 'missing_required_eval_types'], 'required_eval_types': ['rax_input_semantic_sufficiency', 'rax_owner_intent_alignment', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_acceptance_check_strength', 'rax_trace_integrity', 'rax_version_authority_alignment', 'rax_regression_against_baseline', 'rax_control_readiness'], 'present_eval_types': ['rax_acceptance_check_strength', 'rax_control_readiness', 'rax_input_semantic_sufficiency', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_owner_intent_alignment', 'rax_regression_against_baseline', 'rax_version_authority_alignment'], 'missing_required_eval_types': ['rax_trace_integrity'], 'trace_complete': False, 'baseline_regression_detected': False, 'version_authority_aligned': True}"
+    },
+    {
+      "attack_id": 3,
+      "name": "readiness_contradictory_eval_signals",
+      "blocked": true,
+      "succeeded": false,
+      "category": "readiness_gate_failures",
+      "evidence": "{'artifact_type': 'rax_control_readiness_record', 'schema_version': '1.0.0', 'batch': 'RAX-REDTEAM-ARCH-01', 'target_ref': 'roadmap_step_contract:RAX-INTERFACE-24-01', 'ready_for_control': False, 'decision': 'block', 'blocking_reasons': ['contradictory_eval_signals', 'eval_summary_contradicts_eval_results', 'missing_eval:rax_trace_integrity', 'missing_required_eval_types', 'required_eval_failed:rax_input_semantic_sufficiency', 'semantic_intent_insufficient'], 'required_eval_types': ['rax_input_semantic_sufficiency', 'rax_owner_intent_alignment', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_acceptance_check_strength', 'rax_trace_integrity', 'rax_version_authority_alignment', 'rax_regression_against_baseline', 'rax_control_readiness'], 'present_eval_types': ['rax_acceptance_check_strength', 'rax_control_readiness', 'rax_input_semantic_sufficiency', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_owner_intent_alignment', 'rax_regression_against_baseline', 'rax_version_authority_alignment'], 'missing_required_eval_types': ['rax_trace_integrity'], 'trace_complete': False, 'baseline_regression_detected': False, 'version_authority_aligned': True}"
+    },
+    {
+      "attack_id": 4,
+      "name": "externally_forged_readiness_inputs",
+      "blocked": true,
+      "succeeded": false,
+      "category": "readiness_gate_failures",
+      "evidence": "{'artifact_type': 'rax_control_readiness_record', 'schema_version': '1.0.0', 'batch': 'RAX-REDTEAM-ARCH-01', 'target_ref': 'roadmap_step_contract:RAX-INTERFACE-24-01', 'ready_for_control': False, 'decision': 'block', 'blocking_reasons': ['missing_eval:rax_trace_integrity', 'missing_required_eval_types', 'required_eval_coverage_missing_set_mismatch', 'required_eval_coverage_overall_result_mismatch', 'required_eval_coverage_summary_mismatch'], 'required_eval_types': ['rax_input_semantic_sufficiency', 'rax_owner_intent_alignment', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_acceptance_check_strength', 'rax_trace_integrity', 'rax_version_authority_alignment', 'rax_regression_against_baseline', 'rax_control_readiness'], 'present_eval_types': ['rax_acceptance_check_strength', 'rax_control_readiness', 'rax_input_semantic_sufficiency', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_owner_intent_alignment', 'rax_regression_against_baseline', 'rax_version_authority_alignment'], 'missing_required_eval_types': ['rax_trace_integrity'], 'trace_complete': False, 'baseline_regression_detected': False, 'version_authority_aligned': True}"
+    },
+    {
+      "attack_id": 5,
+      "name": "eval_passes_but_readiness_missing",
+      "blocked": true,
+      "succeeded": false,
+      "category": "eval_chain_failures",
+      "evidence": "{'allowed': False, 'decision': 'block', 'ready_for_control': False, 'blocking_reasons': ['missing_control_readiness_artifact']}"
+    },
+    {
+      "attack_id": 6,
+      "name": "eval_partial_readiness_claims_complete",
+      "blocked": true,
+      "succeeded": false,
+      "category": "eval_chain_failures",
+      "evidence": "{'blocked': True, 'reasons': ['eval_summary_missing_required_eval_reference', 'eval_summary_not_pass', 'missing_required_eval_artifact'], 'missing_from_results': ['rax_trace_integrity'], 'missing_from_summary': ['rax_owner_intent_alignment', 'rax_trace_integrity']}"
+    },
+    {
+      "attack_id": 7,
+      "name": "eval_failure_readiness_says_ready",
+      "blocked": true,
+      "succeeded": false,
+      "category": "eval_chain_failures",
+      "evidence": "{'artifact_type': 'rax_control_readiness_record', 'schema_version': '1.0.0', 'batch': 'RAX-REDTEAM-ARCH-01', 'target_ref': 'roadmap_step_contract:RAX-INTERFACE-24-01', 'ready_for_control': False, 'decision': 'block', 'blocking_reasons': ['contradictory_eval_signals', 'eval_summary_contradicts_eval_results', 'required_eval_coverage_overall_result_mismatch', 'required_eval_failed:rax_control_readiness', 'required_eval_failed:rax_input_semantic_sufficiency', 'semantic_intent_insufficient', 'tests_pass_eval_fail'], 'required_eval_types': ['rax_input_semantic_sufficiency', 'rax_owner_intent_alignment', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_acceptance_check_strength', 'rax_trace_integrity', 'rax_version_authority_alignment', 'rax_regression_against_baseline', 'rax_control_readiness'], 'present_eval_types': ['rax_acceptance_check_strength', 'rax_control_readiness', 'rax_input_semantic_sufficiency', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_owner_intent_alignment', 'rax_regression_against_baseline', 'rax_trace_integrity', 'rax_version_authority_alignment'], 'missing_required_eval_types': [], 'trace_complete': True, 'baseline_regression_detected': False, 'version_authority_aligned': True}"
+    },
+    {
+      "attack_id": 8,
+      "name": "eval_indeterminate_cannot_be_ready",
+      "blocked": true,
+      "succeeded": false,
+      "category": "eval_chain_failures",
+      "evidence": "{'artifact_type': 'rax_control_readiness_record', 'schema_version': '1.0.0', 'batch': 'RAX-REDTEAM-ARCH-01', 'target_ref': 'roadmap_step_contract:RAX-INTERFACE-24-01', 'ready_for_control': False, 'decision': 'block', 'blocking_reasons': ['contradictory_eval_signals', 'missing_eval:rax_trace_integrity', 'missing_required_eval_types', 'required_eval_failed:rax_input_semantic_sufficiency'], 'required_eval_types': ['rax_input_semantic_sufficiency', 'rax_owner_intent_alignment', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_acceptance_check_strength', 'rax_trace_integrity', 'rax_version_authority_alignment', 'rax_regression_against_baseline', 'rax_control_readiness'], 'present_eval_types': ['rax_acceptance_check_strength', 'rax_control_readiness', 'rax_input_semantic_sufficiency', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_owner_intent_alignment', 'rax_regression_against_baseline', 'rax_version_authority_alignment'], 'missing_required_eval_types': ['rax_trace_integrity'], 'trace_complete': False, 'baseline_regression_detected': False, 'version_authority_aligned': True}"
+    },
+    {
+      "attack_id": 9,
+      "name": "missing_trace_evidence",
+      "blocked": true,
+      "succeeded": false,
+      "category": "trace_lineage_failures",
+      "evidence": "{'artifact_type': 'rax_control_readiness_record', 'schema_version': '1.0.0', 'batch': 'RAX-REDTEAM-ARCH-01', 'target_ref': 'roadmap_step_contract:RAX-INTERFACE-24-01', 'ready_for_control': False, 'decision': 'block', 'blocking_reasons': ['missing_eval:rax_trace_integrity', 'missing_required_eval_types', 'missing_trace_integrity_evidence'], 'required_eval_types': ['rax_input_semantic_sufficiency', 'rax_owner_intent_alignment', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_acceptance_check_strength', 'rax_trace_integrity', 'rax_version_authority_alignment', 'rax_regression_against_baseline', 'rax_control_readiness'], 'present_eval_types': ['rax_acceptance_check_strength', 'rax_control_readiness', 'rax_input_semantic_sufficiency', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_owner_intent_alignment', 'rax_regression_against_baseline', 'rax_version_authority_alignment'], 'missing_required_eval_types': ['rax_trace_integrity'], 'trace_complete': False, 'baseline_regression_detected': False, 'version_authority_aligned': True}"
+    },
+    {
+      "attack_id": 10,
+      "name": "missing_lineage_evidence",
+      "blocked": true,
+      "succeeded": false,
+      "category": "trace_lineage_failures",
+      "evidence": "{'artifact_type': 'rax_control_readiness_record', 'schema_version': '1.0.0', 'batch': 'RAX-REDTEAM-ARCH-01', 'target_ref': 'roadmap_step_contract:RAX-INTERFACE-24-01', 'ready_for_control': False, 'decision': 'block', 'blocking_reasons': ['missing_eval:rax_trace_integrity', 'missing_lineage_provenance_evidence', 'missing_required_eval_types'], 'required_eval_types': ['rax_input_semantic_sufficiency', 'rax_owner_intent_alignment', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_acceptance_check_strength', 'rax_trace_integrity', 'rax_version_authority_alignment', 'rax_regression_against_baseline', 'rax_control_readiness'], 'present_eval_types': ['rax_acceptance_check_strength', 'rax_control_readiness', 'rax_input_semantic_sufficiency', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_owner_intent_alignment', 'rax_regression_against_baseline', 'rax_version_authority_alignment'], 'missing_required_eval_types': ['rax_trace_integrity'], 'trace_complete': False, 'baseline_regression_detected': False, 'version_authority_aligned': True}"
+    },
+    {
+      "attack_id": 11,
+      "name": "missing_dependency_integrity",
+      "blocked": true,
+      "succeeded": false,
+      "category": "invariant_violations",
+      "evidence": "{'artifact_type': 'rax_control_readiness_record', 'schema_version': '1.0.0', 'batch': 'RAX-REDTEAM-ARCH-01', 'target_ref': 'roadmap_step_contract:RAX-INTERFACE-24-01', 'ready_for_control': False, 'decision': 'block', 'blocking_reasons': ['dependency_graph_corrupt', 'missing_eval:rax_trace_integrity', 'missing_required_eval_types'], 'required_eval_types': ['rax_input_semantic_sufficiency', 'rax_owner_intent_alignment', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_acceptance_check_strength', 'rax_trace_integrity', 'rax_version_authority_alignment', 'rax_regression_against_baseline', 'rax_control_readiness'], 'present_eval_types': ['rax_acceptance_check_strength', 'rax_control_readiness', 'rax_input_semantic_sufficiency', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_owner_intent_alignment', 'rax_regression_against_baseline', 'rax_version_authority_alignment'], 'missing_required_eval_types': ['rax_trace_integrity'], 'trace_complete': False, 'baseline_regression_detected': False, 'version_authority_aligned': True}"
+    },
+    {
+      "attack_id": 12,
+      "name": "missing_version_authority",
+      "blocked": true,
+      "succeeded": false,
+      "category": "invariant_violations",
+      "evidence": "{'artifact_type': 'rax_control_readiness_record', 'schema_version': '1.0.0', 'batch': 'RAX-REDTEAM-ARCH-01', 'target_ref': 'roadmap_step_contract:RAX-INTERFACE-24-01', 'ready_for_control': False, 'decision': 'block', 'blocking_reasons': ['missing_eval:rax_trace_integrity', 'missing_required_eval_types', 'missing_version_authority_evidence'], 'required_eval_types': ['rax_input_semantic_sufficiency', 'rax_owner_intent_alignment', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_acceptance_check_strength', 'rax_trace_integrity', 'rax_version_authority_alignment', 'rax_regression_against_baseline', 'rax_control_readiness'], 'present_eval_types': ['rax_acceptance_check_strength', 'rax_control_readiness', 'rax_input_semantic_sufficiency', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_owner_intent_alignment', 'rax_regression_against_baseline', 'rax_version_authority_alignment'], 'missing_required_eval_types': ['rax_trace_integrity'], 'trace_complete': False, 'baseline_regression_detected': False, 'version_authority_aligned': False}"
+    },
+    {
+      "attack_id": 13,
+      "name": "unknown_state_missing_signal",
+      "blocked": true,
+      "succeeded": false,
+      "category": "invariant_violations",
+      "evidence": "{'artifact_type': 'rax_control_readiness_record', 'schema_version': '1.0.0', 'batch': 'RAX-REDTEAM-ARCH-01', 'target_ref': 'roadmap_step_contract:RAX-INTERFACE-24-01', 'ready_for_control': False, 'decision': 'block', 'blocking_reasons': ['missing_eval:rax_trace_integrity', 'missing_required_eval_types', 'required_eval_coverage_overall_result_mismatch'], 'required_eval_types': ['rax_input_semantic_sufficiency', 'rax_owner_intent_alignment', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_acceptance_check_strength', 'rax_trace_integrity', 'rax_version_authority_alignment', 'rax_regression_against_baseline', 'rax_control_readiness'], 'present_eval_types': ['rax_acceptance_check_strength', 'rax_control_readiness', 'rax_input_semantic_sufficiency', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_owner_intent_alignment', 'rax_regression_against_baseline', 'rax_version_authority_alignment'], 'missing_required_eval_types': ['rax_trace_integrity'], 'trace_complete': False, 'baseline_regression_detected': False, 'version_authority_aligned': True}"
+    },
+    {
+      "attack_id": 14,
+      "name": "schema_valid_meaningless_intent",
+      "blocked": true,
+      "succeeded": false,
+      "category": "semantic_failures",
+      "evidence": "{'passed': False, 'details': ['upstream schema validation passed', 'semantic_intent_insufficient: intent content is placeholder-like or too weak'], 'failure_classification': 'invalid_input', 'stop_condition_triggered': True}"
+    },
+    {
+      "attack_id": 15,
+      "name": "owner_intent_contradiction",
+      "blocked": true,
+      "succeeded": false,
+      "category": "semantic_failures",
+      "evidence": "{'passed': False, 'details': ['upstream schema validation passed', \"owner_intent_contradiction: owner-intent contradiction: owner=PRG cannot claim 'execute runtime'\"], 'failure_classification': 'ownership_violation', 'stop_condition_triggered': True}"
+    },
+    {
+      "attack_id": 16,
+      "name": "semantically_wrong_target_modules",
+      "blocked": true,
+      "succeeded": false,
+      "category": "semantic_failures",
+      "evidence": "{'passed': False, 'details': ['downstream schema validation passed', 'owner_target_contradiction: all target_modules must satisfy owner policy prefixes'], 'failure_classification': 'downstream_incompatible', 'stop_condition_triggered': True}"
+    },
+    {
+      "attack_id": 17,
+      "name": "over_expanded_output",
+      "blocked": true,
+      "succeeded": false,
+      "category": "semantic_failures",
+      "evidence": "{'passed': False, 'details': ['downstream schema validation passed', 'owner_target_contradiction: all target_modules must satisfy owner policy prefixes'], 'failure_classification': 'downstream_incompatible', 'stop_condition_triggered': True}"
+    },
+    {
+      "attack_id": 18,
+      "name": "weak_acceptance_checks",
+      "blocked": true,
+      "succeeded": false,
+      "category": "semantic_failures",
+      "evidence": "{'passed': False, 'details': ['downstream schema validation passed', 'weak_acceptance_check[0]: description too short', 'weak_acceptance_check[0]: weak language detected', 'weak_acceptance_check[0]: missing verification semantics'], 'failure_classification': 'invalid_output', 'stop_condition_triggered': True}"
+    },
+    {
+      "attack_id": 19,
+      "name": "rax_implies_promotion_or_advancement",
+      "blocked": true,
+      "succeeded": false,
+      "category": "control_boundary_violations",
+      "evidence": "{'artifact_type': 'rax_assurance_audit_record', 'roadmap_id': 'SYSTEM-ROADMAP-2026', 'step_id': 'RAX-INTERFACE-24-01', 'input_validation_result': {'passed': True, 'details': ['semantic_intent_sufficient']}, 'output_validation_result': {'passed': True, 'details': ['output_semantically_aligned']}, 'counter_evidence': [], 'freshness_result': {'passed': True, 'details': ['freshness evaluated as part of input assurance']}, 'provenance_result': {'passed': True, 'details': ['provenance evaluated as part of input assurance']}, 'failure_classification': 'none', 'repairability_classification': 'none', 'stop_condition_triggered': False, 'acceptance_decision': 'accept_candidate', 'status_transition_result': 'legal'}"
+    },
+    {
+      "attack_id": 20,
+      "name": "rax_emits_decision_beyond_readiness",
+      "blocked": true,
+      "succeeded": false,
+      "category": "control_boundary_violations",
+      "evidence": "{'artifact_type': 'rax_control_readiness_record', 'schema_version': '1.0.0', 'batch': 'RAX-REDTEAM-ARCH-01', 'target_ref': 'roadmap_step_contract:RAX-INTERFACE-24-01', 'ready_for_control': False, 'decision': 'block', 'blocking_reasons': ['missing_eval:rax_trace_integrity', 'missing_required_eval_types'], 'required_eval_types': ['rax_input_semantic_sufficiency', 'rax_owner_intent_alignment', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_acceptance_check_strength', 'rax_trace_integrity', 'rax_version_authority_alignment', 'rax_regression_against_baseline', 'rax_control_readiness'], 'present_eval_types': ['rax_acceptance_check_strength', 'rax_control_readiness', 'rax_input_semantic_sufficiency', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_owner_intent_alignment', 'rax_regression_against_baseline', 'rax_version_authority_alignment'], 'missing_required_eval_types': ['rax_trace_integrity'], 'trace_complete': False, 'baseline_regression_detected': False, 'version_authority_aligned': True}"
+    },
+    {
+      "attack_id": 21,
+      "name": "rax_bypasses_control_layer",
+      "blocked": true,
+      "succeeded": false,
+      "category": "control_boundary_violations",
+      "evidence": "{'allowed': False, 'decision': 'block', 'ready_for_control': False, 'blocking_reasons': ['missing_control_readiness_artifact']}"
+    },
+    {
+      "attack_id": 22,
+      "name": "same_input_different_readiness",
+      "blocked": true,
+      "succeeded": false,
+      "category": "replay_failures",
+      "evidence": "{'artifact_type': 'rax_control_readiness_record', 'schema_version': '1.0.0', 'batch': 'RAX-REDTEAM-ARCH-01', 'target_ref': 'roadmap_step_contract:RAX-INTERFACE-24-01', 'ready_for_control': False, 'decision': 'hold', 'blocking_reasons': ['contradictory_eval_signals', 'cross_run_eval_signal_inconsistency', 'missing_eval:rax_trace_integrity', 'missing_required_eval_types', 'required_eval_failed:rax_input_semantic_sufficiency', 'semantic_intent_insufficient'], 'required_eval_types': ['rax_input_semantic_sufficiency', 'rax_owner_intent_alignment', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_acceptance_check_strength', 'rax_trace_integrity', 'rax_version_authority_alignment', 'rax_regression_against_baseline', 'rax_control_readiness'], 'present_eval_types': ['rax_acceptance_check_strength', 'rax_control_readiness', 'rax_input_semantic_sufficiency', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_owner_intent_alignment', 'rax_regression_against_baseline', 'rax_version_authority_alignment'], 'missing_required_eval_types': ['rax_trace_integrity'], 'trace_complete': False, 'baseline_regression_detected': False, 'version_authority_aligned': True}"
+    },
+    {
+      "attack_id": 23,
+      "name": "same_tests_different_eval_signals",
+      "blocked": true,
+      "succeeded": false,
+      "category": "replay_failures",
+      "evidence": "{'artifact_type': 'rax_control_readiness_record', 'schema_version': '1.0.0', 'batch': 'RAX-REDTEAM-ARCH-01', 'target_ref': 'roadmap_step_contract:RAX-INTERFACE-24-01', 'ready_for_control': False, 'decision': 'hold', 'blocking_reasons': ['contradictory_eval_signals', 'cross_run_eval_signal_inconsistency', 'missing_eval:rax_trace_integrity', 'missing_required_eval_types', 'required_eval_failed:rax_input_semantic_sufficiency', 'semantic_intent_insufficient'], 'required_eval_types': ['rax_input_semantic_sufficiency', 'rax_owner_intent_alignment', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_acceptance_check_strength', 'rax_trace_integrity', 'rax_version_authority_alignment', 'rax_regression_against_baseline', 'rax_control_readiness'], 'present_eval_types': ['rax_acceptance_check_strength', 'rax_control_readiness', 'rax_input_semantic_sufficiency', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_owner_intent_alignment', 'rax_regression_against_baseline', 'rax_version_authority_alignment'], 'missing_required_eval_types': ['rax_trace_integrity'], 'trace_complete': False, 'baseline_regression_detected': False, 'version_authority_aligned': True}"
+    },
+    {
+      "attack_id": 24,
+      "name": "same_eval_different_readiness",
+      "blocked": true,
+      "succeeded": false,
+      "category": "replay_failures",
+      "evidence": "{'first': {'artifact_type': 'rax_control_readiness_record', 'schema_version': '1.0.0', 'batch': 'RAX-REDTEAM-ARCH-01', 'target_ref': 'roadmap_step_contract:RAX-INTERFACE-24-01', 'ready_for_control': False, 'decision': 'block', 'blocking_reasons': ['missing_eval:rax_trace_integrity', 'missing_required_eval_types'], 'required_eval_types': ['rax_input_semantic_sufficiency', 'rax_owner_intent_alignment', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_acceptance_check_strength', 'rax_trace_integrity', 'rax_version_authority_alignment', 'rax_regression_against_baseline', 'rax_control_readiness'], 'present_eval_types': ['rax_acceptance_check_strength', 'rax_control_readiness', 'rax_input_semantic_sufficiency', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_owner_intent_alignment', 'rax_regression_against_baseline', 'rax_version_authority_alignment'], 'missing_required_eval_types': ['rax_trace_integrity'], 'trace_complete': False, 'baseline_regression_detected': False, 'version_authority_aligned': True}, 'second': {'artifact_type': 'rax_control_readiness_record', 'schema_version': '1.0.0', 'batch': 'RAX-REDTEAM-ARCH-01', 'target_ref': 'roadmap_step_contract:RAX-INTERFACE-24-01', 'ready_for_control': False, 'decision': 'block', 'blocking_reasons': ['missing_eval:rax_trace_integrity', 'missing_required_eval_types'], 'required_eval_types': ['rax_input_semantic_sufficiency', 'rax_owner_intent_alignment', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_acceptance_check_strength', 'rax_trace_integrity', 'rax_version_authority_alignment', 'rax_regression_against_baseline', 'rax_control_readiness'], 'present_eval_types': ['rax_acceptance_check_strength', 'rax_control_readiness', 'rax_input_semantic_sufficiency', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_owner_intent_alignment', 'rax_regression_against_baseline', 'rax_version_authority_alignment'], 'missing_required_eval_types': ['rax_trace_integrity'], 'trace_complete': False, 'baseline_regression_detected': False, 'version_authority_aligned': True}}"
+    },
+    {
+      "attack_id": 25,
+      "name": "schema_valid_but_semantic_contract_invalid",
+      "blocked": true,
+      "succeeded": false,
+      "category": "invariant_violations",
+      "evidence": "{'passed': False, 'details': ['downstream schema validation passed', 'weak_acceptance_check[0]: non-operational acceptance language detected'], 'failure_classification': 'invalid_output', 'stop_condition_triggered': True}"
+    },
+    {
+      "attack_id": 26,
+      "name": "artifact_not_fully_trace_linked",
+      "blocked": true,
+      "succeeded": false,
+      "category": "trace_lineage_failures",
+      "evidence": "{'artifact_type': 'rax_control_readiness_record', 'schema_version': '1.0.0', 'batch': 'RAX-REDTEAM-ARCH-01', 'target_ref': 'roadmap_step_contract:RAX-INTERFACE-24-01', 'ready_for_control': False, 'decision': 'block', 'blocking_reasons': ['artifact_not_trace_linked', 'missing_eval:rax_trace_integrity', 'missing_required_eval_types', 'trace_incomplete'], 'required_eval_types': ['rax_input_semantic_sufficiency', 'rax_owner_intent_alignment', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_acceptance_check_strength', 'rax_trace_integrity', 'rax_version_authority_alignment', 'rax_regression_against_baseline', 'rax_control_readiness'], 'present_eval_types': ['rax_acceptance_check_strength', 'rax_control_readiness', 'rax_input_semantic_sufficiency', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_owner_intent_alignment', 'rax_regression_against_baseline', 'rax_version_authority_alignment'], 'missing_required_eval_types': ['rax_trace_integrity'], 'trace_complete': False, 'baseline_regression_detected': False, 'version_authority_aligned': True}"
+    },
+    {
+      "attack_id": 27,
+      "name": "artifact_lineage_incomplete",
+      "blocked": true,
+      "succeeded": false,
+      "category": "trace_lineage_failures",
+      "evidence": "{'artifact_type': 'rax_control_readiness_record', 'schema_version': '1.0.0', 'batch': 'RAX-REDTEAM-ARCH-01', 'target_ref': 'roadmap_step_contract:RAX-INTERFACE-24-01', 'ready_for_control': False, 'decision': 'block', 'blocking_reasons': ['artifact_lineage_invalid', 'missing_eval:rax_trace_integrity', 'missing_required_eval_types'], 'required_eval_types': ['rax_input_semantic_sufficiency', 'rax_owner_intent_alignment', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_acceptance_check_strength', 'rax_trace_integrity', 'rax_version_authority_alignment', 'rax_regression_against_baseline', 'rax_control_readiness'], 'present_eval_types': ['rax_acceptance_check_strength', 'rax_control_readiness', 'rax_input_semantic_sufficiency', 'rax_normalization_integrity', 'rax_output_semantic_alignment', 'rax_owner_intent_alignment', 'rax_regression_against_baseline', 'rax_version_authority_alignment'], 'missing_required_eval_types': ['rax_trace_integrity'], 'trace_complete': False, 'baseline_regression_detected': False, 'version_authority_aligned': True}"
+    },
+    {
+      "attack_id": 28,
+      "name": "novel_adversarial_pattern",
+      "blocked": false,
+      "succeeded": true,
+      "category": "semantic_failures",
+      "evidence": "{'passed': True, 'details': ['upstream schema validation passed'], 'failure_classification': 'none', 'stop_condition_triggered': False}"
+    },
+    {
+      "attack_id": 29,
+      "name": "combined_weak_signals_simulate_valid",
+      "blocked": true,
+      "succeeded": false,
+      "category": "invariant_violations",
+      "evidence": "{'passed': False, 'details': ['upstream schema validation passed', 'forged_authority_override_detected', 'source_version_drift: supplied_authority=9.9.9 immutable_authority=1.3.112'], 'failure_classification': 'stale_reference', 'stop_condition_triggered': True}"
+    },
+    {
+      "attack_id": 30,
+      "name": "edge_case_schema_valid_borderline_semantics",
+      "blocked": true,
+      "succeeded": false,
+      "category": "semantic_failures",
+      "evidence": "{'passed': False, 'details': ['downstream schema validation passed', 'weak_acceptance_check[0]: weak language detected', 'weak_acceptance_check[0]: missing verification semantics', 'weak_acceptance_check[0]: non-operational acceptance language detected'], 'failure_classification': 'invalid_output', 'stop_condition_triggered': True}"
+    }
+  ]
+}

--- a/scripts/run_rax_redteam_arch_01.py
+++ b/scripts/run_rax_redteam_arch_01.py
@@ -1,0 +1,516 @@
+#!/usr/bin/env python3
+"""RAX-REDTEAM-ARCH-01 architecture-level adversarial review.
+
+Primary prompt type: REVIEW.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from spectrum_systems.contracts import load_example
+from spectrum_systems.modules.runtime.rax_assurance import (
+    assure_rax_input,
+    assure_rax_output,
+    build_rax_assurance_audit_record,
+    evaluate_rax_control_readiness,
+)
+from spectrum_systems.modules.runtime.rax_eval_runner import (
+    enforce_rax_control_advancement,
+    enforce_required_rax_eval_coverage,
+    run_rax_eval_runner,
+)
+from spectrum_systems.modules.runtime.rax_expander import expand_to_step_contract
+from spectrum_systems.modules.runtime.rax_model import load_compact_roadmap_step
+
+POLICY_PATH = REPO_ROOT / "config" / "roadmap_expansion_policy.json"
+
+
+def _load_policy() -> dict[str, Any]:
+    return json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+
+
+def _policy_hash() -> str:
+    return hashlib.sha256(POLICY_PATH.read_bytes()).hexdigest()
+
+
+def _valid_input_assurance_kwargs(upstream: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "policy": _load_policy(),
+        "expected_policy_hash": _policy_hash(),
+        "trace": {
+            "artifact_type": "roadmap_expansion_trace",
+            "step_id": upstream["step_id"],
+            "expansion_version": "1.1.0",
+            "expansion_policy_hash": _policy_hash(),
+            "field_trace": [
+                {
+                    "field_name": "target_modules",
+                    "source_type": "expansion_policy",
+                    "source_ref": "config/roadmap_expansion_policy.json#owner_defaults.PQX.allowed_module_prefixes",
+                    "rule_id": "MODULE_PREFIX_BY_OWNER",
+                    "notes": "Module targets are constrained to policy-declared prefixes.",
+                },
+                {
+                    "field_name": "target_tests",
+                    "source_type": "expansion_policy",
+                    "source_ref": "config/roadmap_expansion_policy.json#owner_defaults.PQX.allowed_test_prefixes",
+                    "rule_id": "TEST_PREFIX_BY_OWNER",
+                    "notes": "Test targets are constrained to policy-declared prefixes.",
+                },
+                {
+                    "field_name": "acceptance_checks",
+                    "source_type": "expansion_policy",
+                    "source_ref": "config/roadmap_expansion_policy.json#acceptance_check_templates",
+                    "rule_id": "ACCEPTANCE_BY_TEMPLATE",
+                    "notes": "Acceptance checks are derived from approved templates.",
+                },
+                {
+                    "field_name": "forbidden_patterns",
+                    "source_type": "governance_rule",
+                    "source_ref": "AGENTS.md#Canonical runtime rules",
+                    "rule_id": "FAIL_CLOSED_DEFAULT_PATTERNS",
+                    "notes": "Forbidden patterns include fail-closed defaults.",
+                },
+                {
+                    "field_name": "downstream_compatibility",
+                    "source_type": "expansion_policy",
+                    "source_ref": "config/roadmap_expansion_policy.json#default_downstream_compatibility",
+                    "rule_id": "DOWNSTREAM_COMPATIBILITY_DEFAULTS",
+                    "notes": "Compatibility defaults are policy-bound.",
+                },
+            ],
+        },
+        "freshness_records": {upstream["input_freshness_ref"]: {"is_fresh": True}},
+        "provenance_records": {upstream["input_provenance_ref"]: {"trusted": True}},
+        "source_version_authority": {upstream["source_authority_ref"]: upstream["source_version"]},
+        "repo_root": REPO_ROOT,
+    }
+
+
+def _input_ok() -> dict[str, Any]:
+    return {
+        "passed": True,
+        "details": ["semantic_intent_sufficient"],
+        "failure_classification": "none",
+        "stop_condition_triggered": False,
+    }
+
+
+def _output_ok() -> dict[str, Any]:
+    return {
+        "passed": True,
+        "details": ["output_semantically_aligned"],
+        "failure_classification": "none",
+        "stop_condition_triggered": False,
+    }
+
+
+def _governed_evidence_ok() -> dict[str, Any]:
+    return {
+        "assurance_audit": {"acceptance_decision": "accept_candidate", "failure_classification": "none"},
+        "trace_integrity_evidence": {"trace_linked": True, "trace_complete": True},
+        "lineage_provenance_evidence": {"lineage_valid": True},
+        "dependency_state": {"graph_integrity": True, "unresolved_dependencies": []},
+        "authority_records": {"docs/roadmaps/system_roadmap.md#RAX-INTERFACE-24-01": "1.3.112"},
+    }
+
+
+def run_review() -> dict[str, Any]:
+    attacks: list[dict[str, Any]] = []
+
+    def record(attack_id: int, name: str, blocked: bool, evidence: str, category: str) -> None:
+        attacks.append(
+            {
+                "attack_id": attack_id,
+                "name": name,
+                "blocked": blocked,
+                "succeeded": not blocked,
+                "category": category,
+                "evidence": evidence,
+            }
+        )
+
+    # Phase 1
+    gate = enforce_rax_control_advancement(readiness_record=None)
+    record(1, "no_readiness_artifact_present", gate["allowed"] is False, str(gate), "readiness_gate_failures")
+
+    out = run_rax_eval_runner(
+        run_id="rax-arch-02",
+        target_ref="roadmap_step_contract:RAX-INTERFACE-24-01",
+        trace_id="00000000-0000-4000-8000-00000000A002",
+        input_assurance=_input_ok(),
+        output_assurance=_output_ok(),
+        tests_passed=True,
+        baseline_regression_detected=False,
+        version_authority_aligned=True,
+        omit_eval_types=["rax_trace_integrity"],
+    )
+    readiness = evaluate_rax_control_readiness(
+        batch="RAX-REDTEAM-ARCH-01",
+        target_ref="roadmap_step_contract:RAX-INTERFACE-24-01",
+        eval_summary=out["eval_summary"],
+        eval_results=out["eval_results"],
+        required_eval_coverage=out["required_eval_coverage"],
+        **_governed_evidence_ok(),
+    )
+    record(2, "readiness_missing_required_eval_signals", readiness["ready_for_control"] is False, str(readiness), "readiness_gate_failures")
+
+    contradictory_results = copy.deepcopy(out["eval_results"])
+    contradictory_results[0]["result_status"] = "fail"
+    contradictory_results[0]["failure_modes"].append("semantic_intent_insufficient")
+    readiness = evaluate_rax_control_readiness(
+        batch="RAX-REDTEAM-ARCH-01",
+        target_ref="roadmap_step_contract:RAX-INTERFACE-24-01",
+        eval_summary={**out["eval_summary"], "system_status": "healthy"},
+        eval_results=contradictory_results,
+        required_eval_coverage=out["required_eval_coverage"],
+        **_governed_evidence_ok(),
+    )
+    record(3, "readiness_contradictory_eval_signals", readiness["ready_for_control"] is False, str(readiness), "readiness_gate_failures")
+
+    forged = {**out["required_eval_coverage"], "present_eval_types": out["required_eval_coverage"]["required_eval_types"], "missing_required_eval_types": [], "overall_result": "pass"}
+    readiness = evaluate_rax_control_readiness(
+        batch="RAX-REDTEAM-ARCH-01",
+        target_ref="roadmap_step_contract:RAX-INTERFACE-24-01",
+        eval_summary=out["eval_summary"],
+        eval_results=out["eval_results"],
+        required_eval_coverage=forged,
+        **_governed_evidence_ok(),
+    )
+    record(4, "externally_forged_readiness_inputs", readiness["ready_for_control"] is False, str(readiness), "readiness_gate_failures")
+
+    # Phase 2
+    gate = enforce_rax_control_advancement(readiness_record=None)
+    record(5, "eval_passes_but_readiness_missing", gate["allowed"] is False, str(gate), "eval_chain_failures")
+
+    tampered = copy.deepcopy(out["required_eval_coverage"])
+    tampered["present_eval_types"] = [x for x in tampered["present_eval_types"] if x != "rax_owner_intent_alignment"]
+    enf = enforce_required_rax_eval_coverage(eval_results=out["eval_results"], required_eval_coverage=tampered)
+    record(6, "eval_partial_readiness_claims_complete", enf["blocked"] is True, str(enf), "eval_chain_failures")
+
+    bad_out = run_rax_eval_runner(
+        run_id="rax-arch-07",
+        target_ref="roadmap_step_contract:RAX-INTERFACE-24-01",
+        trace_id="00000000-0000-4000-8000-00000000A007",
+        input_assurance={"passed": False, "details": ["semantic_intent_insufficient"], "failure_classification": "invalid_input"},
+        output_assurance=_output_ok(),
+        tests_passed=True,
+        baseline_regression_detected=False,
+        version_authority_aligned=True,
+    )
+    forged_cov = {**bad_out["required_eval_coverage"], "overall_result": "pass"}
+    readiness = evaluate_rax_control_readiness(
+        batch="RAX-REDTEAM-ARCH-01",
+        target_ref="roadmap_step_contract:RAX-INTERFACE-24-01",
+        eval_summary={**bad_out["eval_summary"], "system_status": "healthy"},
+        eval_results=bad_out["eval_results"],
+        required_eval_coverage=forged_cov,
+        **_governed_evidence_ok(),
+    )
+    record(7, "eval_failure_readiness_says_ready", readiness["ready_for_control"] is False, str(readiness), "eval_chain_failures")
+
+    indeterminate = copy.deepcopy(out["eval_results"])
+    indeterminate[0]["result_status"] = "unknown"
+    readiness = evaluate_rax_control_readiness(
+        batch="RAX-REDTEAM-ARCH-01",
+        target_ref="roadmap_step_contract:RAX-INTERFACE-24-01",
+        eval_summary=out["eval_summary"],
+        eval_results=indeterminate,
+        required_eval_coverage=out["required_eval_coverage"],
+        **_governed_evidence_ok(),
+    )
+    record(8, "eval_indeterminate_cannot_be_ready", readiness["ready_for_control"] is False, str(readiness), "eval_chain_failures")
+
+    # Phase 3
+    readiness = evaluate_rax_control_readiness(
+        batch="RAX-REDTEAM-ARCH-01",
+        target_ref="roadmap_step_contract:RAX-INTERFACE-24-01",
+        eval_summary=out["eval_summary"],
+        eval_results=out["eval_results"],
+        required_eval_coverage=out["required_eval_coverage"],
+        **{**_governed_evidence_ok(), "trace_integrity_evidence": None},
+    )
+    record(9, "missing_trace_evidence", readiness["ready_for_control"] is False, str(readiness), "trace_lineage_failures")
+
+    readiness = evaluate_rax_control_readiness(
+        batch="RAX-REDTEAM-ARCH-01",
+        target_ref="roadmap_step_contract:RAX-INTERFACE-24-01",
+        eval_summary=out["eval_summary"],
+        eval_results=out["eval_results"],
+        required_eval_coverage=out["required_eval_coverage"],
+        **{**_governed_evidence_ok(), "lineage_provenance_evidence": None},
+    )
+    record(10, "missing_lineage_evidence", readiness["ready_for_control"] is False, str(readiness), "trace_lineage_failures")
+
+    readiness = evaluate_rax_control_readiness(
+        batch="RAX-REDTEAM-ARCH-01",
+        target_ref="roadmap_step_contract:RAX-INTERFACE-24-01",
+        eval_summary=out["eval_summary"],
+        eval_results=out["eval_results"],
+        required_eval_coverage=out["required_eval_coverage"],
+        **{**_governed_evidence_ok(), "dependency_state": {"graph_integrity": False, "unresolved_dependencies": []}},
+    )
+    record(11, "missing_dependency_integrity", readiness["ready_for_control"] is False, str(readiness), "invariant_violations")
+
+    readiness = evaluate_rax_control_readiness(
+        batch="RAX-REDTEAM-ARCH-01",
+        target_ref="roadmap_step_contract:RAX-INTERFACE-24-01",
+        eval_summary=out["eval_summary"],
+        eval_results=out["eval_results"],
+        required_eval_coverage=out["required_eval_coverage"],
+        **{**_governed_evidence_ok(), "authority_records": {}},
+    )
+    record(12, "missing_version_authority", readiness["ready_for_control"] is False, str(readiness), "invariant_violations")
+
+    # unknown signal should fail closed
+    unknown_cov = {**out["required_eval_coverage"], "overall_result": "unknown"}
+    readiness = evaluate_rax_control_readiness(
+        batch="RAX-REDTEAM-ARCH-01",
+        target_ref="roadmap_step_contract:RAX-INTERFACE-24-01",
+        eval_summary=out["eval_summary"],
+        eval_results=out["eval_results"],
+        required_eval_coverage=unknown_cov,
+        **_governed_evidence_ok(),
+    )
+    record(13, "unknown_state_missing_signal", readiness["ready_for_control"] is False, str(readiness), "invariant_violations")
+
+    # Phase 4
+    upstream = load_example("rax_upstream_input_envelope")
+    upstream["intent"] = "todo todo todo todo"
+    res = assure_rax_input(upstream, **_valid_input_assurance_kwargs(upstream))
+    record(14, "schema_valid_meaningless_intent", res["passed"] is False, str(res), "semantic_failures")
+
+    upstream = load_example("rax_upstream_input_envelope")
+    upstream["owner"] = "PRG"
+    upstream["intent"] = "Directly execute runtime entrypoint changes in production for this batch."
+    res = assure_rax_input(upstream, **_valid_input_assurance_kwargs(upstream))
+    record(15, "owner_intent_contradiction", res["passed"] is False, str(res), "semantic_failures")
+
+    step = load_example("roadmap_step_contract")
+    step["owner"] = "PRG"
+    step["runtime_entrypoints"] = ["spectrum_systems.modules.runtime.rax_model:load_compact_roadmap_step"]
+    step["target_modules"] = ["spectrum_systems/modules/runtime/rax_assurance.py"]
+    res = assure_rax_output(step, repo_root=REPO_ROOT, policy=_load_policy())
+    record(16, "semantically_wrong_target_modules", res["passed"] is False, str(res), "semantic_failures")
+
+    step = load_example("roadmap_step_contract")
+    step["runtime_entrypoints"] = ["spectrum_systems.modules.runtime.rax_model:load_compact_roadmap_step"]
+    step["target_modules"] = ["spectrum_systems/modules/runtime/rax_assurance.py", "totally/irrelevant/module.py"]
+    res = assure_rax_output(step, repo_root=REPO_ROOT, policy=_load_policy())
+    record(17, "over_expanded_output", res["passed"] is False, str(res), "semantic_failures")
+
+    step = load_example("roadmap_step_contract")
+    step["runtime_entrypoints"] = ["spectrum_systems.modules.runtime.rax_model:load_compact_roadmap_step"]
+    step["acceptance_checks"] = [{"check_id": "schema_validation_passes", "description": "TODO maybe", "required": True}]
+    res = assure_rax_output(step, repo_root=REPO_ROOT, policy=_load_policy())
+    record(18, "weak_acceptance_checks", res["passed"] is False, str(res), "semantic_failures")
+
+    # Phase 5
+    audit = build_rax_assurance_audit_record(
+        roadmap_id="SYSTEM-ROADMAP-2026",
+        step_id="RAX-INTERFACE-24-01",
+        input_assurance=_input_ok(),
+        output_assurance=_output_ok(),
+    )
+    promotion_terms = {"promote", "promotion", "advance", "approved"}
+    serialized_audit = json.dumps(audit).lower()
+    has_promotion_implied = any(term in serialized_audit for term in promotion_terms)
+    record(19, "rax_implies_promotion_or_advancement", has_promotion_implied is False, str(audit), "control_boundary_violations")
+
+    readiness = evaluate_rax_control_readiness(
+        batch="RAX-REDTEAM-ARCH-01",
+        target_ref="roadmap_step_contract:RAX-INTERFACE-24-01",
+        eval_summary=out["eval_summary"],
+        eval_results=out["eval_results"],
+        required_eval_coverage=out["required_eval_coverage"],
+        **_governed_evidence_ok(),
+    )
+    extra_decision_fields = {"promotion_decision", "advancement_decision", "closure_decision"}
+    record(20, "rax_emits_decision_beyond_readiness", not any(field in readiness for field in extra_decision_fields), str(readiness), "control_boundary_violations")
+
+    gate = enforce_rax_control_advancement(readiness_record=None)
+    record(21, "rax_bypasses_control_layer", gate["allowed"] is False, str(gate), "control_boundary_violations")
+
+    # Phase 6
+    replay_store: dict[str, Any] = {}
+    first = evaluate_rax_control_readiness(
+        batch="RAX-REDTEAM-ARCH-01",
+        target_ref="roadmap_step_contract:RAX-INTERFACE-24-01",
+        eval_summary=out["eval_summary"],
+        eval_results=out["eval_results"],
+        required_eval_coverage=out["required_eval_coverage"],
+        replay_baseline_store=replay_store,
+        replay_key="same-input",
+        **_governed_evidence_ok(),
+    )
+    variant = copy.deepcopy(out["eval_results"])
+    variant[0]["failure_modes"].append("semantic_intent_insufficient")
+    variant[0]["result_status"] = "fail"
+    second = evaluate_rax_control_readiness(
+        batch="RAX-REDTEAM-ARCH-01",
+        target_ref="roadmap_step_contract:RAX-INTERFACE-24-01",
+        eval_summary=out["eval_summary"],
+        eval_results=variant,
+        required_eval_coverage=out["required_eval_coverage"],
+        replay_baseline_store=replay_store,
+        replay_key="same-input",
+        **_governed_evidence_ok(),
+    )
+    record(22, "same_input_different_readiness", second["decision"] in {"hold", "block"}, str(second), "replay_failures")
+
+    replay_store = {}
+    a = evaluate_rax_control_readiness(
+        batch="RAX-REDTEAM-ARCH-01",
+        target_ref="roadmap_step_contract:RAX-INTERFACE-24-01",
+        eval_summary=out["eval_summary"],
+        eval_results=out["eval_results"],
+        required_eval_coverage=out["required_eval_coverage"],
+        replay_baseline_store=replay_store,
+        replay_key="same-input-same-tests",
+        **_governed_evidence_ok(),
+    )
+    b = evaluate_rax_control_readiness(
+        batch="RAX-REDTEAM-ARCH-01",
+        target_ref="roadmap_step_contract:RAX-INTERFACE-24-01",
+        eval_summary=out["eval_summary"],
+        eval_results=variant,
+        required_eval_coverage=out["required_eval_coverage"],
+        replay_baseline_store=replay_store,
+        replay_key="same-input-same-tests",
+        **_governed_evidence_ok(),
+    )
+    record(23, "same_tests_different_eval_signals", a["decision"] in {"ready", "block", "hold"} and b["decision"] == "hold", str(b), "replay_failures")
+
+    r1 = evaluate_rax_control_readiness(
+        batch="RAX-REDTEAM-ARCH-01",
+        target_ref="roadmap_step_contract:RAX-INTERFACE-24-01",
+        eval_summary=out["eval_summary"],
+        eval_results=out["eval_results"],
+        required_eval_coverage=out["required_eval_coverage"],
+        **_governed_evidence_ok(),
+    )
+    r2 = evaluate_rax_control_readiness(
+        batch="RAX-REDTEAM-ARCH-01",
+        target_ref="roadmap_step_contract:RAX-INTERFACE-24-01",
+        eval_summary=out["eval_summary"],
+        eval_results=out["eval_results"],
+        required_eval_coverage=out["required_eval_coverage"],
+        **_governed_evidence_ok(),
+    )
+    record(24, "same_eval_different_readiness", r1["decision"] == r2["decision"] and r1["ready_for_control"] == r2["ready_for_control"], str({"first": r1, "second": r2}), "replay_failures")
+
+    # Phase 7
+    step = load_example("roadmap_step_contract")
+    step["runtime_entrypoints"] = ["spectrum_systems.modules.runtime.rax_model:load_compact_roadmap_step"]
+    step["acceptance_checks"] = [{
+        "check_id": "schema_validation_passes",
+        "description": "This check must mention deterministic language while remaining non-operational and non-falsifiable by runtime behavior.",
+        "required": True,
+    }]
+    res = assure_rax_output(step, repo_root=REPO_ROOT, policy=_load_policy())
+    record(25, "schema_valid_but_semantic_contract_invalid", res["passed"] is False, str(res), "invariant_violations")
+
+    tampered_results = copy.deepcopy(out["eval_results"])
+    for item in tampered_results:
+        item["provenance_refs"] = ["unlinked://fake"]
+    readiness = evaluate_rax_control_readiness(
+        batch="RAX-REDTEAM-ARCH-01",
+        target_ref="roadmap_step_contract:RAX-INTERFACE-24-01",
+        eval_summary=out["eval_summary"],
+        eval_results=tampered_results,
+        required_eval_coverage=out["required_eval_coverage"],
+        **_governed_evidence_ok(),
+    )
+    record(26, "artifact_not_fully_trace_linked", readiness["ready_for_control"] is False, str(readiness), "trace_lineage_failures")
+
+    readiness = evaluate_rax_control_readiness(
+        batch="RAX-REDTEAM-ARCH-01",
+        target_ref="roadmap_step_contract:RAX-INTERFACE-24-01",
+        eval_summary=out["eval_summary"],
+        eval_results=out["eval_results"],
+        required_eval_coverage=out["required_eval_coverage"],
+        **{**_governed_evidence_ok(), "lineage_provenance_evidence": {"lineage_valid": False}},
+    )
+    record(27, "artifact_lineage_incomplete", readiness["ready_for_control"] is False, str(readiness), "trace_lineage_failures")
+
+    # Phase 8
+    upstream = load_example("rax_upstream_input_envelope")
+    upstream["intent"] = "execute exactly what seems useful quickly with minimal proof"
+    upstream["owner"] = "PQX"
+    res = assure_rax_input(upstream, **_valid_input_assurance_kwargs(upstream))
+    record(28, "novel_adversarial_pattern", res["passed"] is False, str(res), "semantic_failures")
+
+    upstream = load_example("rax_upstream_input_envelope")
+    kwargs = _valid_input_assurance_kwargs(upstream)
+    kwargs["trace"]["step_id"] = "OTHER-STEP"
+    kwargs["source_version_authority"] = {upstream["source_authority_ref"]: "9.9.9"}
+    res = assure_rax_input(upstream, **kwargs)
+    record(29, "combined_weak_signals_simulate_valid", res["passed"] is False, str(res), "invariant_violations")
+
+    step = load_example("roadmap_step_contract")
+    step["runtime_entrypoints"] = ["spectrum_systems.modules.runtime.rax_model:load_compact_roadmap_step"]
+    step["acceptance_checks"] = [{"check_id": "schema_validation_passes", "description": "Validation might be okay if possible and documentation only.", "required": True}]
+    res = assure_rax_output(step, repo_root=REPO_ROOT, policy=_load_policy())
+    record(30, "edge_case_schema_valid_borderline_semantics", res["passed"] is False, str(res), "semantic_failures")
+
+    succeeded = [attack for attack in attacks if attack["succeeded"]]
+    blocked = [attack for attack in attacks if attack["blocked"]]
+
+    def by_category(category: str) -> list[str]:
+        return [attack["name"] for attack in succeeded if attack["category"] == category]
+
+    report = {
+        "artifact_type": "rax_redteam_arch_report",
+        "batch": "RAX-REDTEAM-ARCH-01",
+        "execution_mode": "FORENSIC + INVARIANT-DRIVEN + FAIL-FAST",
+        "attacks_attempted": [f"{attack['attack_id']:02d}:{attack['name']}" for attack in attacks],
+        "attacks_blocked": [attack["name"] for attack in blocked],
+        "attacks_that_succeeded": [attack["name"] for attack in succeeded],
+        "invariant_violations": by_category("invariant_violations"),
+        "readiness_gate_failures": by_category("readiness_gate_failures"),
+        "eval_chain_failures": by_category("eval_chain_failures"),
+        "semantic_failures": by_category("semantic_failures"),
+        "trace_lineage_failures": by_category("trace_lineage_failures"),
+        "replay_failures": by_category("replay_failures"),
+        "control_boundary_violations": by_category("control_boundary_violations"),
+        "overall_verdict": "PASS" if not succeeded else "FAIL",
+        "strongest_blocked_attacks": [
+            "no_readiness_artifact_present",
+            "externally_forged_readiness_inputs",
+            "missing_trace_evidence",
+            "same_tests_different_eval_signals",
+            "rax_bypasses_control_layer",
+        ],
+        "remaining_weak_seams": [attack["name"] for attack in succeeded],
+        "next_required_fixes": [] if not succeeded else [
+            "Harden readiness enforcement for every succeeded attack before control consumption.",
+            "Close all semantic acceptance paths that allowed architecturally invalid outputs.",
+            "Add stricter replay freeze behavior where inconsistency was observed.",
+        ],
+        "attack_results": attacks,
+    }
+    return report
+
+
+def main() -> int:
+    out_path = REPO_ROOT / "docs" / "reviews" / "rax_redteam_arch_report.json"
+    report = run_review()
+    out_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote {out_path}")
+    print(f"overall_verdict={report['overall_verdict']}")
+    print(f"attacks_succeeded={len(report['attacks_that_succeeded'])}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Provide a deterministic, architecture-level red-team harness to validate RAX against Spectrum Systems system invariants, control-readiness gating, eval→readiness→control chain, fail-closed semantics, trace/lineage integrity, semantic correctness, replay determinism, and control-boundary enforcement.
- Capture forensic evidence and a machine-readable verdict artifact to drive remediation and preserve fail-fast proof for governance decisions.

### Description
- Add `scripts/run_rax_redteam_arch_01.py`, a REVIEW-mode harness implementing 30 adversarial attacks across readiness, eval-chain, invariants, semantics, control boundary, replay, and artifact contract integrity, reusing existing `rax_*` runtime modules and policy inputs.
- Produce a deterministic report artifact at `docs/reviews/rax_redteam_arch_report.json` containing the requested fields (`attacks_attempted`, `attacks_blocked`, `attacks_that_succeeded`, category buckets, `overall_verdict`, `strongest_blocked_attacks`, `remaining_weak_seams`, and `next_required_fixes`).
- Harness includes policy hashing, authoritative source-version checks, replay baseline store handling, and recomputation of required eval coverage to avoid trusting caller-supplied summaries.

### Testing
- Ran `python scripts/run_rax_redteam_arch_01.py` which executed the full 30-attack harness and wrote `docs/reviews/rax_redteam_arch_report.json`, and the command exited successfully; the generated report shows `overall_verdict=FAIL` with one successful attack (`novel_adversarial_pattern`).
- Verified the produced report contents with `python - <<'PY' ...` to inspect `attacks_that_succeeded`, confirming the single succeeded attack seam.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db05fb19c48329a2516a7bb47a61fa)