### PR TITLE
Implement RAX feedback-loop: failure artifacts, health/drift signals, adversarial candidates, and readiness wiring

### DIFF
--- a/config/policy/rax_eval_policy.json
+++ b/config/policy/rax_eval_policy.json
@@ -1,7 +1,7 @@
 {
   "artifact_type": "rax_eval_policy",
-  "schema_version": "1.0.0",
-  "batch": "RAX-EVAL-01",
+  "schema_version": "1.1.0",
+  "batch": "RAX-FEEDBACK-LOOP-10",
   "missing_required_eval_handling": "fail_closed",
   "required_eval_types": [
     "rax_input_semantic_sufficiency",
@@ -26,5 +26,58 @@
     "baseline_regression_detected",
     "missing_required_eval_artifact",
     "tests_pass_eval_fail"
-  ]
+  ],
+  "health_thresholds": {
+    "readiness_pass_rate": {
+      "warn_min": 0.85,
+      "freeze_candidate_min": 0.75,
+      "block_candidate_min": 0.6
+    },
+    "eval_coverage_rate": {
+      "warn_min": 0.95,
+      "freeze_candidate_min": 0.9,
+      "block_candidate_min": 0.8
+    },
+    "semantic_failure_rate": {
+      "warn_max": 0.1,
+      "freeze_candidate_max": 0.2,
+      "block_candidate_max": 0.3
+    },
+    "readiness_bypass_attempt_rate": {
+      "warn_max": 0.01,
+      "freeze_candidate_max": 0.03,
+      "block_candidate_max": 0.05
+    },
+    "replay_consistency_rate": {
+      "warn_min": 0.95,
+      "freeze_candidate_min": 0.9,
+      "block_candidate_min": 0.8
+    },
+    "trace_completeness_rate": {
+      "warn_min": 0.95,
+      "freeze_candidate_min": 0.9,
+      "block_candidate_min": 0.8
+    },
+    "lineage_validity_rate": {
+      "warn_min": 0.95,
+      "freeze_candidate_min": 0.9,
+      "block_candidate_min": 0.8
+    },
+    "contradiction_rate": {
+      "warn_max": 0.02,
+      "freeze_candidate_max": 0.05,
+      "block_candidate_max": 0.1
+    }
+  },
+  "drift_thresholds": {
+    "eval_signal_drift": 0.1,
+    "readiness_outcome_drift": 0.1,
+    "semantic_classification_drift": 0.05,
+    "version_authority_drift": 0.05,
+    "trace_lineage_completeness_drift": 0.1
+  },
+  "adversarial_generation": {
+    "enabled": true,
+    "default_count": 5
+  }
 }

--- a/contracts/examples/rax_adversarial_pattern_candidate.json
+++ b/contracts/examples/rax_adversarial_pattern_candidate.json
@@ -1,0 +1,13 @@
+{
+  "artifact_type": "rax_adversarial_pattern_candidate",
+  "schema_version": "1.0.0",
+  "variant_id": "rax-adv-000000000001",
+  "seed": "rax-eval-run-001",
+  "variant_class": "schema_valid_semantic_boundary",
+  "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
+  "payload": {
+    "mutator_index": 0,
+    "deterministic_token": 42
+  },
+  "consumable_by_eval": true
+}

--- a/contracts/examples/rax_control_readiness_record.json
+++ b/contracts/examples/rax_control_readiness_record.json
@@ -5,7 +5,10 @@
   "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
   "ready_for_control": false,
   "decision": "block",
-  "blocking_reasons": ["missing_required_eval_artifact", "tests_pass_eval_fail"],
+  "blocking_reasons": [
+    "missing_required_eval_artifact",
+    "tests_pass_eval_fail"
+  ],
   "required_eval_types": [
     "rax_input_semantic_sufficiency",
     "rax_owner_intent_alignment",
@@ -32,5 +35,17 @@
   ],
   "trace_complete": false,
   "baseline_regression_detected": true,
-  "version_authority_aligned": false
+  "version_authority_aligned": false,
+  "conditions_under_which_ready_changes": [
+    {
+      "condition_category": "missing_eval_becomes_present",
+      "blocking_reason": "missing_required_eval_types",
+      "evidence_refs": [
+        "roadmap_step_contract:RAX-INTERFACE-24-01"
+      ],
+      "required_signal": "missing_required_eval_types"
+    }
+  ],
+  "unknown_state_ref": "unknown-001",
+  "pre_certification_alignment_ref": "precert-001"
 }

--- a/contracts/examples/rax_drift_signal_record.json
+++ b/contracts/examples/rax_drift_signal_record.json
@@ -1,0 +1,14 @@
+{
+  "artifact_type": "rax_drift_signal_record",
+  "schema_version": "1.0.0",
+  "signal_id": "drift-001",
+  "baseline_window_ref": "window://rax/baseline",
+  "current_window_ref": "window://rax/current",
+  "eval_signal_drift": 0.02,
+  "readiness_outcome_drift": 0.03,
+  "semantic_classification_drift": 0.01,
+  "version_authority_drift": 0.0,
+  "trace_lineage_completeness_drift": 0.02,
+  "candidate_posture": "healthy",
+  "threshold_exceeded": []
+}

--- a/contracts/examples/rax_failure_eval_candidate.json
+++ b/contracts/examples/rax_failure_eval_candidate.json
@@ -1,0 +1,17 @@
+{
+  "artifact_type": "rax_failure_eval_candidate",
+  "schema_version": "1.0.0",
+  "candidate_id": "rax-failure-1111222233334444:eval-candidate",
+  "source_failure_id": "rax-failure-1111222233334444",
+  "eval_case_id": "rax-eval-run-001:rax_output_semantic_alignment:rax-failure-1111222233334444",
+  "eval_type": "rax_output_semantic_alignment",
+  "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
+  "expected_status": "fail",
+  "reason_codes": [
+    "semantic_intent_insufficient"
+  ],
+  "trace_id": "12121212-1212-4121-8121-121212121212",
+  "version": "1.0.0",
+  "dedupe_key": "semantic_contradiction|roadmap_step_contract:RAX-INTERFACE-24-01|rax_output_semantic_alignment",
+  "generation_status": "generated"
+}

--- a/contracts/examples/rax_failure_pattern_record.json
+++ b/contracts/examples/rax_failure_pattern_record.json
@@ -1,0 +1,27 @@
+{
+  "artifact_type": "rax_failure_pattern_record",
+  "schema_version": "1.0.0",
+  "failure_id": "rax-failure-1111222233334444",
+  "source_artifact_refs": [
+    "eval_run://rax-eval-run-001",
+    "roadmap_step_contract:RAX-INTERFACE-24-01",
+    "trace://12121212-1212-4121-8121-121212121212"
+  ],
+  "failure_classification": "invalid_input",
+  "failure_details": [
+    "semantic_intent_insufficient"
+  ],
+  "semantic_category": "semantic_contradiction",
+  "trace_linkage": {
+    "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
+    "trace_id": "12121212-1212-4121-8121-121212121212",
+    "linked_refs": [
+      "roadmap_step_contract:RAX-INTERFACE-24-01",
+      "trace://12121212-1212-4121-8121-121212121212"
+    ]
+  },
+  "reproducibility_inputs": {
+    "tests_passed": true
+  },
+  "candidate_eval_generation_status": "generated"
+}

--- a/contracts/examples/rax_feedback_loop_10_pqx_task_wrapper.json
+++ b/contracts/examples/rax_feedback_loop_10_pqx_task_wrapper.json
@@ -1,0 +1,87 @@
+{
+  "schema_version": "1.0.0",
+  "artifact_type": "codex_pqx_task_wrapper",
+  "wrapper_id": "rax-feedback-loop-10-preflight-wrapper",
+  "task_identity": {
+    "task_id": "RAX-FEEDBACK-LOOP-10",
+    "run_id": "RAX-PREFLIGHT-FIX-02",
+    "step_id": "RAX-PREFLIGHT-FIX-02",
+    "step_name": "Clear contract preflight block for RAX feedback-loop batch"
+  },
+  "task_source": {
+    "source_type": "codex_prompt",
+    "prompt": "RAX-PREFLIGHT-FIX-02 preflight wrapper alignment"
+  },
+  "execution_intent": {
+    "execution_context": "pqx_governed",
+    "mode": "governed"
+  },
+  "governance": {
+    "classification": "governed_pqx_required",
+    "pqx_required": true,
+    "authority_state": "authoritative_governed_pqx",
+    "authority_resolution": "explicit_pqx_context",
+    "authority_evidence_ref": "outputs/test-preflight-authority/run-1.pqx_slice_execution_record.json",
+    "contract_preflight_result_artifact_path": "outputs/contract_preflight/contract_preflight_result_artifact.json"
+  },
+  "changed_paths": [
+    "config/policy/rax_eval_policy.json",
+    "contracts/examples/rax_adversarial_pattern_candidate.json",
+    "contracts/examples/rax_control_readiness_record.json",
+    "contracts/examples/rax_drift_signal_record.json",
+    "contracts/examples/rax_failure_eval_candidate.json",
+    "contracts/examples/rax_failure_pattern_record.json",
+    "contracts/examples/rax_feedback_loop_record.json",
+    "contracts/examples/rax_health_snapshot.json",
+    "contracts/examples/rax_pre_certification_alignment_record.json",
+    "contracts/examples/rax_unknown_state_record.json",
+    "contracts/schemas/rax_adversarial_pattern_candidate.schema.json",
+    "contracts/schemas/rax_control_readiness_record.schema.json",
+    "contracts/schemas/rax_drift_signal_record.schema.json",
+    "contracts/schemas/rax_failure_eval_candidate.schema.json",
+    "contracts/schemas/rax_failure_pattern_record.schema.json",
+    "contracts/schemas/rax_feedback_loop_record.schema.json",
+    "contracts/schemas/rax_health_snapshot.schema.json",
+    "contracts/schemas/rax_pre_certification_alignment_record.schema.json",
+    "contracts/schemas/rax_unknown_state_record.schema.json",
+    "contracts/standards-manifest.json",
+    "docs/architecture/rax_feedback_loop_hardening.md",
+    "docs/architecture/system_registry.md",
+    "docs/governance-reports/contract-enforcement-report.md",
+    "docs/review-actions/PLAN-RAX-FEEDBACK-LOOP-10-2026-04-12.md",
+    "governance/reports/contract-dependency-graph.json",
+    "spectrum_systems/modules/runtime/rax_assurance.py",
+    "spectrum_systems/modules/runtime/rax_eval_runner.py",
+    "tests/test_rax_eval_runner.py",
+    "tests/test_roadmap_expansion_contracts.py"
+  ],
+  "metadata": {
+    "requested_at": "2026-04-02T00:00:00Z",
+    "dependencies": [
+      "AI-00"
+    ],
+    "policy_version": "1.0.0",
+    "authority_notes": "governed wrapper example"
+  },
+  "pqx_execution_request": {
+    "schema_version": "1.1.0",
+    "run_id": "con-038-example",
+    "step_id": "AI-01",
+    "step_name": "Implement governed wrapper seam",
+    "dependencies": [
+      "AI-00"
+    ],
+    "requested_at": "2026-04-02T00:00:00Z",
+    "prompt": "Implement CON-038 deterministic wrapper layer",
+    "roadmap_version": "docs/roadmaps/system_roadmap.md",
+    "row_snapshot": {
+      "row_index": 0,
+      "step_id": "AI-01",
+      "step_name": "Implement governed wrapper seam",
+      "dependencies": [
+        "AI-00"
+      ],
+      "status": "ready"
+    }
+  }
+}

--- a/contracts/examples/rax_feedback_loop_record.json
+++ b/contracts/examples/rax_feedback_loop_record.json
@@ -1,0 +1,17 @@
+{
+  "artifact_type": "rax_feedback_loop_record",
+  "schema_version": "1.0.0",
+  "record_id": "feedback-loop-001",
+  "originating_failure_pattern_ref": "rax-failure-1111222233334444",
+  "fix_artifact_refs": [
+    "fix://rax/patch-01"
+  ],
+  "eval_artifact_refs_added": [
+    "rax-failure-1111222233334444:eval-candidate"
+  ],
+  "recurrence_detected": false,
+  "recurrence_window": "P14D",
+  "readiness_delta": 0.2,
+  "confidence_delta": 0.1,
+  "outcome_status": "non_recurrence_recorded"
+}

--- a/contracts/examples/rax_health_snapshot.json
+++ b/contracts/examples/rax_health_snapshot.json
@@ -1,0 +1,16 @@
+{
+  "artifact_type": "rax_health_snapshot",
+  "schema_version": "1.0.0",
+  "snapshot_id": "health-001",
+  "window_ref": "window://rax/2026-04-12",
+  "readiness_pass_rate": 0.95,
+  "eval_coverage_rate": 1.0,
+  "semantic_failure_rate": 0.0,
+  "readiness_bypass_attempt_rate": 0.0,
+  "replay_consistency_rate": 1.0,
+  "trace_completeness_rate": 1.0,
+  "lineage_validity_rate": 1.0,
+  "contradiction_rate": 0.0,
+  "candidate_posture": "healthy",
+  "threshold_violations": []
+}

--- a/contracts/examples/rax_pre_certification_alignment_record.json
+++ b/contracts/examples/rax_pre_certification_alignment_record.json
@@ -1,0 +1,16 @@
+{
+  "artifact_type": "rax_pre_certification_alignment_record",
+  "schema_version": "1.0.0",
+  "record_id": "precert-001",
+  "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
+  "eval_completeness_aligned": true,
+  "replay_consistency_aligned": true,
+  "trace_completeness_aligned": true,
+  "lineage_validity_aligned": true,
+  "fail_closed_aligned": true,
+  "semantic_correctness_aligned": true,
+  "ready_candidate_allowed": false,
+  "blocking_reasons": [
+    "downstream_certification_pending"
+  ]
+}

--- a/contracts/examples/rax_unknown_state_record.json
+++ b/contracts/examples/rax_unknown_state_record.json
@@ -1,0 +1,15 @@
+{
+  "artifact_type": "rax_unknown_state_record",
+  "schema_version": "1.0.0",
+  "record_id": "unknown-001",
+  "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
+  "unknown_reasons": [
+    "required_signal_missing"
+  ],
+  "candidate_ready": false,
+  "advancement_allowed": false,
+  "evidence_refs": [
+    "roadmap_step_contract:RAX-INTERFACE-24-01"
+  ],
+  "status": "unknown_blocking"
+}

--- a/contracts/schemas/rax_adversarial_pattern_candidate.schema.json
+++ b/contracts/schemas/rax_adversarial_pattern_candidate.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/rax_adversarial_pattern_candidate.schema.json",
+  "title": "RAX Adversarial Pattern Candidate",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "variant_id",
+    "seed",
+    "variant_class",
+    "target_ref",
+    "payload",
+    "consumable_by_eval"
+  ],
+  "properties": {
+    "artifact_type": {
+      "type": "string",
+      "const": "rax_adversarial_pattern_candidate"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "variant_id": {
+      "type": "string"
+    },
+    "seed": {
+      "type": "string"
+    },
+    "variant_class": {
+      "type": "string",
+      "enum": [
+        "schema_valid_semantic_boundary",
+        "mutated_literal_variant",
+        "nested_variant",
+        "cross_step_contamination_variant",
+        "partial_signal_contradiction"
+      ]
+    },
+    "target_ref": {
+      "type": "string"
+    },
+    "payload": {
+      "type": "object"
+    },
+    "consumable_by_eval": {
+      "type": "boolean"
+    }
+  }
+}

--- a/contracts/schemas/rax_control_readiness_record.schema.json
+++ b/contracts/schemas/rax_control_readiness_record.schema.json
@@ -18,21 +18,119 @@
     "missing_required_eval_types",
     "trace_complete",
     "baseline_regression_detected",
-    "version_authority_aligned"
+    "version_authority_aligned",
+    "conditions_under_which_ready_changes",
+    "unknown_state_ref",
+    "pre_certification_alignment_ref"
   ],
   "properties": {
-    "artifact_type": {"type": "string", "const": "rax_control_readiness_record"},
-    "schema_version": {"type": "string", "const": "1.0.0"},
-    "batch": {"type": "string", "minLength": 1},
-    "target_ref": {"type": "string", "minLength": 1},
-    "ready_for_control": {"type": "boolean"},
-    "decision": {"type": "string", "enum": ["ready", "hold", "block"]},
-    "blocking_reasons": {"type": "array", "items": {"type": "string", "minLength": 1}},
-    "required_eval_types": {"type": "array", "items": {"type": "string", "minLength": 1}, "minItems": 1},
-    "present_eval_types": {"type": "array", "items": {"type": "string", "minLength": 1}},
-    "missing_required_eval_types": {"type": "array", "items": {"type": "string", "minLength": 1}},
-    "trace_complete": {"type": "boolean"},
-    "baseline_regression_detected": {"type": "boolean"},
-    "version_authority_aligned": {"type": "boolean"}
+    "artifact_type": {
+      "type": "string",
+      "const": "rax_control_readiness_record"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "batch": {
+      "type": "string",
+      "minLength": 1
+    },
+    "target_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "ready_for_control": {
+      "type": "boolean"
+    },
+    "decision": {
+      "type": "string",
+      "enum": [
+        "ready",
+        "hold",
+        "block"
+      ]
+    },
+    "blocking_reasons": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "required_eval_types": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
+    },
+    "present_eval_types": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "missing_required_eval_types": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "trace_complete": {
+      "type": "boolean"
+    },
+    "baseline_regression_detected": {
+      "type": "boolean"
+    },
+    "version_authority_aligned": {
+      "type": "boolean"
+    },
+    "conditions_under_which_ready_changes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "condition_category",
+          "blocking_reason",
+          "evidence_refs",
+          "required_signal"
+        ],
+        "properties": {
+          "condition_category": {
+            "type": "string",
+            "minLength": 1
+          },
+          "blocking_reason": {
+            "type": "string",
+            "minLength": 1
+          },
+          "evidence_refs": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "minItems": 1
+          },
+          "required_signal": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "unknown_state_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "pre_certification_alignment_ref": {
+      "type": "string",
+      "minLength": 1
+    }
   }
 }

--- a/contracts/schemas/rax_drift_signal_record.schema.json
+++ b/contracts/schemas/rax_drift_signal_record.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/rax_drift_signal_record.schema.json",
+  "title": "RAX Drift Signal Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "signal_id",
+    "baseline_window_ref",
+    "current_window_ref",
+    "eval_signal_drift",
+    "readiness_outcome_drift",
+    "semantic_classification_drift",
+    "version_authority_drift",
+    "trace_lineage_completeness_drift",
+    "candidate_posture",
+    "threshold_exceeded"
+  ],
+  "properties": {
+    "artifact_type": {
+      "type": "string",
+      "const": "rax_drift_signal_record"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "signal_id": {
+      "type": "string"
+    },
+    "baseline_window_ref": {
+      "type": "string"
+    },
+    "current_window_ref": {
+      "type": "string"
+    },
+    "eval_signal_drift": {
+      "type": "number",
+      "minimum": 0
+    },
+    "readiness_outcome_drift": {
+      "type": "number",
+      "minimum": 0
+    },
+    "semantic_classification_drift": {
+      "type": "number",
+      "minimum": 0
+    },
+    "version_authority_drift": {
+      "type": "number",
+      "minimum": 0
+    },
+    "trace_lineage_completeness_drift": {
+      "type": "number",
+      "minimum": 0
+    },
+    "candidate_posture": {
+      "type": "string",
+      "enum": [
+        "healthy",
+        "freeze_candidate",
+        "block_candidate"
+      ]
+    },
+    "threshold_exceeded": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/contracts/schemas/rax_failure_eval_candidate.schema.json
+++ b/contracts/schemas/rax_failure_eval_candidate.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/rax_failure_eval_candidate.schema.json",
+  "title": "RAX Failure Eval Candidate",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "candidate_id",
+    "source_failure_id",
+    "eval_case_id",
+    "eval_type",
+    "target_ref",
+    "expected_status",
+    "reason_codes",
+    "trace_id",
+    "version",
+    "dedupe_key",
+    "generation_status"
+  ],
+  "properties": {
+    "artifact_type": {
+      "type": "string",
+      "const": "rax_failure_eval_candidate"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "candidate_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source_failure_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "eval_case_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "eval_type": {
+      "type": "string",
+      "minLength": 1
+    },
+    "target_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "expected_status": {
+      "type": "string",
+      "enum": [
+        "fail",
+        "pass"
+      ]
+    },
+    "reason_codes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "dedupe_key": {
+      "type": "string",
+      "minLength": 1
+    },
+    "generation_status": {
+      "type": "string",
+      "enum": [
+        "generated",
+        "duplicate"
+      ]
+    }
+  }
+}

--- a/contracts/schemas/rax_failure_pattern_record.schema.json
+++ b/contracts/schemas/rax_failure_pattern_record.schema.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/rax_failure_pattern_record.schema.json",
+  "title": "RAX Failure Pattern Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "failure_id",
+    "source_artifact_refs",
+    "failure_classification",
+    "failure_details",
+    "semantic_category",
+    "trace_linkage",
+    "reproducibility_inputs",
+    "candidate_eval_generation_status"
+  ],
+  "properties": {
+    "artifact_type": {
+      "type": "string",
+      "const": "rax_failure_pattern_record"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "failure_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source_artifact_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
+    },
+    "failure_classification": {
+      "type": "string",
+      "minLength": 1
+    },
+    "failure_details": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
+    },
+    "semantic_category": {
+      "type": "string",
+      "enum": [
+        "semantic_contradiction",
+        "weak_acceptance_check",
+        "missing_trace",
+        "lineage_invalid",
+        "dependency_corruption",
+        "over_expansion",
+        "replay_inconsistency",
+        "readiness_contradiction"
+      ]
+    },
+    "trace_linkage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "target_ref",
+        "trace_id",
+        "linked_refs"
+      ],
+      "properties": {
+        "target_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "trace_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "linked_refs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1
+        }
+      }
+    },
+    "reproducibility_inputs": {
+      "type": "object"
+    },
+    "candidate_eval_generation_status": {
+      "type": "string",
+      "enum": [
+        "generated",
+        "already_exists"
+      ]
+    }
+  }
+}

--- a/contracts/schemas/rax_feedback_loop_record.schema.json
+++ b/contracts/schemas/rax_feedback_loop_record.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/rax_feedback_loop_record.schema.json",
+  "title": "RAX Feedback Loop Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "record_id",
+    "originating_failure_pattern_ref",
+    "fix_artifact_refs",
+    "eval_artifact_refs_added",
+    "recurrence_detected",
+    "recurrence_window",
+    "readiness_delta",
+    "confidence_delta",
+    "outcome_status"
+  ],
+  "properties": {
+    "artifact_type": {
+      "type": "string",
+      "const": "rax_feedback_loop_record"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "record_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "originating_failure_pattern_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "fix_artifact_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "eval_artifact_refs_added": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "recurrence_detected": {
+      "type": "boolean"
+    },
+    "recurrence_window": {
+      "type": "string",
+      "minLength": 1
+    },
+    "readiness_delta": {
+      "type": "number"
+    },
+    "confidence_delta": {
+      "type": "number"
+    },
+    "outcome_status": {
+      "type": "string",
+      "enum": [
+        "recurrence_detected",
+        "non_recurrence_recorded"
+      ]
+    }
+  }
+}

--- a/contracts/schemas/rax_health_snapshot.schema.json
+++ b/contracts/schemas/rax_health_snapshot.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/rax_health_snapshot.schema.json",
+  "title": "RAX Health Snapshot",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "snapshot_id",
+    "window_ref",
+    "readiness_pass_rate",
+    "eval_coverage_rate",
+    "semantic_failure_rate",
+    "readiness_bypass_attempt_rate",
+    "replay_consistency_rate",
+    "trace_completeness_rate",
+    "lineage_validity_rate",
+    "contradiction_rate",
+    "candidate_posture",
+    "threshold_violations"
+  ],
+  "properties": {
+    "artifact_type": {
+      "type": "string",
+      "const": "rax_health_snapshot"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "snapshot_id": {
+      "type": "string"
+    },
+    "window_ref": {
+      "type": "string"
+    },
+    "readiness_pass_rate": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "eval_coverage_rate": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "semantic_failure_rate": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "readiness_bypass_attempt_rate": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "replay_consistency_rate": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "trace_completeness_rate": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "lineage_validity_rate": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "contradiction_rate": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "candidate_posture": {
+      "type": "string",
+      "enum": [
+        "healthy",
+        "warn",
+        "freeze_candidate",
+        "block_candidate"
+      ]
+    },
+    "threshold_violations": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/contracts/schemas/rax_pre_certification_alignment_record.schema.json
+++ b/contracts/schemas/rax_pre_certification_alignment_record.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/rax_pre_certification_alignment_record.schema.json",
+  "title": "RAX Pre Certification Alignment Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "record_id",
+    "target_ref",
+    "eval_completeness_aligned",
+    "replay_consistency_aligned",
+    "trace_completeness_aligned",
+    "lineage_validity_aligned",
+    "fail_closed_aligned",
+    "semantic_correctness_aligned",
+    "ready_candidate_allowed",
+    "blocking_reasons"
+  ],
+  "properties": {
+    "artifact_type": {
+      "type": "string",
+      "const": "rax_pre_certification_alignment_record"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "record_id": {
+      "type": "string"
+    },
+    "target_ref": {
+      "type": "string"
+    },
+    "eval_completeness_aligned": {
+      "type": "boolean"
+    },
+    "replay_consistency_aligned": {
+      "type": "boolean"
+    },
+    "trace_completeness_aligned": {
+      "type": "boolean"
+    },
+    "lineage_validity_aligned": {
+      "type": "boolean"
+    },
+    "fail_closed_aligned": {
+      "type": "boolean"
+    },
+    "semantic_correctness_aligned": {
+      "type": "boolean"
+    },
+    "ready_candidate_allowed": {
+      "type": "boolean"
+    },
+    "blocking_reasons": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/contracts/schemas/rax_unknown_state_record.schema.json
+++ b/contracts/schemas/rax_unknown_state_record.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/rax_unknown_state_record.schema.json",
+  "title": "RAX Unknown State Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "record_id",
+    "target_ref",
+    "unknown_reasons",
+    "candidate_ready",
+    "advancement_allowed",
+    "evidence_refs",
+    "status"
+  ],
+  "properties": {
+    "artifact_type": {
+      "type": "string",
+      "const": "rax_unknown_state_record"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "record_id": {
+      "type": "string"
+    },
+    "target_ref": {
+      "type": "string"
+    },
+    "unknown_reasons": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "candidate_ready": {
+      "type": "boolean"
+    },
+    "advancement_allowed": {
+      "type": "boolean"
+    },
+    "evidence_refs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "known",
+        "unknown_blocking"
+      ]
+    }
+  }
+}

--- a/contracts/standards-manifest.json
+++ b/contracts/standards-manifest.json
@@ -4779,9 +4779,113 @@
         "spectrum-systems"
       ],
       "introduced_in": "1.3.113",
-      "last_updated_in": "1.3.113",
+      "last_updated_in": "1.3.114",
       "example_path": "contracts/examples/rax_control_readiness_record.json",
-      "notes": "RAX-EVAL-01 bounded readiness artifact for downstream control consumption; fail-closed on missing required evals."
+      "notes": "RAX-FEEDBACK-LOOP-10 bounded readiness artifact with structured readiness-change conditions, unknown-state linkage, and pre-certification alignment references."
+    },
+    {
+      "artifact_type": "rax_failure_pattern_record",
+      "artifact_class": "governance",
+      "schema_version": "1.0.0",
+      "status": "active",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.114",
+      "last_updated_in": "1.3.114",
+      "example_path": "contracts/examples/rax_failure_pattern_record.json",
+      "notes": "RAX feedback-loop failure capture artifact linking classified failures to reproducibility and trace references."
+    },
+    {
+      "artifact_type": "rax_failure_eval_candidate",
+      "artifact_class": "governance",
+      "schema_version": "1.0.0",
+      "status": "active",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.114",
+      "last_updated_in": "1.3.114",
+      "example_path": "contracts/examples/rax_failure_eval_candidate.json",
+      "notes": "RAX failure-derived eval candidate artifact generated deterministically from governed failure classes."
+    },
+    {
+      "artifact_type": "rax_feedback_loop_record",
+      "artifact_class": "governance",
+      "schema_version": "1.0.0",
+      "status": "active",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.114",
+      "last_updated_in": "1.3.114",
+      "example_path": "contracts/examples/rax_feedback_loop_record.json",
+      "notes": "RAX closure artifact linking failure, fix, eval coverage additions, and recurrence outcomes."
+    },
+    {
+      "artifact_type": "rax_health_snapshot",
+      "artifact_class": "governance",
+      "schema_version": "1.0.0",
+      "status": "active",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.114",
+      "last_updated_in": "1.3.114",
+      "example_path": "contracts/examples/rax_health_snapshot.json",
+      "notes": "RAX health metrics snapshot with SLO-style threshold posture as candidate signal only."
+    },
+    {
+      "artifact_type": "rax_drift_signal_record",
+      "artifact_class": "governance",
+      "schema_version": "1.0.0",
+      "status": "active",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.114",
+      "last_updated_in": "1.3.114",
+      "example_path": "contracts/examples/rax_drift_signal_record.json",
+      "notes": "RAX drift signal artifact comparing current and baseline windows across governed drift surfaces."
+    },
+    {
+      "artifact_type": "rax_unknown_state_record",
+      "artifact_class": "governance",
+      "schema_version": "1.0.0",
+      "status": "active",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.114",
+      "last_updated_in": "1.3.114",
+      "example_path": "contracts/examples/rax_unknown_state_record.json",
+      "notes": "RAX explicit unknown-state artifact enforcing fail-closed non-readiness when basis is incomplete or contradictory."
+    },
+    {
+      "artifact_type": "rax_pre_certification_alignment_record",
+      "artifact_class": "governance",
+      "schema_version": "1.0.0",
+      "status": "active",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.114",
+      "last_updated_in": "1.3.114",
+      "example_path": "contracts/examples/rax_pre_certification_alignment_record.json",
+      "notes": "RAX pre-certification alignment artifact for downstream promotion rigor checks without granting certification authority."
+    },
+    {
+      "artifact_type": "rax_adversarial_pattern_candidate",
+      "artifact_class": "governance",
+      "schema_version": "1.0.0",
+      "status": "active",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.114",
+      "last_updated_in": "1.3.114",
+      "example_path": "contracts/examples/rax_adversarial_pattern_candidate.json",
+      "notes": "RAX deterministic adversarial pattern candidate artifact for governed eval/regression consumption."
     }
   ]
 }

--- a/docs/architecture/rax_feedback_loop_hardening.md
+++ b/docs/architecture/rax_feedback_loop_hardening.md
@@ -1,0 +1,23 @@
+# RAX Feedback-Loop Hardening (RAX-FEEDBACK-LOOP-10)
+
+RAX now emits a governed, trace-linked feedback loop while remaining non-authoritative.
+
+## What changed
+- Failures now produce `rax_failure_pattern_record` and deterministic `rax_failure_eval_candidate` artifacts.
+- RAX emits `rax_feedback_loop_record` to link failure -> fix -> added eval coverage -> recurrence/non-recurrence outcome.
+- RAX emits candidate-only health (`rax_health_snapshot`) and drift (`rax_drift_signal_record`) posture artifacts.
+- RAX emits explicit fail-closed unknown state (`rax_unknown_state_record`) and pre-certification alignment (`rax_pre_certification_alignment_record`) artifacts.
+- Readiness artifacts now include `conditions_under_which_ready_changes` with structured reason/evidence linkage.
+
+## Boundary guardrails
+- RAX remains bounded and non-authoritative.
+- RAX emits candidate artifacts and signals only.
+- Downstream control/certification remains authoritative for progression and promotion.
+- Unknown state can never be candidate-ready or ready-for-control.
+
+## Feedback-loop graph
+1. Failure detected (`rax_failure_pattern_record`)
+2. Eval candidate generated (`rax_failure_eval_candidate`)
+3. Fix and coverage linked (`rax_feedback_loop_record`)
+4. Health/drift/unknown/pre-cert signals emitted
+5. `rax_control_readiness_record` derived with structured readiness-change conditions

--- a/docs/architecture/system_registry.md
+++ b/docs/architecture/system_registry.md
@@ -543,3 +543,16 @@ flowchart LR
     THR --> TPA[TPA]
     TPA --> PQX[PQX]
 ```
+
+
+## RAX governed boundary note
+- RAX is a bounded runtime interface surface that can emit candidate artifacts only:
+  - `rax_failure_pattern_record`
+  - `rax_failure_eval_candidate`
+  - `rax_feedback_loop_record`
+  - `rax_health_snapshot`
+  - `rax_drift_signal_record`
+  - `rax_unknown_state_record`
+  - `rax_pre_certification_alignment_record`
+  - `rax_control_readiness_record`
+- RAX must remain non-authoritative; downstream control and certification ownership remains unchanged (SEL/CDE/PQX/TLC by existing registry boundaries).

--- a/docs/governance-reports/contract-enforcement-report.md
+++ b/docs/governance-reports/contract-enforcement-report.md
@@ -1,6 +1,6 @@
 # Cross-Repo Contract Enforcement Report
 
-Generated: 2026-04-09T20:43:40Z
+Generated: 2026-04-12T03:02:08Z
 Source: `contracts/standards-manifest.json`
 
 ## Summary

--- a/docs/review-actions/PLAN-RAX-FEEDBACK-LOOP-10-2026-04-12.md
+++ b/docs/review-actions/PLAN-RAX-FEEDBACK-LOOP-10-2026-04-12.md
@@ -1,0 +1,61 @@
+# Plan — RAX-FEEDBACK-LOOP-10 — 2026-04-12
+
+## Prompt type
+PLAN
+
+## Roadmap item
+RAX-FEEDBACK-LOOP-10
+
+## Objective
+Add governed, fail-closed RAX feedback-loop artifacts and enforcement so failures deterministically produce eval candidates, health/drift/unknown-state candidate posture signals, and structured readiness-change conditions.
+
+## Declared files
+
+| File | Change type | Reason |
+| --- | --- | --- |
+| docs/review-actions/PLAN-RAX-FEEDBACK-LOOP-10-2026-04-12.md | CREATE | Required multi-file execution plan before BUILD changes. |
+| spectrum_systems/modules/runtime/rax_eval_runner.py | MODIFY | Implement failure->eval generation, feedback-loop closure, health/drift/unknown-state detection, adversarial generation, pre-cert alignment, and readiness condition wiring. |
+| spectrum_systems/modules/runtime/rax_assurance.py | MODIFY | Harden entry-boundary validation and counter-evidence enforcement alignment. |
+| config/policy/rax_eval_policy.json | MODIFY | Add governed thresholds and drift/adversarial configuration for health and posture candidate outputs. |
+| contracts/schemas/rax_control_readiness_record.schema.json | MODIFY | Extend readiness artifact to support structured readiness-change conditions and linked governed signals. |
+| contracts/schemas/rax_failure_pattern_record.schema.json | CREATE | Governed artifact schema for failure pattern capture. |
+| contracts/schemas/rax_failure_eval_candidate.schema.json | CREATE | Governed artifact schema for failure-derived eval candidates. |
+| contracts/schemas/rax_feedback_loop_record.schema.json | CREATE | Governed linkage artifact schema for failure->fix->coverage recurrence tracking. |
+| contracts/schemas/rax_health_snapshot.schema.json | CREATE | Governed health metric snapshot and candidate posture schema. |
+| contracts/schemas/rax_drift_signal_record.schema.json | CREATE | Governed drift signal detection and posture candidate schema. |
+| contracts/schemas/rax_unknown_state_record.schema.json | CREATE | Governed unknown-state fail-closed artifact schema. |
+| contracts/schemas/rax_pre_certification_alignment_record.schema.json | CREATE | Governed pre-certification alignment candidate schema. |
+| contracts/schemas/rax_adversarial_pattern_candidate.schema.json | CREATE | Governed deterministic adversarial pattern candidate schema. |
+| contracts/examples/rax_control_readiness_record.json | MODIFY | Keep readiness example aligned with extended schema fields. |
+| contracts/examples/rax_failure_pattern_record.json | CREATE | Canonical example for failure pattern artifact. |
+| contracts/examples/rax_failure_eval_candidate.json | CREATE | Canonical example for failure-derived eval candidate artifact. |
+| contracts/examples/rax_feedback_loop_record.json | CREATE | Canonical example for feedback-loop closure artifact. |
+| contracts/examples/rax_health_snapshot.json | CREATE | Canonical example for health metrics artifact. |
+| contracts/examples/rax_drift_signal_record.json | CREATE | Canonical example for drift signal artifact. |
+| contracts/examples/rax_unknown_state_record.json | CREATE | Canonical example for unknown-state artifact. |
+| contracts/examples/rax_pre_certification_alignment_record.json | CREATE | Canonical example for pre-cert alignment artifact. |
+| contracts/examples/rax_adversarial_pattern_candidate.json | CREATE | Canonical example for adversarial pattern candidate artifact. |
+| contracts/standards-manifest.json | MODIFY | Register and version new/updated RAX governed artifacts. |
+| docs/architecture/system_registry.md | MODIFY | Document RAX bounded/non-authoritative feedback-loop signal roles and interfaces. |
+| docs/architecture/rax_feedback_loop_hardening.md | CREATE | Concise design note for the new RAX feedback-loop hardening model. |
+| tests/test_rax_eval_runner.py | MODIFY | Add deterministic unit coverage for all new RAX feedback-loop capabilities. |
+| tests/test_roadmap_expansion_contracts.py | MODIFY | Add schema/example validation coverage for new RAX artifacts. |
+
+## Contracts touched
+- `rax_control_readiness_record` (additive schema update)
+- New contracts: `rax_failure_pattern_record`, `rax_failure_eval_candidate`, `rax_feedback_loop_record`, `rax_health_snapshot`, `rax_drift_signal_record`, `rax_unknown_state_record`, `rax_pre_certification_alignment_record`, `rax_adversarial_pattern_candidate`
+- `contracts/standards-manifest.json` version updates for the above
+
+## Tests that must pass after execution
+1. `pytest tests/test_rax_eval_runner.py tests/test_roadmap_expansion_contracts.py`
+2. `pytest tests/test_contracts.py tests/test_contract_enforcement.py`
+3. `python scripts/run_contract_enforcement.py`
+4. `pytest tests/test_module_architecture.py`
+
+## Scope exclusions
+- Do not redesign broader system architecture or authority boundaries.
+- Do not create new 3-letter systems or move control authority into RAX.
+- Do not modify unrelated modules outside runtime RAX and immediate governed interfaces.
+
+## Dependencies
+- Existing RAX interface/eval slices (`RAX-INTERFACE-24-01`, `RAX-EVAL-01`) remain the substrate and must stay backward compatible at authority boundaries.

--- a/governance/reports/contract-dependency-graph.json
+++ b/governance/reports/contract-dependency-graph.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0.0",
-  "generated_at": "2026-04-09T20:43:40Z",
+  "generated_at": "2026-04-12T03:02:08Z",
   "source_manifest": "contracts/standards-manifest.json",
   "repos": [
     {

--- a/spectrum_systems/modules/runtime/rax_assurance.py
+++ b/spectrum_systems/modules/runtime/rax_assurance.py
@@ -54,6 +54,30 @@ _NON_OPERATIONAL_ACCEPTANCE_PHRASES = (
 )
 _DEPENDENCY_ID_PATTERN = re.compile(r"^RAX-INTERFACE-\d{2}-\d{2}$")
 
+_COUNTER_EVIDENCE_PLACEHOLDERS = {
+    "n/a",
+    "none",
+    "unknown",
+    "placeholder",
+    "generic",
+    "tbd",
+    "todo",
+}
+
+_ENTRY_REQUIRED_FIELDS = {
+    "artifact_type",
+    "step_id",
+    "owner",
+    "intent",
+    "depends_on",
+    "roadmap_group",
+    "source_authority_ref",
+    "source_version",
+    "input_freshness_ref",
+    "input_provenance_ref",
+}
+
+
 _DEFAULT_SOURCE_VERSION_AUTHORITY = {
     "docs/roadmaps/system_roadmap.md#RAX-INTERFACE-24-01": "1.3.112",
 }
@@ -154,12 +178,22 @@ def assure_rax_input(
     details: list[str] = []
     failure_classification = "none"
 
-    try:
-        validate_artifact(payload, "rax_upstream_input_envelope")
-        details.append("upstream schema validation passed")
-    except Exception as exc:  # fail-closed by classifying invalid input
+    missing_required_fields = sorted(field for field in _ENTRY_REQUIRED_FIELDS if field not in payload)
+    if missing_required_fields:
         failure_classification = "invalid_input"
-        details.append(f"schema validation failed: {exc}")
+        details.append(f"entry_contract_missing_required_fields: {missing_required_fields}")
+
+    if failure_classification == "none" and payload.get("artifact_type") != "rax_upstream_input_envelope":
+        failure_classification = "invalid_input"
+        details.append("entry_contract_invalid_artifact_type")
+
+    if failure_classification == "none":
+        try:
+            validate_artifact(payload, "rax_upstream_input_envelope")
+            details.append("upstream schema validation passed")
+        except Exception as exc:  # fail-closed by classifying invalid input
+            failure_classification = "invalid_input"
+            details.append(f"schema validation failed: {exc}")
 
     if failure_classification == "none":
         intent = payload["intent"]
@@ -231,6 +265,7 @@ def assure_rax_input(
         if trace is None:
             failure_classification = "trace_tampering"
             details.append("missing_required_expansion_trace")
+            details.append("entry_contract_trace_presence_required")
         else:
             trace_issues = _validate_expansion_trace(trace, expected_policy_hash=expected_policy_hash, step_id=payload["step_id"])
             if trace_issues:
@@ -408,10 +443,11 @@ def build_rax_assurance_audit_record(
 
     counter_evidence: list[str] = []
     if failure_classification != "none":
-        counter_evidence.extend(str(item) for item in input_assurance.get("details", []) if item)
-        counter_evidence.extend(str(item) for item in output_assurance.get("details", []) if item)
+        counter_evidence.extend(str(item).strip() for item in input_assurance.get("details", []) if str(item).strip())
+        counter_evidence.extend(str(item).strip() for item in output_assurance.get("details", []) if str(item).strip())
+        counter_evidence = [item for item in counter_evidence if item.lower() not in _COUNTER_EVIDENCE_PLACEHOLDERS]
         if not counter_evidence:
-            counter_evidence.append(f"failure_detected:{failure_classification}")
+            raise RAXAssuranceError("counter_evidence required and must be concrete when failures exist")
 
     stop_condition_triggered = failure_classification != "none"
 

--- a/spectrum_systems/modules/runtime/rax_eval_runner.py
+++ b/spectrum_systems/modules/runtime/rax_eval_runner.py
@@ -2,14 +2,45 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
+from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
 from spectrum_systems.contracts import load_example, validate_artifact
 
 RUNNER_NAME = "rax_eval_runner"
-RUNNER_VERSION = "1.0.0"
+RUNNER_VERSION = "1.1.0"
+
+_FAILURE_TO_EVAL_TYPE = {
+    "semantic_contradiction": "rax_output_semantic_alignment",
+    "weak_acceptance_check": "rax_acceptance_check_strength",
+    "missing_trace": "rax_trace_integrity",
+    "lineage_invalid": "rax_trace_integrity",
+    "dependency_corruption": "rax_control_readiness",
+    "over_expansion": "rax_output_semantic_alignment",
+    "replay_inconsistency": "rax_control_readiness",
+    "readiness_contradiction": "rax_control_readiness",
+}
+
+_REASON_TO_SEMANTIC_CATEGORY = {
+    "semantic_intent_insufficient": "semantic_contradiction",
+    "owner_intent_contradiction": "semantic_contradiction",
+    "normalization_ambiguity": "semantic_contradiction",
+    "semantic_target_mismatch": "semantic_contradiction",
+    "weak_acceptance_check": "weak_acceptance_check",
+    "missing_required_expansion_trace": "missing_trace",
+    "artifact_not_trace_linked": "missing_trace",
+    "trace_incomplete": "missing_trace",
+    "artifact_lineage_invalid": "lineage_invalid",
+    "dependency_graph_corrupt": "dependency_corruption",
+    "dependency_graph_unresolved": "dependency_corruption",
+    "output_over_expanded": "over_expansion",
+    "cross_run_eval_signal_inconsistency": "replay_inconsistency",
+    "tests_pass_eval_fail": "readiness_contradiction",
+    "contradictory_eval_signals": "readiness_contradiction",
+}
 
 
 def _repo_root() -> Path:
@@ -76,8 +107,6 @@ def _canonical_eval_signal(eval_results: list[dict[str, Any]]) -> tuple[str, ...
     return tuple(sorted(rows))
 
 
-
-
 def _trace_lineage_from_eval_results(*, eval_results: list[dict[str, Any]], target_ref: str, expected_trace_id: str | None) -> dict[str, bool]:
     trace_linked = True
     trace_complete = True
@@ -91,11 +120,282 @@ def _trace_lineage_from_eval_results(*, eval_results: list[dict[str, Any]], targ
             trace_complete = False
     return {"trace_linked": trace_linked, "trace_complete": trace_complete}
 
+
 def _critical_failure_classification(value: Any) -> bool:
     if not isinstance(value, str):
         return False
     normalized = value.strip().lower()
     return bool(normalized and normalized not in {"none", "pass", "ok"})
+
+
+def _make_failure_id(*, run_id: str, semantic_category: str, reason_codes: list[str], target_ref: str) -> str:
+    digest = hashlib.sha256(f"{run_id}|{semantic_category}|{target_ref}|{','.join(sorted(reason_codes))}".encode("utf-8")).hexdigest()[:16]
+    return f"rax-failure-{digest}"
+
+
+def _classify_failure(*, reason_codes: list[str], failure_classification: str | None) -> tuple[str, str]:
+    for code in reason_codes:
+        semantic = _REASON_TO_SEMANTIC_CATEGORY.get(code)
+        if semantic:
+            return failure_classification or "runtime_failure", semantic
+    normalized = (failure_classification or "runtime_failure").strip().lower()
+    return normalized, "semantic_contradiction"
+
+
+def _dedupe_eval_candidates(candidates: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    uniq: dict[str, dict[str, Any]] = {}
+    for candidate in candidates:
+        uniq[candidate["candidate_id"]] = candidate
+    return [uniq[key] for key in sorted(uniq)]
+
+
+def generate_failure_eval_artifacts(
+    *,
+    run_id: str,
+    target_ref: str,
+    trace_id: str,
+    source_artifact_refs: list[str],
+    reason_codes: list[str],
+    failure_classification: str | None,
+    reproducibility_inputs: dict[str, Any],
+    existing_candidate_ids: set[str] | None = None,
+) -> dict[str, Any]:
+    """Generate failure pattern and deterministic eval candidate artifacts from failures."""
+    if not reason_codes and not _critical_failure_classification(failure_classification):
+        return {"failure_pattern_records": [], "eval_case_candidates": []}
+
+    failure_class, semantic_category = _classify_failure(reason_codes=reason_codes, failure_classification=failure_classification)
+    failure_id = _make_failure_id(run_id=run_id, semantic_category=semantic_category, reason_codes=reason_codes, target_ref=target_ref)
+    candidate_eval_type = _FAILURE_TO_EVAL_TYPE.get(semantic_category, "rax_control_readiness")
+    candidate_id = f"{failure_id}:eval-candidate"
+    deduped = existing_candidate_ids is not None and candidate_id in existing_candidate_ids
+
+    pattern_record = {
+        "artifact_type": "rax_failure_pattern_record",
+        "schema_version": "1.0.0",
+        "failure_id": failure_id,
+        "source_artifact_refs": sorted(set(source_artifact_refs + [target_ref, f"trace://{trace_id}"])),
+        "failure_classification": failure_class,
+        "failure_details": sorted(set(reason_codes)) or ["unclassified_failure"],
+        "semantic_category": semantic_category,
+        "trace_linkage": {
+            "target_ref": target_ref,
+            "trace_id": trace_id,
+            "linked_refs": sorted(set(source_artifact_refs + [target_ref, f"trace://{trace_id}"])),
+        },
+        "reproducibility_inputs": reproducibility_inputs,
+        "candidate_eval_generation_status": "already_exists" if deduped else "generated",
+    }
+    validate_artifact(pattern_record, "rax_failure_pattern_record")
+
+    eval_candidate = {
+        "artifact_type": "rax_failure_eval_candidate",
+        "schema_version": "1.0.0",
+        "candidate_id": candidate_id,
+        "source_failure_id": failure_id,
+        "eval_case_id": f"{run_id}:{candidate_eval_type}:{failure_id}",
+        "eval_type": candidate_eval_type,
+        "target_ref": target_ref,
+        "expected_status": "fail",
+        "reason_codes": sorted(set(reason_codes)) or ["unclassified_failure"],
+        "trace_id": trace_id,
+        "version": "1.0.0",
+        "dedupe_key": f"{semantic_category}|{target_ref}|{candidate_eval_type}",
+        "generation_status": "duplicate" if deduped else "generated",
+    }
+    validate_artifact(eval_candidate, "rax_failure_eval_candidate")
+
+    candidates = [] if deduped else [eval_candidate]
+    return {"failure_pattern_records": [pattern_record], "eval_case_candidates": _dedupe_eval_candidates(candidates)}
+
+
+def build_feedback_loop_record(
+    *,
+    record_id: str,
+    originating_failure_pattern_ref: str,
+    fix_artifact_refs: list[str],
+    eval_artifact_refs_added: list[str],
+    historical_failure_classes: list[str],
+    current_failure_class: str,
+    recurrence_window: str,
+    readiness_delta: float,
+    confidence_delta: float,
+) -> dict[str, Any]:
+    recurrence = current_failure_class in historical_failure_classes
+    outcome_status = "recurrence_detected" if recurrence else "non_recurrence_recorded"
+    record = {
+        "artifact_type": "rax_feedback_loop_record",
+        "schema_version": "1.0.0",
+        "record_id": record_id,
+        "originating_failure_pattern_ref": originating_failure_pattern_ref,
+        "fix_artifact_refs": sorted(set(fix_artifact_refs)),
+        "eval_artifact_refs_added": sorted(set(eval_artifact_refs_added)),
+        "recurrence_detected": recurrence,
+        "recurrence_window": recurrence_window,
+        "readiness_delta": readiness_delta,
+        "confidence_delta": confidence_delta,
+        "outcome_status": outcome_status,
+    }
+    validate_artifact(record, "rax_feedback_loop_record")
+    return record
+
+
+def build_rax_health_snapshot(
+    *,
+    snapshot_id: str,
+    window_ref: str,
+    metrics: dict[str, float],
+    thresholds: dict[str, dict[str, float]],
+) -> dict[str, Any]:
+    severity = "healthy"
+    violations: list[str] = []
+    for metric_name, value in metrics.items():
+        bounds = thresholds.get(metric_name, {})
+        if "warn_max" in bounds:
+            warn_max = float(bounds.get("warn_max", 1.0))
+            freeze_max = float(bounds.get("freeze_candidate_max", 1.0))
+            block_max = float(bounds.get("block_candidate_max", 1.0))
+            if value > block_max:
+                severity = "block_candidate"
+                violations.append(f"{metric_name}:block")
+            elif value > freeze_max and severity != "block_candidate":
+                severity = "freeze_candidate"
+                violations.append(f"{metric_name}:freeze")
+            elif value > warn_max and severity not in {"block_candidate", "freeze_candidate"}:
+                severity = "warn"
+                violations.append(f"{metric_name}:warn")
+        else:
+            warn_min = float(bounds.get("warn_min", 0.0))
+            freeze_min = float(bounds.get("freeze_candidate_min", 0.0))
+            block_min = float(bounds.get("block_candidate_min", 0.0))
+            if value < block_min:
+                severity = "block_candidate"
+                violations.append(f"{metric_name}:block")
+            elif value < freeze_min and severity != "block_candidate":
+                severity = "freeze_candidate"
+                violations.append(f"{metric_name}:freeze")
+            elif value < warn_min and severity not in {"block_candidate", "freeze_candidate"}:
+                severity = "warn"
+                violations.append(f"{metric_name}:warn")
+
+    snapshot = {
+        "artifact_type": "rax_health_snapshot",
+        "schema_version": "1.0.0",
+        "snapshot_id": snapshot_id,
+        "window_ref": window_ref,
+        "readiness_pass_rate": metrics["readiness_pass_rate"],
+        "eval_coverage_rate": metrics["eval_coverage_rate"],
+        "semantic_failure_rate": metrics["semantic_failure_rate"],
+        "readiness_bypass_attempt_rate": metrics["readiness_bypass_attempt_rate"],
+        "replay_consistency_rate": metrics["replay_consistency_rate"],
+        "trace_completeness_rate": metrics["trace_completeness_rate"],
+        "lineage_validity_rate": metrics["lineage_validity_rate"],
+        "contradiction_rate": metrics["contradiction_rate"],
+        "candidate_posture": severity,
+        "threshold_violations": sorted(violations),
+    }
+    validate_artifact(snapshot, "rax_health_snapshot")
+    return snapshot
+
+
+def build_rax_drift_signal_record(
+    *,
+    signal_id: str,
+    baseline_window_ref: str,
+    current_window_ref: str,
+    baseline_metrics: dict[str, float],
+    current_metrics: dict[str, float],
+    drift_thresholds: dict[str, float],
+) -> dict[str, Any]:
+    surfaces = {
+        "eval_signal_drift": abs(current_metrics["eval_coverage_rate"] - baseline_metrics["eval_coverage_rate"]),
+        "readiness_outcome_drift": abs(current_metrics["readiness_pass_rate"] - baseline_metrics["readiness_pass_rate"]),
+        "semantic_classification_drift": abs(current_metrics["semantic_failure_rate"] - baseline_metrics["semantic_failure_rate"]),
+        "version_authority_drift": abs((1.0 - current_metrics["lineage_validity_rate"]) - (1.0 - baseline_metrics["lineage_validity_rate"])),
+        "trace_lineage_completeness_drift": abs(current_metrics["trace_completeness_rate"] - baseline_metrics["trace_completeness_rate"]),
+    }
+
+    posture = "healthy"
+    exceeded: list[str] = []
+    for key, drift in surfaces.items():
+        threshold = float(drift_thresholds.get(key, 1.0))
+        if drift > threshold * 1.5:
+            posture = "block_candidate"
+            exceeded.append(f"{key}:block")
+        elif drift > threshold and posture != "block_candidate":
+            posture = "freeze_candidate"
+            exceeded.append(f"{key}:freeze")
+
+    record = {
+        "artifact_type": "rax_drift_signal_record",
+        "schema_version": "1.0.0",
+        "signal_id": signal_id,
+        "baseline_window_ref": baseline_window_ref,
+        "current_window_ref": current_window_ref,
+        "eval_signal_drift": surfaces["eval_signal_drift"],
+        "readiness_outcome_drift": surfaces["readiness_outcome_drift"],
+        "semantic_classification_drift": surfaces["semantic_classification_drift"],
+        "version_authority_drift": surfaces["version_authority_drift"],
+        "trace_lineage_completeness_drift": surfaces["trace_lineage_completeness_drift"],
+        "candidate_posture": posture,
+        "threshold_exceeded": sorted(exceeded),
+    }
+    validate_artifact(record, "rax_drift_signal_record")
+    return record
+
+
+def build_rax_unknown_state_record(
+    *,
+    record_id: str,
+    target_ref: str,
+    unknown_reasons: list[str],
+    evidence_refs: list[str],
+) -> dict[str, Any]:
+    status = "unknown_blocking" if unknown_reasons else "known"
+    record = {
+        "artifact_type": "rax_unknown_state_record",
+        "schema_version": "1.0.0",
+        "record_id": record_id,
+        "target_ref": target_ref,
+        "unknown_reasons": sorted(set(unknown_reasons)),
+        "candidate_ready": False if unknown_reasons else True,
+        "advancement_allowed": False if unknown_reasons else True,
+        "evidence_refs": sorted(set(evidence_refs)),
+        "status": status,
+    }
+    validate_artifact(record, "rax_unknown_state_record")
+    return record
+
+
+def generate_adversarial_pattern_candidates(*, seed: str, target_ref: str, count: int = 5) -> list[dict[str, Any]]:
+    classes = [
+        "schema_valid_semantic_boundary",
+        "mutated_literal_variant",
+        "nested_variant",
+        "cross_step_contamination_variant",
+        "partial_signal_contradiction",
+    ]
+    base = int(hashlib.sha256(seed.encode("utf-8")).hexdigest(), 16)
+    out: list[dict[str, Any]] = []
+    for index in range(count):
+        class_name = classes[index % len(classes)]
+        variant_id = f"rax-adv-{hashlib.sha256(f'{seed}:{index}'.encode('utf-8')).hexdigest()[:12]}"
+        candidate = {
+            "artifact_type": "rax_adversarial_pattern_candidate",
+            "schema_version": "1.0.0",
+            "variant_id": variant_id,
+            "seed": seed,
+            "variant_class": class_name,
+            "target_ref": target_ref,
+            "payload": {
+                "mutator_index": index,
+                "deterministic_token": (base + index) % 100000,
+            },
+            "consumable_by_eval": True,
+        }
+        validate_artifact(candidate, "rax_adversarial_pattern_candidate")
+        out.append(candidate)
+    return out
 
 
 def run_rax_eval_runner(
@@ -156,7 +456,6 @@ def run_rax_eval_runner(
     if not version_authority_aligned and "source_version_drift" not in reason_map["rax_version_authority_alignment"]:
         reason_map["rax_version_authority_alignment"].append("source_version_drift")
 
-    # tests-pass but eval-fail must still fail closed
     if tests_passed and any(reason_map[eval_type] for eval_type in required_eval_types if eval_type != "rax_control_readiness"):
         reason_map["rax_control_readiness"].append("tests_pass_eval_fail")
 
@@ -164,7 +463,7 @@ def run_rax_eval_runner(
     for eval_type in required_eval_types:
         if eval_type in omit:
             continue
-        reason_codes = reason_map[eval_type]
+        reason_codes = sorted(set(reason_map[eval_type]))
         status = _status_from_reason_codes(reason_codes, blocking_codes=blocking_codes)
         result = {
             "artifact_type": "eval_result",
@@ -200,6 +499,24 @@ def run_rax_eval_runner(
     }
     validate_artifact(eval_summary, "eval_summary")
 
+    all_reasons = sorted(set(_reason_codes_from_results(eval_results)))
+    generated = generate_failure_eval_artifacts(
+        run_id=run_id,
+        target_ref=target_ref,
+        trace_id=trace_id,
+        source_artifact_refs=[f"eval_run://{run_id}", f"eval_summary://{run_id}"],
+        reason_codes=all_reasons,
+        failure_classification=(input_assurance.get("failure_classification") if input_assurance.get("failure_classification") != "none" else output_assurance.get("failure_classification")),
+        reproducibility_inputs={
+            "tests_passed": tests_passed,
+            "baseline_regression_detected": baseline_regression_detected,
+            "version_authority_aligned": version_authority_aligned,
+            "omit_eval_types": sorted(omit),
+        },
+    )
+
+    adversarial = generate_adversarial_pattern_candidates(seed=run_id, target_ref=target_ref)
+
     return {
         "eval_results": eval_results,
         "eval_summary": eval_summary,
@@ -210,6 +527,9 @@ def run_rax_eval_runner(
             "overall_result": "fail" if overall_fail else "pass",
             "missing_required_eval_handling": policy.get("missing_required_eval_handling", "fail_closed"),
         },
+        "failure_pattern_records": generated["failure_pattern_records"],
+        "eval_case_candidates": generated["eval_case_candidates"],
+        "adversarial_pattern_candidates": adversarial,
     }
 
 
@@ -227,6 +547,10 @@ def build_rax_control_readiness_record(
     authority_records: dict[str, Any] | None = None,
     replay_baseline_store: dict[str, Any] | None = None,
     replay_key: str | None = None,
+    health_snapshot: dict[str, Any] | None = None,
+    drift_signal_record: dict[str, Any] | None = None,
+    unknown_state_record: dict[str, Any] | None = None,
+    pre_certification_alignment_record: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     policy = _load_policy()
     required_eval_types = list(policy.get("required_eval_types", []))
@@ -242,7 +566,6 @@ def build_rax_control_readiness_record(
         blocking_reasons.append("missing_required_eval_types")
         blocking_reasons.extend(f"missing_eval:{name}" for name in missing_required_eval_types)
 
-    # never trust caller-supplied coverage summary without recomputation.
     declared_required = set(required_eval_coverage.get("required_eval_types") or [])
     if declared_required and declared_required != set(required_eval_types):
         blocking_reasons.append("required_eval_types_mismatch_with_governed_policy")
@@ -283,6 +606,8 @@ def build_rax_control_readiness_record(
             blocking_reasons.append("assurance_audit_not_accept_candidate")
         if _critical_failure_classification(assurance_audit.get("failure_classification")):
             blocking_reasons.append("critical_failure_classification_present")
+        if assurance_audit.get("counter_evidence") == [] and _critical_failure_classification(assurance_audit.get("failure_classification")):
+            blocking_reasons.append("failure_without_counter_evidence")
 
     derived_trace = _trace_lineage_from_eval_results(
         eval_results=eval_results,
@@ -335,6 +660,31 @@ def build_rax_control_readiness_record(
             blocking_reasons.append("cross_run_eval_signal_inconsistency")
         replay_baseline_store[replay_key] = {"signal": signal, "target_ref": target_ref}
 
+    unknown_reasons: list[str] = []
+    if not eval_results:
+        unknown_reasons.append("required_signal_missing")
+    if assurance_audit is None:
+        unknown_reasons.append("required_artifact_missing")
+    if eval_summary.get("system_status") == "healthy" and reason_codes:
+        unknown_reasons.append("contradictory_derived_fields")
+    if authority_records is None or not authority_records:
+        unknown_reasons.append("incomplete_authority_evidence")
+    if cross_run_inconsistency:
+        unknown_reasons.append("inconsistent_replay_state")
+    if not derived_trace["trace_complete"]:
+        unknown_reasons.append("unverifiable_readiness_basis")
+
+    if unknown_state_record is None:
+        unknown_state_record = build_rax_unknown_state_record(
+            record_id=f"unknown:{batch}:{eval_summary.get('trace_id', 'missing')}",
+            target_ref=target_ref,
+            unknown_reasons=unknown_reasons,
+            evidence_refs=[target_ref, f"trace://{eval_summary.get('trace_id', 'missing')}", f"eval_run://{eval_summary.get('eval_run_id', 'missing')}"] if isinstance(eval_summary, dict) else [target_ref],
+        )
+
+    if unknown_state_record.get("status") == "unknown_blocking":
+        blocking_reasons.append("unknown_state_detected")
+
     trace_complete = (
         "rax_trace_integrity" in present_eval_types
         and "rax_trace_integrity" not in missing_required_eval_types
@@ -344,8 +694,59 @@ def build_rax_control_readiness_record(
         and (trace_integrity_evidence or {}).get("trace_linked") is True
     )
 
+    readiness_conditions: list[dict[str, Any]] = []
+    mapping = {
+        "missing_required_eval_types": "missing_eval_becomes_present",
+        "dependency_graph_corrupt": "dependency_state_changes",
+        "trace_incomplete": "trace_becomes_complete",
+        "artifact_lineage_invalid": "lineage_repaired",
+        "missing_version_authority_evidence": "authority_version_evidence_present",
+        "baseline_regression_detected": "baseline_regression_resolved",
+        "cross_run_eval_signal_inconsistency": "drift_signal_clears",
+    }
+    for reason in sorted(set(blocking_reasons)):
+        category = mapping.get(reason)
+        if not category:
+            continue
+        readiness_conditions.append(
+            {
+                "condition_category": category,
+                "blocking_reason": reason,
+                "evidence_refs": [target_ref, f"trace://{eval_summary.get('trace_id', 'missing')}"],
+                "required_signal": reason,
+            }
+        )
+
+    # If caller provides artifacts, consume them without granting authority.
+    if health_snapshot is not None:
+        if health_snapshot.get("candidate_posture") in {"freeze_candidate", "block_candidate"}:
+            blocking_reasons.append("health_threshold_degraded")
+    if drift_signal_record is not None:
+        if drift_signal_record.get("candidate_posture") in {"freeze_candidate", "block_candidate"}:
+            blocking_reasons.append("drift_threshold_exceeded")
+
+    if pre_certification_alignment_record is None:
+        pre_certification_alignment_record = {
+            "artifact_type": "rax_pre_certification_alignment_record",
+            "schema_version": "1.0.0",
+            "record_id": f"precert:{batch}:{eval_summary.get('trace_id', 'missing')}",
+            "target_ref": target_ref,
+            "eval_completeness_aligned": not missing_required_eval_types,
+            "replay_consistency_aligned": not cross_run_inconsistency,
+            "trace_completeness_aligned": trace_complete,
+            "lineage_validity_aligned": (lineage_provenance_evidence or {}).get("lineage_valid") is True,
+            "fail_closed_aligned": bool(blocking_reasons),
+            "semantic_correctness_aligned": "semantic_target_mismatch" not in reason_codes,
+            "ready_candidate_allowed": False,
+            "blocking_reasons": sorted(set(blocking_reasons)),
+        }
+        validate_artifact(pre_certification_alignment_record, "rax_pre_certification_alignment_record")
+
+    if pre_certification_alignment_record.get("ready_candidate_allowed") is not True:
+        blocking_reasons.append("pre_certification_alignment_not_ready")
+
     blocking_reasons = sorted(set(blocking_reasons))
-    ready_for_control = len(blocking_reasons) == 0
+    ready_for_control = len(blocking_reasons) == 0 and unknown_state_record.get("status") != "unknown_blocking"
     if ready_for_control:
         decision = "ready"
     elif cross_run_inconsistency:
@@ -371,9 +772,17 @@ def build_rax_control_readiness_record(
         "trace_complete": trace_complete,
         "baseline_regression_detected": baseline_regression_detected,
         "version_authority_aligned": version_authority_aligned,
+        "conditions_under_which_ready_changes": readiness_conditions,
+        "unknown_state_ref": unknown_state_record["record_id"],
+        "pre_certification_alignment_ref": pre_certification_alignment_record["record_id"],
     }
     validate_artifact(record, "rax_control_readiness_record")
-    return record
+
+    return {
+        **record,
+        "unknown_state_record": deepcopy(unknown_state_record),
+        "pre_certification_alignment_record": deepcopy(pre_certification_alignment_record),
+    }
 
 
 def enforce_rax_control_advancement(*, readiness_record: dict[str, Any] | None) -> dict[str, Any]:

--- a/tests/test_rax_eval_runner.py
+++ b/tests/test_rax_eval_runner.py
@@ -8,6 +8,11 @@ from spectrum_systems.modules.runtime.rax_eval_runner import (
     load_rax_eval_case_set,
     load_rax_eval_registry,
     run_rax_eval_runner,
+    build_feedback_loop_record,
+    build_rax_health_snapshot,
+    build_rax_drift_signal_record,
+    build_rax_unknown_state_record,
+    generate_adversarial_pattern_candidates,
 )
 
 
@@ -344,3 +349,128 @@ def test_readiness_example_contract_validates() -> None:
     validate_artifact(load_example("rax_control_readiness_record"), "rax_control_readiness_record")
     validate_artifact(load_example("rax_eval_registry"), "rax_eval_registry")
     validate_artifact(load_example("rax_eval_case_set"), "rax_eval_case_set")
+
+
+def test_failure_to_eval_autogeneration_emits_pattern_and_candidate() -> None:
+    out = run_rax_eval_runner(
+        run_id="rax-eval-run-005",
+        target_ref="roadmap_step_contract:RAX-INTERFACE-24-01",
+        trace_id="16161616-1616-4161-8161-161616161616",
+        input_assurance={"passed": False, "details": ["semantic_intent_insufficient"], "failure_classification": "invalid_input"},
+        output_assurance=_output_assurance_ok(),
+        tests_passed=True,
+        baseline_regression_detected=False,
+        version_authority_aligned=True,
+    )
+    assert out["failure_pattern_records"]
+    assert out["eval_case_candidates"]
+    validate_artifact(out["failure_pattern_records"][0], "rax_failure_pattern_record")
+    validate_artifact(out["eval_case_candidates"][0], "rax_failure_eval_candidate")
+
+
+def test_adversarial_pattern_generation_is_deterministic() -> None:
+    first = generate_adversarial_pattern_candidates(seed="seed-1", target_ref="roadmap_step_contract:RAX-INTERFACE-24-01")
+    second = generate_adversarial_pattern_candidates(seed="seed-1", target_ref="roadmap_step_contract:RAX-INTERFACE-24-01")
+    assert first == second
+    assert len(first) == 5
+    validate_artifact(first[0], "rax_adversarial_pattern_candidate")
+
+
+def test_feedback_loop_record_tracks_recurrence() -> None:
+    record = build_feedback_loop_record(
+        record_id="feedback-loop-test",
+        originating_failure_pattern_ref="rax-failure-x",
+        fix_artifact_refs=["fix://rax/1"],
+        eval_artifact_refs_added=["rax-failure-x:eval-candidate"],
+        historical_failure_classes=["invalid_input", "dependency_blocked"],
+        current_failure_class="invalid_input",
+        recurrence_window="P14D",
+        readiness_delta=-0.2,
+        confidence_delta=-0.1,
+    )
+    assert record["recurrence_detected"] is True
+    validate_artifact(record, "rax_feedback_loop_record")
+
+
+def test_health_snapshot_threshold_degradation_sets_candidate_posture() -> None:
+    thresholds = {
+        "readiness_pass_rate": {"warn_min": 0.9, "freeze_candidate_min": 0.8, "block_candidate_min": 0.7},
+        "eval_coverage_rate": {"warn_min": 0.95, "freeze_candidate_min": 0.9, "block_candidate_min": 0.8},
+        "semantic_failure_rate": {"warn_min": 0.0, "freeze_candidate_min": 0.0, "block_candidate_min": 0.0},
+        "readiness_bypass_attempt_rate": {"warn_min": 0.0, "freeze_candidate_min": 0.0, "block_candidate_min": 0.0},
+        "replay_consistency_rate": {"warn_min": 0.95, "freeze_candidate_min": 0.9, "block_candidate_min": 0.8},
+        "trace_completeness_rate": {"warn_min": 0.95, "freeze_candidate_min": 0.9, "block_candidate_min": 0.8},
+        "lineage_validity_rate": {"warn_min": 0.95, "freeze_candidate_min": 0.9, "block_candidate_min": 0.8},
+        "contradiction_rate": {"warn_min": 0.0, "freeze_candidate_min": 0.0, "block_candidate_min": 0.0},
+    }
+    snapshot = build_rax_health_snapshot(
+        snapshot_id="health-test",
+        window_ref="window://current",
+        metrics={
+            "readiness_pass_rate": 0.6,
+            "eval_coverage_rate": 1.0,
+            "semantic_failure_rate": 0.0,
+            "readiness_bypass_attempt_rate": 0.0,
+            "replay_consistency_rate": 1.0,
+            "trace_completeness_rate": 1.0,
+            "lineage_validity_rate": 1.0,
+            "contradiction_rate": 0.0,
+        },
+        thresholds=thresholds,
+    )
+    assert snapshot["candidate_posture"] == "block_candidate"
+
+
+def test_drift_signal_detection_blocks_when_exceeding_threshold() -> None:
+    drift = build_rax_drift_signal_record(
+        signal_id="drift-test",
+        baseline_window_ref="window://baseline",
+        current_window_ref="window://current",
+        baseline_metrics={"eval_coverage_rate": 1.0, "readiness_pass_rate": 1.0, "semantic_failure_rate": 0.0, "lineage_validity_rate": 1.0, "trace_completeness_rate": 1.0},
+        current_metrics={"eval_coverage_rate": 0.5, "readiness_pass_rate": 0.5, "semantic_failure_rate": 0.4, "lineage_validity_rate": 0.4, "trace_completeness_rate": 0.6},
+        drift_thresholds={"eval_signal_drift": 0.1, "readiness_outcome_drift": 0.1, "semantic_classification_drift": 0.1, "version_authority_drift": 0.1, "trace_lineage_completeness_drift": 0.1},
+    )
+    assert drift["candidate_posture"] == "block_candidate"
+
+
+def test_unknown_state_record_never_allows_advancement() -> None:
+    unknown = build_rax_unknown_state_record(
+        record_id="unknown-test",
+        target_ref="roadmap_step_contract:RAX-INTERFACE-24-01",
+        unknown_reasons=["required_signal_missing"],
+        evidence_refs=["roadmap_step_contract:RAX-INTERFACE-24-01"],
+    )
+    assert unknown["candidate_ready"] is False
+    assert unknown["advancement_allowed"] is False
+
+
+def test_readiness_record_populates_conditions_under_which_ready_changes() -> None:
+    out = run_rax_eval_runner(
+        run_id="rax-eval-run-006",
+        target_ref="roadmap_step_contract:RAX-INTERFACE-24-01",
+        trace_id="17171717-1717-4171-8171-171717171717",
+        input_assurance=_input_assurance_ok(),
+        output_assurance=_output_assurance_ok(),
+        tests_passed=True,
+        baseline_regression_detected=False,
+        version_authority_aligned=True,
+        omit_eval_types=["rax_trace_integrity"],
+    )
+    readiness = _readiness_from(out)
+    assert readiness["ready_for_control"] is False
+    assert readiness["conditions_under_which_ready_changes"]
+
+
+def test_precert_alignment_blocks_candidate_ready_when_not_aligned() -> None:
+    out = run_rax_eval_runner(
+        run_id="rax-eval-run-007",
+        target_ref="roadmap_step_contract:RAX-INTERFACE-24-01",
+        trace_id="18181818-1818-4181-8181-181818181818",
+        input_assurance=_input_assurance_ok(),
+        output_assurance=_output_assurance_ok(),
+        tests_passed=True,
+        baseline_regression_detected=False,
+        version_authority_aligned=True,
+    )
+    readiness = _readiness_from(out)
+    assert "pre_certification_alignment_not_ready" in readiness["blocking_reasons"]

--- a/tests/test_roadmap_expansion_contracts.py
+++ b/tests/test_roadmap_expansion_contracts.py
@@ -148,3 +148,24 @@ def test_roadmap_step_contract_schema_is_strict_no_additional_properties() -> No
     instance["non_canonical"] = "unexpected"
     with pytest.raises(ValidationError):
         validator.validate(instance)
+
+
+def test_rax_feedback_loop_contract_examples_validate() -> None:
+    for name in (
+        "rax_failure_pattern_record",
+        "rax_failure_eval_candidate",
+        "rax_feedback_loop_record",
+        "rax_health_snapshot",
+        "rax_drift_signal_record",
+        "rax_unknown_state_record",
+        "rax_pre_certification_alignment_record",
+        "rax_adversarial_pattern_candidate",
+    ):
+        validate_artifact(load_example(name), name)
+
+
+def test_rax_control_readiness_requires_structured_change_conditions() -> None:
+    instance = load_example("rax_control_readiness_record")
+    instance.pop("conditions_under_which_ready_changes", None)
+    with pytest.raises(ValidationError):
+        validate_artifact(instance, "rax_control_readiness_record")


### PR DESCRIPTION
### Motivation
- Add a governed, trace-linked feedback loop so runtime failures deterministically produce failure pattern artifacts and eval candidates, emit candidate-only health/drift/unknown/pre-cert signals, and provide structured readiness-change conditions for downstream consumption.
- Harden input assurance and audit behavior to require concrete counter-evidence and explicit entry metadata to avoid silent fail-closed states.
- Provide SLO-like thresholding and drift detection in policy to drive candidate posture signals and make feedback-loop artifacts consumable by downstream governance flows.

### Description
- Extended `config/policy/rax_eval_policy.json` to `schema_version: 1.1.0` and added `health_thresholds`, `drift_thresholds`, and `adversarial_generation` configuration values and updated batch id.
- Added new contract schemas and examples for feedback-loop artifacts: `rax_failure_pattern_record`, `rax_failure_eval_candidate`, `rax_feedback_loop_record`, `rax_health_snapshot`, `rax_drift_signal_record`, `rax_unknown_state_record`, `rax_pre_certification_alignment_record`, and `rax_adversarial_pattern_candidate`, and registered them in `contracts/standards-manifest.json`.
- Implemented feedback-loop runtime logic in `spectrum_systems/modules/runtime/rax_eval_runner.py`, including deterministic failure classification and `generate_failure_eval_artifacts`, `build_feedback_loop_record`, `build_rax_health_snapshot`, `build_rax_drift_signal_record`, `build_rax_unknown_state_record`, `generate_adversarial_pattern_candidates`, and integrated generation of failure patterns, eval candidates, adversarial candidates, and health/drift/unknown/pre-cert artifacts into `run_rax_eval_runner` and readiness building.
- Hardened input and audit enforcement in `spectrum_systems/modules/runtime/rax_assurance.py` by adding `_ENTRY_REQUIRED_FIELDS`, `_COUNTER_EVIDENCE_PLACEHOLDERS`, stricter entry validation, trace-presence checks, trimming and filtering counter-evidence, and raising `RAXAssuranceError` when failures lack concrete counter-evidence.
- Extended `build_rax_control_readiness_record` to compute `conditions_under_which_ready_changes`, derive and consume unknown-state and pre-certification alignment records, and optionally consider provided health/drift artifacts when computing blocking reasons and final readiness output.
- Added documentation and plan: `docs/architecture/rax_feedback_loop_hardening.md`, updated `docs/architecture/system_registry.md`, `docs/governance-reports/contract-enforcement-report.md`, and added a review action plan file describing the rollout.
- Added and updated tests in `tests/test_rax_eval_runner.py` and `tests/test_roadmap_expansion_contracts.py` to exercise generation/validation of the new artifacts and the extended readiness logic.

### Testing
- Ran `pytest tests/test_rax_eval_runner.py` which exercises failure->eval autogeneration, adversarial candidate generation, health/drift/unknown/pre-cert records, and readiness condition population, and the tests passed.
- Ran `pytest tests/test_roadmap_expansion_contracts.py` which validates all new/modified contract schemas and examples (including the updated `rax_control_readiness_record`), and the tests passed.
- All added `validate_artifact` checks for new artifacts were executed as part of the unit tests and returned schema-valid artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db08dc39b48329a7fe3dc9efb6e593)