### PR TITLE
RAX-HARDEN-NOVEL-01: close novel adversarial semantic seam in input assurance

### DIFF
--- a/contracts/examples/rax_eval_case_set.json
+++ b/contracts/examples/rax_eval_case_set.json
@@ -4,23 +4,271 @@
   "batch": "RAX-EVAL-01",
   "case_set_version": "1.0.0",
   "cases": [
-    {"eval_case_id": "rax-case-semantic-empty-intent", "eval_type": "rax_input_semantic_sufficiency", "case_class": "failure_class", "target_ref": "upstream:semantic-empty", "expected_status": "fail", "reason_codes": ["semantic_intent_insufficient"], "signals": ["intent_placeholder_detected"], "trace_id": "11111111-1111-4111-8111-111111111111"},
-    {"eval_case_id": "rax-case-owner-intent-contradiction", "eval_type": "rax_owner_intent_alignment", "case_class": "failure_class", "target_ref": "upstream:owner-intent-contradiction", "expected_status": "fail", "reason_codes": ["owner_intent_contradiction"], "signals": ["owner_intent_misaligned"], "trace_id": "22222222-2222-4222-8222-222222222222"},
-    {"eval_case_id": "rax-case-normalization-collapse", "eval_type": "rax_normalization_integrity", "case_class": "failure_class", "target_ref": "upstream:normalization-collapse", "expected_status": "fail", "reason_codes": ["normalization_ambiguity"], "signals": ["normalization_lossy"], "trace_id": "33333333-3333-4333-8333-333333333333"},
-    {"eval_case_id": "rax-case-wrong-target", "eval_type": "rax_output_semantic_alignment", "case_class": "adversarial", "target_ref": "contract:wrong-target", "expected_status": "fail", "reason_codes": ["semantic_target_mismatch"], "signals": ["target_module_semantically_wrong"], "trace_id": "44444444-4444-4444-8444-444444444444"},
-    {"eval_case_id": "rax-case-output-overexpanded", "eval_type": "rax_output_semantic_alignment", "case_class": "adversarial", "target_ref": "contract:over-expanded", "expected_status": "fail", "reason_codes": ["output_over_expanded"], "signals": ["downstream_unusable"], "trace_id": "55555555-5555-4555-8555-555555555555"},
-    {"eval_case_id": "rax-case-weak-acceptance-checks", "eval_type": "rax_acceptance_check_strength", "case_class": "failure_class", "target_ref": "contract:weak-acceptance", "expected_status": "fail", "reason_codes": ["weak_acceptance_check"], "signals": ["acceptance_strength_below_policy"], "trace_id": "66666666-6666-4666-8666-666666666666"},
-    {"eval_case_id": "rax-case-missing-trace", "eval_type": "rax_trace_integrity", "case_class": "failure_class", "target_ref": "trace:missing", "expected_status": "fail", "reason_codes": ["missing_required_expansion_trace"], "signals": ["trace_incomplete"], "trace_id": "77777777-7777-4777-8777-777777777777"},
-    {"eval_case_id": "rax-case-source-version-drift", "eval_type": "rax_version_authority_alignment", "case_class": "failure_class", "target_ref": "upstream:source-version-drift", "expected_status": "fail", "reason_codes": ["source_version_drift"], "signals": ["version_authority_mismatch"], "trace_id": "88888888-8888-4888-8888-888888888888"},
-    {"eval_case_id": "rax-case-missing-control-readiness-evidence", "eval_type": "rax_control_readiness", "case_class": "failure_class", "target_ref": "readiness:missing-evidence", "expected_status": "fail", "reason_codes": ["control_readiness_evidence_missing"], "signals": ["control_readiness_false"], "trace_id": "99999999-9999-4999-8999-999999999999"},
-    {"eval_case_id": "rax-case-missing-required-eval-artifact", "eval_type": "rax_control_readiness", "case_class": "failure_class", "target_ref": "summary:missing-required-eval", "expected_status": "fail", "reason_codes": ["missing_required_eval_artifact"], "signals": ["fail_closed_missing_eval"], "trace_id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"},
-    {"eval_case_id": "rax-case-schema-valid-semantically-wrong", "eval_type": "rax_output_semantic_alignment", "case_class": "adversarial", "target_ref": "contract:schema-valid-semantic-wrong", "expected_status": "fail", "reason_codes": ["schema_valid_semantic_failure"], "signals": ["semantic_contradiction_detected"], "trace_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"},
-    {"eval_case_id": "rax-case-trace-linked-incomplete-output", "eval_type": "rax_trace_integrity", "case_class": "adversarial", "target_ref": "trace:linked-incomplete", "expected_status": "fail", "reason_codes": ["trace_linked_output_incomplete"], "signals": ["trace_not_sufficient"], "trace_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc"},
-    {"eval_case_id": "rax-case-test-pass-eval-fail", "eval_type": "rax_control_readiness", "case_class": "adversarial", "target_ref": "flow:test-pass-eval-fail", "expected_status": "fail", "reason_codes": ["tests_pass_eval_fail"], "signals": ["tests_not_sufficient_for_readiness"], "trace_id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd"},
-    {"eval_case_id": "rax-case-regression-missing-baseline-guard", "eval_type": "rax_regression_against_baseline", "case_class": "failure_class", "target_ref": "contract:baseline-regression", "expected_status": "fail", "reason_codes": ["baseline_regression_detected"], "signals": ["regression_blocking"], "trace_id": "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee"},
-    {"eval_case_id": "rax-case-baseline-input", "eval_type": "rax_input_semantic_sufficiency", "case_class": "baseline", "target_ref": "upstream:baseline", "expected_status": "pass", "reason_codes": ["baseline_ok"], "signals": ["semantic_intent_sufficient"], "trace_id": "f1111111-1111-4111-8111-111111111111"},
-    {"eval_case_id": "rax-case-baseline-output", "eval_type": "rax_output_semantic_alignment", "case_class": "baseline", "target_ref": "contract:baseline", "expected_status": "pass", "reason_codes": ["baseline_ok"], "signals": ["output_semantically_aligned"], "trace_id": "f2222222-2222-4222-8222-222222222222"},
-    {"eval_case_id": "rax-case-baseline-trace", "eval_type": "rax_trace_integrity", "case_class": "baseline", "target_ref": "trace:baseline", "expected_status": "pass", "reason_codes": ["baseline_ok"], "signals": ["trace_complete"], "trace_id": "f3333333-3333-4333-8333-333333333333"},
-    {"eval_case_id": "rax-case-baseline-readiness", "eval_type": "rax_control_readiness", "case_class": "baseline", "target_ref": "readiness:baseline", "expected_status": "pass", "reason_codes": ["baseline_ok"], "signals": ["control_readiness_true"], "trace_id": "f4444444-4444-4444-8444-444444444444"}
+    {
+      "eval_case_id": "rax-case-semantic-empty-intent",
+      "eval_type": "rax_input_semantic_sufficiency",
+      "case_class": "failure_class",
+      "target_ref": "upstream:semantic-empty",
+      "expected_status": "fail",
+      "reason_codes": [
+        "semantic_intent_insufficient"
+      ],
+      "signals": [
+        "intent_placeholder_detected"
+      ],
+      "trace_id": "11111111-1111-4111-8111-111111111111"
+    },
+    {
+      "eval_case_id": "rax-case-owner-intent-contradiction",
+      "eval_type": "rax_owner_intent_alignment",
+      "case_class": "failure_class",
+      "target_ref": "upstream:owner-intent-contradiction",
+      "expected_status": "fail",
+      "reason_codes": [
+        "owner_intent_contradiction"
+      ],
+      "signals": [
+        "owner_intent_misaligned"
+      ],
+      "trace_id": "22222222-2222-4222-8222-222222222222"
+    },
+    {
+      "eval_case_id": "rax-case-normalization-collapse",
+      "eval_type": "rax_normalization_integrity",
+      "case_class": "failure_class",
+      "target_ref": "upstream:normalization-collapse",
+      "expected_status": "fail",
+      "reason_codes": [
+        "normalization_ambiguity"
+      ],
+      "signals": [
+        "normalization_lossy"
+      ],
+      "trace_id": "33333333-3333-4333-8333-333333333333"
+    },
+    {
+      "eval_case_id": "rax-case-wrong-target",
+      "eval_type": "rax_output_semantic_alignment",
+      "case_class": "adversarial",
+      "target_ref": "contract:wrong-target",
+      "expected_status": "fail",
+      "reason_codes": [
+        "semantic_target_mismatch"
+      ],
+      "signals": [
+        "target_module_semantically_wrong"
+      ],
+      "trace_id": "44444444-4444-4444-8444-444444444444"
+    },
+    {
+      "eval_case_id": "rax-case-output-overexpanded",
+      "eval_type": "rax_output_semantic_alignment",
+      "case_class": "adversarial",
+      "target_ref": "contract:over-expanded",
+      "expected_status": "fail",
+      "reason_codes": [
+        "output_over_expanded"
+      ],
+      "signals": [
+        "downstream_unusable"
+      ],
+      "trace_id": "55555555-5555-4555-8555-555555555555"
+    },
+    {
+      "eval_case_id": "rax-case-weak-acceptance-checks",
+      "eval_type": "rax_acceptance_check_strength",
+      "case_class": "failure_class",
+      "target_ref": "contract:weak-acceptance",
+      "expected_status": "fail",
+      "reason_codes": [
+        "weak_acceptance_check"
+      ],
+      "signals": [
+        "acceptance_strength_below_policy"
+      ],
+      "trace_id": "66666666-6666-4666-8666-666666666666"
+    },
+    {
+      "eval_case_id": "rax-case-missing-trace",
+      "eval_type": "rax_trace_integrity",
+      "case_class": "failure_class",
+      "target_ref": "trace:missing",
+      "expected_status": "fail",
+      "reason_codes": [
+        "missing_required_expansion_trace"
+      ],
+      "signals": [
+        "trace_incomplete"
+      ],
+      "trace_id": "77777777-7777-4777-8777-777777777777"
+    },
+    {
+      "eval_case_id": "rax-case-source-version-drift",
+      "eval_type": "rax_version_authority_alignment",
+      "case_class": "failure_class",
+      "target_ref": "upstream:source-version-drift",
+      "expected_status": "fail",
+      "reason_codes": [
+        "source_version_drift"
+      ],
+      "signals": [
+        "version_authority_mismatch"
+      ],
+      "trace_id": "88888888-8888-4888-8888-888888888888"
+    },
+    {
+      "eval_case_id": "rax-case-missing-control-readiness-evidence",
+      "eval_type": "rax_control_readiness",
+      "case_class": "failure_class",
+      "target_ref": "readiness:missing-evidence",
+      "expected_status": "fail",
+      "reason_codes": [
+        "control_readiness_evidence_missing"
+      ],
+      "signals": [
+        "control_readiness_false"
+      ],
+      "trace_id": "99999999-9999-4999-8999-999999999999"
+    },
+    {
+      "eval_case_id": "rax-case-missing-required-eval-artifact",
+      "eval_type": "rax_control_readiness",
+      "case_class": "failure_class",
+      "target_ref": "summary:missing-required-eval",
+      "expected_status": "fail",
+      "reason_codes": [
+        "missing_required_eval_artifact"
+      ],
+      "signals": [
+        "fail_closed_missing_eval"
+      ],
+      "trace_id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+    },
+    {
+      "eval_case_id": "rax-case-schema-valid-semantically-wrong",
+      "eval_type": "rax_output_semantic_alignment",
+      "case_class": "adversarial",
+      "target_ref": "contract:schema-valid-semantic-wrong",
+      "expected_status": "fail",
+      "reason_codes": [
+        "schema_valid_semantic_failure"
+      ],
+      "signals": [
+        "semantic_contradiction_detected"
+      ],
+      "trace_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+    },
+    {
+      "eval_case_id": "rax-case-trace-linked-incomplete-output",
+      "eval_type": "rax_trace_integrity",
+      "case_class": "adversarial",
+      "target_ref": "trace:linked-incomplete",
+      "expected_status": "fail",
+      "reason_codes": [
+        "trace_linked_output_incomplete"
+      ],
+      "signals": [
+        "trace_not_sufficient"
+      ],
+      "trace_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+    },
+    {
+      "eval_case_id": "rax-case-test-pass-eval-fail",
+      "eval_type": "rax_control_readiness",
+      "case_class": "adversarial",
+      "target_ref": "flow:test-pass-eval-fail",
+      "expected_status": "fail",
+      "reason_codes": [
+        "tests_pass_eval_fail"
+      ],
+      "signals": [
+        "tests_not_sufficient_for_readiness"
+      ],
+      "trace_id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
+    },
+    {
+      "eval_case_id": "rax-case-regression-missing-baseline-guard",
+      "eval_type": "rax_regression_against_baseline",
+      "case_class": "failure_class",
+      "target_ref": "contract:baseline-regression",
+      "expected_status": "fail",
+      "reason_codes": [
+        "baseline_regression_detected"
+      ],
+      "signals": [
+        "regression_blocking"
+      ],
+      "trace_id": "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee"
+    },
+    {
+      "eval_case_id": "rax-case-novel-adversarial-semantic-ambiguity",
+      "eval_type": "rax_input_semantic_sufficiency",
+      "case_class": "adversarial",
+      "target_ref": "upstream:novel-adversarial-semantic-ambiguity",
+      "expected_status": "fail",
+      "reason_codes": [
+        "semantic_intent_insufficient"
+      ],
+      "signals": [
+        "ambiguous_or_evidence_avoiding_intent"
+      ],
+      "trace_id": "e1212121-1212-4121-8121-121212121212"
+    },
+    {
+      "eval_case_id": "rax-case-baseline-input",
+      "eval_type": "rax_input_semantic_sufficiency",
+      "case_class": "baseline",
+      "target_ref": "upstream:baseline",
+      "expected_status": "pass",
+      "reason_codes": [
+        "baseline_ok"
+      ],
+      "signals": [
+        "semantic_intent_sufficient"
+      ],
+      "trace_id": "f1111111-1111-4111-8111-111111111111"
+    },
+    {
+      "eval_case_id": "rax-case-baseline-output",
+      "eval_type": "rax_output_semantic_alignment",
+      "case_class": "baseline",
+      "target_ref": "contract:baseline",
+      "expected_status": "pass",
+      "reason_codes": [
+        "baseline_ok"
+      ],
+      "signals": [
+        "output_semantically_aligned"
+      ],
+      "trace_id": "f2222222-2222-4222-8222-222222222222"
+    },
+    {
+      "eval_case_id": "rax-case-baseline-trace",
+      "eval_type": "rax_trace_integrity",
+      "case_class": "baseline",
+      "target_ref": "trace:baseline",
+      "expected_status": "pass",
+      "reason_codes": [
+        "baseline_ok"
+      ],
+      "signals": [
+        "trace_complete"
+      ],
+      "trace_id": "f3333333-3333-4333-8333-333333333333"
+    },
+    {
+      "eval_case_id": "rax-case-baseline-readiness",
+      "eval_type": "rax_control_readiness",
+      "case_class": "baseline",
+      "target_ref": "readiness:baseline",
+      "expected_status": "pass",
+      "reason_codes": [
+        "baseline_ok"
+      ],
+      "signals": [
+        "control_readiness_true"
+      ],
+      "trace_id": "f4444444-4444-4444-8444-444444444444"
+    }
   ]
 }

--- a/docs/review-actions/PLAN-RAX-HARDEN-NOVEL-01-2026-04-12.md
+++ b/docs/review-actions/PLAN-RAX-HARDEN-NOVEL-01-2026-04-12.md
@@ -1,0 +1,28 @@
+# PLAN — RAX-HARDEN-NOVEL-01 (2026-04-12)
+
+Primary prompt type: BUILD
+
+## Scope
+Close only the remaining `novel_adversarial_pattern` seam in `RAX-REDTEAM-ARCH-01` by tightening semantic input assurance and wiring the failure into governed failure/eval/adversarial regression surfaces.
+
+## File plan (surgical)
+| File | Change | Purpose |
+| --- | --- | --- |
+| `spectrum_systems/modules/runtime/rax_assurance.py` | MODIFY | Add generalized semantic intent guard for ambiguity/evidence-avoidance execution language so novel adversarial intent fails closed. |
+| `tests/test_rax_interface_assurance.py` | MODIFY | Add permanent regression tests for exact novel pattern + nearby variant to ensure `passed=false`, explicit `failure_classification`, and `stop_condition_triggered=true`. |
+| `contracts/examples/rax_eval_case_set.json` | MODIFY | Add governed eval case for novel adversarial semantic pattern. |
+| `docs/reviews/rax_failure_pattern_novel_adversarial_pattern.json` | CREATE | Failure-pattern artifact with minimal reproducer and semantic gap classification. |
+| `docs/reviews/rax_novel_adversarial_design_note_2026-04-12.md` | CREATE | Concise review note documenting the semantic blind spot and fix rationale. |
+| `docs/reviews/rax_adversarial_seed_patterns.json` | MODIFY/CREATE | Add seed/pattern class so lightweight adversarial generation replays this class. |
+
+## Validation plan
+1. `pytest tests/test_rax_interface_assurance.py -k "novel_adversarial orambiguity_or_minimal_proof" -q`
+2. `pytest tests/test_rax_interface_assurance.py -q`
+3. `pytest tests/test_rax_eval_runner.py -q`
+4. `python scripts/run_rax_redteam_arch_01.py` and verify `novel_adversarial_pattern` is blocked.
+
+## Constraints honored
+- No new authority surfaces.
+- No roadmap expansion/redesign.
+- Fail-closed behavior only.
+- Artifact-backed and trace-linked updates.

--- a/docs/reviews/rax_adversarial_seed_patterns.json
+++ b/docs/reviews/rax_adversarial_seed_patterns.json
@@ -1,0 +1,26 @@
+{
+  "artifact_type": "rax_adversarial_seed_patterns",
+  "schema_version": "1.0.0",
+  "batch": "RAX-HARDEN-NOVEL-01",
+  "seed_classes": [
+    {
+      "seed_id": "novel_adversarial_pattern",
+      "target_surface": "rax_input_semantic_sufficiency",
+      "generation_strategy": "intent_phrase_mutation",
+      "base_prompt": "execute exactly what seems useful quickly with minimal proof",
+      "variants": [
+        "execute exactly what seems useful quickly with minimal proof",
+        "Execute implementation changes as needed without proof for this step"
+      ],
+      "expected_outcome": {
+        "passed": false,
+        "failure_classification": "invalid_input",
+        "stop_condition_triggered": true
+      },
+      "trace_links": [
+        "docs/reviews/rax_failure_pattern_novel_adversarial_pattern.json",
+        "docs/reviews/rax_eval_candidate_novel_adversarial_pattern.json"
+      ]
+    }
+  ]
+}

--- a/docs/reviews/rax_eval_candidate_novel_adversarial_pattern.json
+++ b/docs/reviews/rax_eval_candidate_novel_adversarial_pattern.json
@@ -1,0 +1,39 @@
+{
+  "artifact_type": "eval_case",
+  "schema_version": "1.0.0",
+  "run_id": "run-d1c2740c3f044efa",
+  "trace_id": "fede4b1b-0b68-5aa1-bdc9-8eb68aadee28",
+  "eval_case_id": "ec-2da521ef728ab4ac",
+  "input_artifact_refs": [
+    "failure_pattern_record:fpr-d999743b2d7efb4b"
+  ],
+  "expected_output_spec": {
+    "pass_condition": "future_runs_must_not_repeat_normalized_failure_key",
+    "normalized_failure_key": "254e6c8bf84a437555b25e83cb20d3834bcb74e6bba843aabcd59cfd8d0a5b00",
+    "max_allowed_recurrence_count": 0,
+    "anchor_trace_id": "novel-adversarial-pattern-2026-04-12"
+  },
+  "scoring_rubric": {
+    "metric": "failure_pattern_recurrence_count",
+    "pass_if_lte": 0,
+    "fail_if_gte": 1,
+    "failure_action": "freeze_or_block"
+  },
+  "evaluation_type": "deterministic",
+  "created_from": "failure_trace",
+  "slice_tags": [
+    "batch_l_failure_learning",
+    "recurrence_prevention"
+  ],
+  "risk_class": "high",
+  "priority": "p0",
+  "provenance": {
+    "source_failure_pattern_record": "fpr-d999743b2d7efb4b",
+    "source_normalized_failure_key": "254e6c8bf84a437555b25e83cb20d3834bcb74e6bba843aabcd59cfd8d0a5b00",
+    "source_failure_pattern_ref": "failure_pattern_record:fpr-d999743b2d7efb4b",
+    "provenance_refs": [
+      "failure_pattern_record:fpr-d999743b2d7efb4b",
+      "trace:novel-adversarial-pattern-2026-04-12"
+    ]
+  }
+}

--- a/docs/reviews/rax_failure_pattern_novel_adversarial_pattern.json
+++ b/docs/reviews/rax_failure_pattern_novel_adversarial_pattern.json
@@ -1,0 +1,23 @@
+{
+  "artifact_type": "failure_pattern_record",
+  "schema_version": "1.0.0",
+  "pattern_id": "fpr-d999743b2d7efb4b",
+  "normalized_failure_key": "254e6c8bf84a437555b25e83cb20d3834bcb74e6bba843aabcd59cfd8d0a5b00",
+  "occurrence_count": 1,
+  "first_seen": "2026-04-12T00:00:00Z",
+  "last_seen": "2026-04-12T00:00:00Z",
+  "associated_stop_reasons": [
+    "semantic_validation_failed"
+  ],
+  "associated_root_causes": [
+    "assure_rax_input:semantic_intent_insufficient",
+    "assure_rax_input:ambiguous_or_evidence_avoiding_intent_phrase"
+  ],
+  "related_artifacts": [
+    "docs/reviews/rax_redteam_arch_report.json#attack_results[novel_adversarial_pattern]",
+    "contracts/examples/rax_eval_case_set.json#rax-case-novel-adversarial-semantic-ambiguity"
+  ],
+  "trace_ids": [
+    "novel-adversarial-pattern-2026-04-12"
+  ]
+}

--- a/docs/reviews/rax_novel_adversarial_design_note_2026-04-12.md
+++ b/docs/reviews/rax_novel_adversarial_design_note_2026-04-12.md
@@ -1,0 +1,24 @@
+# RAX novel adversarial semantic seam closure note (2026-04-12)
+
+## Seam
+`novel_adversarial_pattern` passed because input semantic checks accepted execution intent text that looked syntactically rich but avoided governed evidence commitments.
+
+Minimum reproducer:
+- owner: `PQX`
+- intent: `execute exactly what seems useful quickly with minimal proof`
+
+## Exact semantic gap
+The prior `assure_rax_input` path enforced placeholder rejection and explicit owner-intent contradiction rules, but it did not reject ambiguous/evidence-avoiding execution language that omits explicit artifact/evidence verification anchors.
+
+## Fix
+A fail-closed semantic rule was added to the input validation path:
+1. Reject execution-intent phrasing that lacks governed verification/evidence anchors.
+2. Reject hedge/evidence-avoidance phrases (for example `as needed`, `minimal proof`, `without proof`) as semantic insufficiency.
+
+## Result
+This seam now returns:
+- `passed = false`
+- `failure_classification = invalid_input`
+- `stop_condition_triggered = true`
+
+with counter-evidence emitted in `details` as `semantic_intent_insufficient:*` markers.

--- a/docs/reviews/rax_redteam_arch_report.json
+++ b/docs/reviews/rax_redteam_arch_report.json
@@ -62,22 +62,19 @@
     "schema_valid_but_semantic_contract_invalid",
     "artifact_not_fully_trace_linked",
     "artifact_lineage_incomplete",
+    "novel_adversarial_pattern",
     "combined_weak_signals_simulate_valid",
     "edge_case_schema_valid_borderline_semantics"
   ],
-  "attacks_that_succeeded": [
-    "novel_adversarial_pattern"
-  ],
+  "attacks_that_succeeded": [],
   "invariant_violations": [],
   "readiness_gate_failures": [],
   "eval_chain_failures": [],
-  "semantic_failures": [
-    "novel_adversarial_pattern"
-  ],
+  "semantic_failures": [],
   "trace_lineage_failures": [],
   "replay_failures": [],
   "control_boundary_violations": [],
-  "overall_verdict": "FAIL",
+  "overall_verdict": "PASS",
   "strongest_blocked_attacks": [
     "no_readiness_artifact_present",
     "externally_forged_readiness_inputs",
@@ -85,14 +82,8 @@
     "same_tests_different_eval_signals",
     "rax_bypasses_control_layer"
   ],
-  "remaining_weak_seams": [
-    "novel_adversarial_pattern"
-  ],
-  "next_required_fixes": [
-    "Harden readiness enforcement for every succeeded attack before control consumption.",
-    "Close all semantic acceptance paths that allowed architecturally invalid outputs.",
-    "Add stricter replay freeze behavior where inconsistency was observed."
-  ],
+  "remaining_weak_seams": [],
+  "next_required_fixes": [],
   "attack_results": [
     {
       "attack_id": 1,
@@ -313,10 +304,10 @@
     {
       "attack_id": 28,
       "name": "novel_adversarial_pattern",
-      "blocked": false,
-      "succeeded": true,
+      "blocked": true,
+      "succeeded": false,
       "category": "semantic_failures",
-      "evidence": "{'passed': True, 'details': ['upstream schema validation passed'], 'failure_classification': 'none', 'stop_condition_triggered': False}"
+      "evidence": "{'passed': False, 'details': ['upstream schema validation passed', 'semantic_intent_insufficient: execution intent missing governed verification/evidence anchors'], 'failure_classification': 'invalid_input', 'stop_condition_triggered': True}"
     },
     {
       "attack_id": 29,

--- a/spectrum_systems/modules/runtime/rax_assurance.py
+++ b/spectrum_systems/modules/runtime/rax_assurance.py
@@ -54,6 +54,41 @@ _NON_OPERATIONAL_ACCEPTANCE_PHRASES = (
 )
 _DEPENDENCY_ID_PATTERN = re.compile(r"^RAX-INTERFACE-\d{2}-\d{2}$")
 
+
+_EXECUTION_INTENT_VERBS = (
+    "execute",
+    "apply",
+    "change",
+    "modify",
+    "update",
+    "ship",
+    "deploy",
+    "implement",
+)
+
+_INTENT_HEDGE_PHRASES = (
+    "seems useful",
+    "whatever seems useful",
+    "as needed",
+    "if needed",
+    "quickly",
+    "minimal proof",
+    "without proof",
+    "best effort",
+)
+
+_REQUIRED_GOVERNANCE_INTENT_TERMS = (
+    "artifact",
+    "trace",
+    "evidence",
+    "acceptance",
+    "verify",
+    "validated",
+    "deterministic",
+    "fail-closed",
+    "contract",
+)
+
 _DEFAULT_SOURCE_VERSION_AUTHORITY = {
     "docs/roadmaps/system_roadmap.md#RAX-INTERFACE-24-01": "1.3.112",
 }
@@ -91,6 +126,21 @@ def _is_semantically_sufficient_intent(intent: str) -> bool:
     meaningful_tokens = [token for token in tokens if len(token) >= 4 and token not in generic_placeholders]
     return len(meaningful_tokens) >= 3
 
+
+
+
+def _semantic_intent_gap_reason(intent: str) -> str | None:
+    normalized = " ".join(intent.lower().split())
+
+    has_execution_language = any(verb in normalized for verb in _EXECUTION_INTENT_VERBS)
+    has_governance_anchor = any(term in normalized for term in _REQUIRED_GOVERNANCE_INTENT_TERMS)
+    if has_execution_language and not has_governance_anchor:
+        return "semantic_intent_insufficient: execution intent missing governed verification/evidence anchors"
+
+    for phrase in _INTENT_HEDGE_PHRASES:
+        if phrase in normalized:
+            return f"semantic_intent_insufficient: ambiguous_or_evidence_avoiding_intent_phrase='{phrase}'"
+    return None
 
 def _validate_owner_intent_semantics(owner: str, intent: str) -> str | None:
     lowered = intent.lower()
@@ -172,6 +222,12 @@ def assure_rax_input(
         if owner_contradiction:
             failure_classification = "ownership_violation"
             details.append(f"owner_intent_contradiction: {owner_contradiction}")
+
+    if failure_classification == "none":
+        semantic_gap = _semantic_intent_gap_reason(payload["intent"])
+        if semantic_gap:
+            failure_classification = "invalid_input"
+            details.append(semantic_gap)
 
     if failure_classification == "none":
         if payload["owner"] not in policy.get("owner_defaults", {}):

--- a/tests/test_rax_eval_runner.py
+++ b/tests/test_rax_eval_runner.py
@@ -69,6 +69,14 @@ def test_rax_eval_case_set_example_is_valid_and_includes_adversarial_and_baselin
     assert {"baseline", "adversarial", "failure_class"}.issubset(classes)
 
 
+
+def test_eval_case_set_contains_novel_adversarial_semantic_case() -> None:
+    case_set = load_rax_eval_case_set()
+    case = next(case for case in case_set["cases"] if case["eval_case_id"] == "rax-case-novel-adversarial-semantic-ambiguity")
+    assert case["case_class"] == "adversarial"
+    assert case["eval_type"] == "rax_input_semantic_sufficiency"
+    assert "semantic_intent_insufficient" in case["reason_codes"]
+
 def test_runner_emits_structured_eval_results_and_summary() -> None:
     out = run_rax_eval_runner(
         run_id="rax-eval-run-001",

--- a/tests/test_rax_interface_assurance.py
+++ b/tests/test_rax_interface_assurance.py
@@ -166,6 +166,51 @@ def test_input_assurance_rejects_owner_intent_contradiction() -> None:
     assert any("owner_intent_contradiction" in detail for detail in result["details"])
 
 
+def test_input_assurance_rejects_novel_adversarial_pattern_intent() -> None:
+    upstream = load_example("rax_upstream_input_envelope")
+    upstream["owner"] = "PQX"
+    upstream["intent"] = "execute exactly what seems useful quickly with minimal proof"
+    result = assure_rax_input(upstream, **_valid_input_assurance_kwargs(upstream))
+    assert result["passed"] is False
+    assert result["failure_classification"] == "invalid_input"
+    assert result["stop_condition_triggered"] is True
+    assert any(
+        "execution intent missing governed verification/evidence anchors" in detail
+        or "ambiguous_or_evidence_avoiding_intent_phrase" in detail
+        for detail in result["details"]
+    )
+
+
+def test_input_assurance_rejects_nearby_ambiguous_execution_variant() -> None:
+    upstream = load_example("rax_upstream_input_envelope")
+    upstream["owner"] = "PQX"
+    upstream["intent"] = "Execute implementation changes as needed without proof for this step"
+    result = assure_rax_input(upstream, **_valid_input_assurance_kwargs(upstream))
+    assert result["passed"] is False
+    assert result["failure_classification"] == "invalid_input"
+    assert result["stop_condition_triggered"] is True
+    assert any(
+        "execution intent missing governed verification/evidence anchors" in detail
+        or "ambiguous_or_evidence_avoiding_intent_phrase" in detail
+        for detail in result["details"]
+    )
+
+
+def test_input_assurance_rejects_all_seeded_novel_adversarial_variants() -> None:
+    seed_path = REPO_ROOT / "docs" / "reviews" / "rax_adversarial_seed_patterns.json"
+    seed_doc = json.loads(seed_path.read_text(encoding="utf-8"))
+    seed = next(item for item in seed_doc["seed_classes"] if item["seed_id"] == "novel_adversarial_pattern")
+
+    for variant in seed["variants"]:
+        upstream = load_example("rax_upstream_input_envelope")
+        upstream["owner"] = "PQX"
+        upstream["intent"] = variant
+        result = assure_rax_input(upstream, **_valid_input_assurance_kwargs(upstream))
+        assert result["passed"] is False
+        assert result["failure_classification"] == "invalid_input"
+        assert result["stop_condition_triggered"] is True
+
+
 def test_input_assurance_requires_trace_presence() -> None:
     upstream = load_example("rax_upstream_input_envelope")
     kwargs = _valid_input_assurance_kwargs(upstream)


### PR DESCRIPTION
### Motivation
- Close the single remaining red-team seam `novel_adversarial_pattern` where syntactically-rich upstream `intent` text could evade semantic validation by avoiding governed evidence anchors. 
- The fix must be surgical and fail-closed, integrate into the failure→eval→adversarial feedback loop, and not broaden authority or redesign RAX.
- Add artifact-backed regression and seed-driven adversarial coverage so the defect cannot reappear as a one-off string match.

### Description
- Hardened input semantic validation by extending `assure_rax_input` in `spectrum_systems/modules/runtime/rax_assurance.py` with generalized intent checks that: reject execution-intent phrasing that lacks governed verification/evidence anchors and flag hedge/evidence-avoiding phrases (e.g., `minimal proof`, `as needed`) as semantic insufficiency while preserving owner-intent contradiction precedence. (key helpers: `_semantic_intent_gap_reason`, new constants). 
- Added permanent regression tests in `tests/test_rax_interface_assurance.py` for the exact reproducer and a nearby variant and a seeded-variant loop driven by `docs/reviews/rax_adversarial_seed_patterns.json`. 
- Added an adversarial eval-case entry to `contracts/examples/rax_eval_case_set.json` (`rax-case-novel-adversarial-semantic-ambiguity`) and a unit test in `tests/test_rax_eval_runner.py` that asserts its presence. 
- Emitted governed artifacts to feed the failure→eval loop: `docs/reviews/rax_failure_pattern_novel_adversarial_pattern.json` (failure pattern), `docs/reviews/rax_eval_candidate_novel_adversarial_pattern.json` (eval candidate), and `docs/reviews/rax_adversarial_seed_patterns.json` (seed patterns). 
- Added a short surgical plan and design note: `docs/review-actions/PLAN-RAX-HARDEN-NOVEL-01-2026-04-12.md` and `docs/reviews/rax_novel_adversarial_design_note_2026-04-12.md` documenting the semantic blind spot and rationale.

### Testing
- Ran targeted regression for the new seam: `pytest tests/test_rax_interface_assurance.py -k 'novel_adversarial or nearby_ambiguous or seeded_novel'` — passed. 
- Ran full assurance interface suite: `pytest tests/test_rax_interface_assurance.py -q` — passed (all tests in that file passed). 
- Ran eval runner tests: `pytest tests/test_rax_eval_runner.py -q` — passed (17 tests). 
- Executed the architecture red-team harness run: `python scripts/run_rax_redteam_arch_01.py` and verified `overall_verdict=PASS` and that `novel_adversarial_pattern` is blocked. 
- Validated generated artifacts against their schemas using `spectrum_systems.contracts.validate_artifact` for `docs/reviews/rax_failure_pattern_novel_adversarial_pattern.json` (`failure_pattern_record`), `docs/reviews/rax_eval_candidate_novel_adversarial_pattern.json` (`eval_case`), and `contracts/examples/rax_eval_case_set.json` (`rax_eval_case_set`) — validation succeeded.

Files changed (high level): `spectrum_systems/modules/runtime/rax_assurance.py`, `tests/test_rax_interface_assurance.py`, `tests/test_rax_eval_runner.py`, `contracts/examples/rax_eval_case_set.json`, `docs/reviews/rax_failure_pattern_novel_adversarial_pattern.json`, `docs/reviews/rax_eval_candidate_novel_adversarial_pattern.json`, `docs/reviews/rax_adversarial_seed_patterns.json`, `docs/reviews/rax_novel_adversarial_design_note_2026-04-12.md`, and the surgical plan `docs/review-actions/PLAN-RAX-HARDEN-NOVEL-01-2026-04-12.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db8886e5608329be9348cb2f93080f)