### PR TITLE
RAX-RED-01: add adversarial eval pack and fail-closed readiness hardening

### DIFF
--- a/contracts/examples/rax_eval_case_set.json
+++ b/contracts/examples/rax_eval_case_set.json
@@ -5,116 +5,60 @@
   "case_set_version": "1.0.0",
   "cases": [
     {
-      "eval_case_id": "rax-case-semantic-empty-intent",
+      "eval_case_id": "rax-case-baseline-input",
       "eval_type": "rax_input_semantic_sufficiency",
-      "case_class": "failure_class",
-      "target_ref": "upstream:semantic-empty",
-      "expected_status": "fail",
+      "case_class": "baseline",
+      "target_ref": "upstream:baseline",
+      "expected_status": "pass",
       "reason_codes": [
-        "semantic_intent_insufficient"
+        "baseline_ok"
       ],
       "signals": [
-        "intent_placeholder_detected"
+        "semantic_intent_sufficient"
       ],
-      "trace_id": "11111111-1111-4111-8111-111111111111"
+      "trace_id": "f1111111-1111-4111-8111-111111111111"
     },
     {
-      "eval_case_id": "rax-case-owner-intent-contradiction",
-      "eval_type": "rax_owner_intent_alignment",
-      "case_class": "failure_class",
-      "target_ref": "upstream:owner-intent-contradiction",
-      "expected_status": "fail",
-      "reason_codes": [
-        "owner_intent_contradiction"
-      ],
-      "signals": [
-        "owner_intent_misaligned"
-      ],
-      "trace_id": "22222222-2222-4222-8222-222222222222"
-    },
-    {
-      "eval_case_id": "rax-case-normalization-collapse",
-      "eval_type": "rax_normalization_integrity",
-      "case_class": "failure_class",
-      "target_ref": "upstream:normalization-collapse",
-      "expected_status": "fail",
-      "reason_codes": [
-        "normalization_ambiguity"
-      ],
-      "signals": [
-        "normalization_lossy"
-      ],
-      "trace_id": "33333333-3333-4333-8333-333333333333"
-    },
-    {
-      "eval_case_id": "rax-case-wrong-target",
+      "eval_case_id": "rax-case-baseline-output",
       "eval_type": "rax_output_semantic_alignment",
-      "case_class": "adversarial",
-      "target_ref": "contract:wrong-target",
-      "expected_status": "fail",
+      "case_class": "baseline",
+      "target_ref": "contract:baseline",
+      "expected_status": "pass",
       "reason_codes": [
-        "semantic_target_mismatch"
+        "baseline_ok"
       ],
       "signals": [
-        "target_module_semantically_wrong"
+        "output_semantically_aligned"
       ],
-      "trace_id": "44444444-4444-4444-8444-444444444444"
+      "trace_id": "f2222222-2222-4222-8222-222222222222"
     },
     {
-      "eval_case_id": "rax-case-output-overexpanded",
-      "eval_type": "rax_output_semantic_alignment",
-      "case_class": "adversarial",
-      "target_ref": "contract:over-expanded",
-      "expected_status": "fail",
+      "eval_case_id": "rax-case-baseline-readiness",
+      "eval_type": "rax_control_readiness",
+      "case_class": "baseline",
+      "target_ref": "readiness:baseline",
+      "expected_status": "pass",
       "reason_codes": [
-        "output_over_expanded"
+        "baseline_ok"
       ],
       "signals": [
-        "downstream_unusable"
+        "control_readiness_true"
       ],
-      "trace_id": "55555555-5555-4555-8555-555555555555"
+      "trace_id": "f4444444-4444-4444-8444-444444444444"
     },
     {
-      "eval_case_id": "rax-case-weak-acceptance-checks",
-      "eval_type": "rax_acceptance_check_strength",
-      "case_class": "failure_class",
-      "target_ref": "contract:weak-acceptance",
-      "expected_status": "fail",
-      "reason_codes": [
-        "weak_acceptance_check"
-      ],
-      "signals": [
-        "acceptance_strength_below_policy"
-      ],
-      "trace_id": "66666666-6666-4666-8666-666666666666"
-    },
-    {
-      "eval_case_id": "rax-case-missing-trace",
+      "eval_case_id": "rax-case-baseline-trace",
       "eval_type": "rax_trace_integrity",
-      "case_class": "failure_class",
-      "target_ref": "trace:missing",
-      "expected_status": "fail",
+      "case_class": "baseline",
+      "target_ref": "trace:baseline",
+      "expected_status": "pass",
       "reason_codes": [
-        "missing_required_expansion_trace"
+        "baseline_ok"
       ],
       "signals": [
-        "trace_incomplete"
+        "trace_complete"
       ],
-      "trace_id": "77777777-7777-4777-8777-777777777777"
-    },
-    {
-      "eval_case_id": "rax-case-source-version-drift",
-      "eval_type": "rax_version_authority_alignment",
-      "case_class": "failure_class",
-      "target_ref": "upstream:source-version-drift",
-      "expected_status": "fail",
-      "reason_codes": [
-        "source_version_drift"
-      ],
-      "signals": [
-        "version_authority_mismatch"
-      ],
-      "trace_id": "88888888-8888-4888-8888-888888888888"
+      "trace_id": "f3333333-3333-4333-8333-333333333333"
     },
     {
       "eval_case_id": "rax-case-missing-control-readiness-evidence",
@@ -145,60 +89,32 @@
       "trace_id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
     },
     {
-      "eval_case_id": "rax-case-schema-valid-semantically-wrong",
-      "eval_type": "rax_output_semantic_alignment",
-      "case_class": "adversarial",
-      "target_ref": "contract:schema-valid-semantic-wrong",
-      "expected_status": "fail",
-      "reason_codes": [
-        "schema_valid_semantic_failure"
-      ],
-      "signals": [
-        "semantic_contradiction_detected"
-      ],
-      "trace_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
-    },
-    {
-      "eval_case_id": "rax-case-trace-linked-incomplete-output",
+      "eval_case_id": "rax-case-missing-trace",
       "eval_type": "rax_trace_integrity",
-      "case_class": "adversarial",
-      "target_ref": "trace:linked-incomplete",
-      "expected_status": "fail",
-      "reason_codes": [
-        "trace_linked_output_incomplete"
-      ],
-      "signals": [
-        "trace_not_sufficient"
-      ],
-      "trace_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
-    },
-    {
-      "eval_case_id": "rax-case-test-pass-eval-fail",
-      "eval_type": "rax_control_readiness",
-      "case_class": "adversarial",
-      "target_ref": "flow:test-pass-eval-fail",
-      "expected_status": "fail",
-      "reason_codes": [
-        "tests_pass_eval_fail"
-      ],
-      "signals": [
-        "tests_not_sufficient_for_readiness"
-      ],
-      "trace_id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
-    },
-    {
-      "eval_case_id": "rax-case-regression-missing-baseline-guard",
-      "eval_type": "rax_regression_against_baseline",
       "case_class": "failure_class",
-      "target_ref": "contract:baseline-regression",
+      "target_ref": "trace:missing",
       "expected_status": "fail",
       "reason_codes": [
-        "baseline_regression_detected"
+        "missing_required_expansion_trace"
       ],
       "signals": [
-        "regression_blocking"
+        "trace_incomplete"
       ],
-      "trace_id": "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee"
+      "trace_id": "77777777-7777-4777-8777-777777777777"
+    },
+    {
+      "eval_case_id": "rax-case-normalization-collapse",
+      "eval_type": "rax_normalization_integrity",
+      "case_class": "failure_class",
+      "target_ref": "upstream:normalization-collapse",
+      "expected_status": "fail",
+      "reason_codes": [
+        "normalization_ambiguity"
+      ],
+      "signals": [
+        "normalization_lossy"
+      ],
+      "trace_id": "33333333-3333-4333-8333-333333333333"
     },
     {
       "eval_case_id": "rax-case-novel-adversarial-semantic-ambiguity",
@@ -215,60 +131,264 @@
       "trace_id": "e1212121-1212-4121-8121-121212121212"
     },
     {
-      "eval_case_id": "rax-case-baseline-input",
-      "eval_type": "rax_input_semantic_sufficiency",
-      "case_class": "baseline",
-      "target_ref": "upstream:baseline",
-      "expected_status": "pass",
-      "reason_codes": [
-        "baseline_ok"
-      ],
-      "signals": [
-        "semantic_intent_sufficient"
-      ],
-      "trace_id": "f1111111-1111-4111-8111-111111111111"
-    },
-    {
-      "eval_case_id": "rax-case-baseline-output",
+      "eval_case_id": "rax-case-output-overexpanded",
       "eval_type": "rax_output_semantic_alignment",
-      "case_class": "baseline",
-      "target_ref": "contract:baseline",
-      "expected_status": "pass",
+      "case_class": "adversarial",
+      "target_ref": "contract:over-expanded",
+      "expected_status": "fail",
       "reason_codes": [
-        "baseline_ok"
+        "output_over_expanded"
       ],
       "signals": [
-        "output_semantically_aligned"
+        "downstream_unusable"
       ],
-      "trace_id": "f2222222-2222-4222-8222-222222222222"
+      "trace_id": "55555555-5555-4555-8555-555555555555"
     },
     {
-      "eval_case_id": "rax-case-baseline-trace",
-      "eval_type": "rax_trace_integrity",
-      "case_class": "baseline",
-      "target_ref": "trace:baseline",
-      "expected_status": "pass",
+      "eval_case_id": "rax-case-owner-intent-contradiction",
+      "eval_type": "rax_owner_intent_alignment",
+      "case_class": "failure_class",
+      "target_ref": "upstream:owner-intent-contradiction",
+      "expected_status": "fail",
       "reason_codes": [
-        "baseline_ok"
+        "owner_intent_contradiction"
       ],
       "signals": [
-        "trace_complete"
+        "owner_intent_misaligned"
       ],
-      "trace_id": "f3333333-3333-4333-8333-333333333333"
+      "trace_id": "22222222-2222-4222-8222-222222222222"
     },
     {
-      "eval_case_id": "rax-case-baseline-readiness",
+      "eval_case_id": "rax-case-regression-missing-baseline-guard",
+      "eval_type": "rax_regression_against_baseline",
+      "case_class": "failure_class",
+      "target_ref": "contract:baseline-regression",
+      "expected_status": "fail",
+      "reason_codes": [
+        "baseline_regression_detected"
+      ],
+      "signals": [
+        "regression_blocking"
+      ],
+      "trace_id": "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee"
+    },
+    {
+      "eval_case_id": "rax-case-schema-valid-semantically-wrong",
+      "eval_type": "rax_output_semantic_alignment",
+      "case_class": "adversarial",
+      "target_ref": "contract:schema-valid-semantic-wrong",
+      "expected_status": "fail",
+      "reason_codes": [
+        "schema_valid_semantic_failure"
+      ],
+      "signals": [
+        "semantic_contradiction_detected"
+      ],
+      "trace_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+    },
+    {
+      "eval_case_id": "rax-case-semantic-empty-intent",
+      "eval_type": "rax_input_semantic_sufficiency",
+      "case_class": "failure_class",
+      "target_ref": "upstream:semantic-empty",
+      "expected_status": "fail",
+      "reason_codes": [
+        "semantic_intent_insufficient"
+      ],
+      "signals": [
+        "intent_placeholder_detected"
+      ],
+      "trace_id": "11111111-1111-4111-8111-111111111111"
+    },
+    {
+      "eval_case_id": "rax-case-source-version-drift",
+      "eval_type": "rax_version_authority_alignment",
+      "case_class": "failure_class",
+      "target_ref": "upstream:source-version-drift",
+      "expected_status": "fail",
+      "reason_codes": [
+        "source_version_drift"
+      ],
+      "signals": [
+        "version_authority_mismatch"
+      ],
+      "trace_id": "88888888-8888-4888-8888-888888888888"
+    },
+    {
+      "eval_case_id": "rax-case-test-pass-eval-fail",
       "eval_type": "rax_control_readiness",
-      "case_class": "baseline",
-      "target_ref": "readiness:baseline",
-      "expected_status": "pass",
+      "case_class": "adversarial",
+      "target_ref": "flow:test-pass-eval-fail",
+      "expected_status": "fail",
       "reason_codes": [
-        "baseline_ok"
+        "tests_pass_eval_fail"
       ],
       "signals": [
-        "control_readiness_true"
+        "tests_not_sufficient_for_readiness"
       ],
-      "trace_id": "f4444444-4444-4444-8444-444444444444"
+      "trace_id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
+    },
+    {
+      "eval_case_id": "rax-case-trace-linked-incomplete-output",
+      "eval_type": "rax_trace_integrity",
+      "case_class": "adversarial",
+      "target_ref": "trace:linked-incomplete",
+      "expected_status": "fail",
+      "reason_codes": [
+        "trace_linked_output_incomplete"
+      ],
+      "signals": [
+        "trace_not_sufficient"
+      ],
+      "trace_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+    },
+    {
+      "eval_case_id": "rax-case-weak-acceptance-checks",
+      "eval_type": "rax_acceptance_check_strength",
+      "case_class": "failure_class",
+      "target_ref": "contract:weak-acceptance",
+      "expected_status": "fail",
+      "reason_codes": [
+        "weak_acceptance_check"
+      ],
+      "signals": [
+        "acceptance_strength_below_policy"
+      ],
+      "trace_id": "66666666-6666-4666-8666-666666666666"
+    },
+    {
+      "eval_case_id": "rax-case-wrong-target",
+      "eval_type": "rax_output_semantic_alignment",
+      "case_class": "adversarial",
+      "target_ref": "contract:wrong-target",
+      "expected_status": "fail",
+      "reason_codes": [
+        "semantic_target_mismatch"
+      ],
+      "signals": [
+        "target_module_semantically_wrong"
+      ],
+      "trace_id": "44444444-4444-4444-8444-444444444444"
+    },
+    {
+      "eval_case_id": "rax-red-01-counter-evidence",
+      "eval_type": "rax_control_readiness",
+      "case_class": "adversarial",
+      "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
+      "expected_status": "fail",
+      "reason_codes": [
+        "critical_failure_classification_present"
+      ],
+      "signals": [
+        "RAX-RED-01",
+        "fail_closed_required"
+      ],
+      "trace_id": "20000000-0000-4000-8000-000000000001"
+    },
+    {
+      "eval_case_id": "rax-red-01-feedback-poison",
+      "eval_type": "rax_acceptance_check_strength",
+      "case_class": "adversarial",
+      "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
+      "expected_status": "fail",
+      "reason_codes": [
+        "weak_acceptance_check"
+      ],
+      "signals": [
+        "RAX-RED-01",
+        "fail_closed_required"
+      ],
+      "trace_id": "20000000-0000-4000-8000-000000000001"
+    },
+    {
+      "eval_case_id": "rax-red-01-policy-drift",
+      "eval_type": "rax_control_readiness",
+      "case_class": "adversarial",
+      "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
+      "expected_status": "fail",
+      "reason_codes": [
+        "required_eval_types_mismatch_with_governed_policy"
+      ],
+      "signals": [
+        "RAX-RED-01",
+        "fail_closed_required"
+      ],
+      "trace_id": "20000000-0000-4000-8000-000000000001"
+    },
+    {
+      "eval_case_id": "rax-red-01-provenance-gap",
+      "eval_type": "rax_trace_integrity",
+      "case_class": "adversarial",
+      "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
+      "expected_status": "fail",
+      "reason_codes": [
+        "artifact_lineage_incomplete"
+      ],
+      "signals": [
+        "RAX-RED-01",
+        "fail_closed_required"
+      ],
+      "trace_id": "20000000-0000-4000-8000-000000000001"
+    },
+    {
+      "eval_case_id": "rax-red-01-readiness-inflation",
+      "eval_type": "rax_trace_integrity",
+      "case_class": "adversarial",
+      "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
+      "expected_status": "fail",
+      "reason_codes": [
+        "missing_required_expansion_trace"
+      ],
+      "signals": [
+        "RAX-RED-01",
+        "fail_closed_required"
+      ],
+      "trace_id": "20000000-0000-4000-8000-000000000001"
+    },
+    {
+      "eval_case_id": "rax-red-01-replay-inconsistency",
+      "eval_type": "rax_control_readiness",
+      "case_class": "adversarial",
+      "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
+      "expected_status": "fail",
+      "reason_codes": [
+        "replay_consistency_evidence_incomplete"
+      ],
+      "signals": [
+        "RAX-RED-01",
+        "fail_closed_required"
+      ],
+      "trace_id": "20000000-0000-4000-8000-000000000001"
+    },
+    {
+      "eval_case_id": "rax-red-01-semantic-drift",
+      "eval_type": "rax_input_semantic_sufficiency",
+      "case_class": "adversarial",
+      "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
+      "expected_status": "fail",
+      "reason_codes": [
+        "semantic_intent_insufficient"
+      ],
+      "signals": [
+        "RAX-RED-01",
+        "fail_closed_required"
+      ],
+      "trace_id": "20000000-0000-4000-8000-000000000001"
+    },
+    {
+      "eval_case_id": "rax-red-01-unknown-state",
+      "eval_type": "rax_control_readiness",
+      "case_class": "adversarial",
+      "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
+      "expected_status": "fail",
+      "reason_codes": [
+        "unknown_state_detected"
+      ],
+      "signals": [
+        "RAX-RED-01",
+        "fail_closed_required"
+      ],
+      "trace_id": "20000000-0000-4000-8000-000000000001"
     }
   ]
 }

--- a/docs/review-actions/PLAN-RAX-RED-01-2026-04-12.md
+++ b/docs/review-actions/PLAN-RAX-RED-01-2026-04-12.md
@@ -1,0 +1,37 @@
+# Plan — RAX-RED-01 — 2026-04-12
+
+## Prompt type
+VALIDATE
+
+## Batch
+RAX-RED-01
+
+## Scope
+Adversarial hardening for the RAX boundary only (no feature expansion, no authority shift).
+
+## Objectives
+1. Build a deterministic adversarial fixture pack spanning all eight required failure classes.
+2. Execute the fixture pack through existing RAX assurance/eval/readiness paths.
+3. Capture any incorrect outcomes and encode fail-closed guards.
+4. Add permanent regression tests so discovered exploits remain blocked.
+
+## Files in scope
+| File | Action | Purpose |
+| --- | --- | --- |
+| `docs/review-actions/PLAN-RAX-RED-01-2026-04-12.md` | CREATE | Required written plan for >2 file change. |
+| `tests/fixtures/rax_adversarial_eval_pack.json` | CREATE | Deterministic adversarial fixtures for all required failure classes. |
+| `tests/test_rax_redteam_adversarial_pack.py` | CREATE | Serial adversarial execution + outcome classification regression tests. |
+| `tests/test_rax_eval_runner.py` | MODIFY | Add focused fail-closed regression checks for discovered readiness gaps. |
+| `spectrum_systems/modules/runtime/rax_eval_runner.py` | MODIFY | Harden replay/lineage fail-closed checks discovered by adversarial runs. |
+
+## Execution steps
+1. Add fixture pack with one fixture per failure class (schema-valid where applicable, single-target failure mode).
+2. Add serial test harness that runs each fixture through RAX runner/readiness and asserts fail-closed outcome class.
+3. Tighten readiness computation for discovered exploitable seams (partial replay signal, incomplete lineage).
+4. Add targeted tests proving each discovered exploit is permanently blocked.
+5. Run RAX-targeted tests + required contract enforcement tests.
+
+## Validation commands
+1. `pytest tests/test_rax_redteam_adversarial_pack.py`
+2. `pytest tests/test_rax_eval_runner.py tests/test_rax_interface_assurance.py`
+3. `pytest tests/test_contracts.py`

--- a/spectrum_systems/modules/runtime/rax_eval_runner.py
+++ b/spectrum_systems/modules/runtime/rax_eval_runner.py
@@ -632,6 +632,8 @@ def build_rax_control_readiness_record(
     else:
         if lineage_provenance_evidence.get("lineage_valid") is not True:
             blocking_reasons.append("artifact_lineage_invalid")
+        if lineage_provenance_evidence.get("lineage_chain_complete") is not True:
+            blocking_reasons.append("artifact_lineage_incomplete")
 
     if dependency_state is None:
         blocking_reasons.append("missing_dependency_state")
@@ -652,6 +654,8 @@ def build_rax_control_readiness_record(
     version_authority_aligned = "source_version_drift" not in reason_codes and "missing_version_authority_evidence" not in blocking_reasons
 
     cross_run_inconsistency = False
+    if (replay_baseline_store is None) ^ (replay_key is None):
+        blocking_reasons.append("replay_consistency_evidence_incomplete")
     if replay_baseline_store is not None and replay_key:
         signal = _canonical_eval_signal(eval_results)
         previous = replay_baseline_store.get(replay_key)
@@ -669,6 +673,8 @@ def build_rax_control_readiness_record(
         unknown_reasons.append("contradictory_derived_fields")
     if authority_records is None or not authority_records:
         unknown_reasons.append("incomplete_authority_evidence")
+    if (replay_baseline_store is None) ^ (replay_key is None):
+        unknown_reasons.append("partial_replay_evidence")
     if cross_run_inconsistency:
         unknown_reasons.append("inconsistent_replay_state")
     if not derived_trace["trace_complete"]:

--- a/tests/fixtures/rax_adversarial_eval_pack.json
+++ b/tests/fixtures/rax_adversarial_eval_pack.json
@@ -1,0 +1,109 @@
+{
+  "artifact_type": "rax_adversarial_eval_pack",
+  "batch": "RAX-RED-01",
+  "version": "1.0.0",
+  "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
+  "cases": [
+    {
+      "case_id": "A_semantic_drift",
+      "failure_class": "semantic_drift",
+      "run_id": "rax-red-01-a",
+      "trace_id": "10000000-0000-4000-8000-000000000001",
+      "input_assurance": {"passed": false, "details": ["semantic_intent_insufficient"], "failure_classification": "invalid_input", "stop_condition_triggered": true},
+      "output_assurance": {"passed": true, "details": ["output_semantically_aligned"], "failure_classification": "none", "stop_condition_triggered": false},
+      "tests_passed": true,
+      "baseline_regression_detected": false,
+      "version_authority_aligned": true,
+      "expected_blocking_reason": "semantic_intent_insufficient"
+    },
+    {
+      "case_id": "B_readiness_inflation",
+      "failure_class": "readiness_inflation",
+      "run_id": "rax-red-01-b",
+      "trace_id": "10000000-0000-4000-8000-000000000002",
+      "omit_eval_types": ["rax_trace_integrity"],
+      "input_assurance": {"passed": true, "details": ["semantic_intent_sufficient"], "failure_classification": "none", "stop_condition_triggered": false},
+      "output_assurance": {"passed": true, "details": ["output_semantically_aligned"], "failure_classification": "none", "stop_condition_triggered": false},
+      "tests_passed": true,
+      "baseline_regression_detected": false,
+      "version_authority_aligned": true,
+      "expected_blocking_reason": "missing_required_eval_types"
+    },
+    {
+      "case_id": "C_counter_evidence_weak",
+      "failure_class": "missing_weak_counter_evidence",
+      "run_id": "rax-red-01-c",
+      "trace_id": "10000000-0000-4000-8000-000000000003",
+      "input_assurance": {"passed": false, "details": ["owner_intent_contradiction: owner=PRG cannot claim runtime execution"], "failure_classification": "ownership_violation", "stop_condition_triggered": true},
+      "output_assurance": {"passed": true, "details": [], "failure_classification": "none", "stop_condition_triggered": false},
+      "tests_passed": true,
+      "baseline_regression_detected": false,
+      "version_authority_aligned": true,
+      "expected_blocking_reason": "critical_failure_classification_present"
+    },
+    {
+      "case_id": "D_provenance_gap",
+      "failure_class": "provenance_gaps",
+      "run_id": "rax-red-01-d",
+      "trace_id": "10000000-0000-4000-8000-000000000004",
+      "input_assurance": {"passed": true, "details": ["semantic_intent_sufficient"], "failure_classification": "none", "stop_condition_triggered": false},
+      "output_assurance": {"passed": true, "details": ["output_semantically_aligned"], "failure_classification": "none", "stop_condition_triggered": false},
+      "tests_passed": true,
+      "baseline_regression_detected": false,
+      "version_authority_aligned": true,
+      "lineage_provenance_evidence": {"lineage_valid": true, "lineage_chain_complete": false},
+      "expected_blocking_reason": "artifact_lineage_incomplete"
+    },
+    {
+      "case_id": "E_replay_inconsistency",
+      "failure_class": "replay_inconsistency",
+      "run_id": "rax-red-01-e",
+      "trace_id": "10000000-0000-4000-8000-000000000005",
+      "input_assurance": {"passed": true, "details": ["semantic_intent_sufficient"], "failure_classification": "none", "stop_condition_triggered": false},
+      "output_assurance": {"passed": true, "details": ["output_semantically_aligned"], "failure_classification": "none", "stop_condition_triggered": false},
+      "tests_passed": true,
+      "baseline_regression_detected": false,
+      "version_authority_aligned": true,
+      "replay_key_only": true,
+      "expected_blocking_reason": "replay_consistency_evidence_incomplete"
+    },
+    {
+      "case_id": "F_policy_drift_mismatch",
+      "failure_class": "policy_drift_mismatch",
+      "run_id": "rax-red-01-f",
+      "trace_id": "10000000-0000-4000-8000-000000000006",
+      "input_assurance": {"passed": true, "details": ["semantic_intent_sufficient"], "failure_classification": "none", "stop_condition_triggered": false},
+      "output_assurance": {"passed": true, "details": ["output_semantically_aligned"], "failure_classification": "none", "stop_condition_triggered": false},
+      "tests_passed": true,
+      "baseline_regression_detected": false,
+      "version_authority_aligned": true,
+      "tamper_required_coverage": true,
+      "expected_blocking_reason": "required_eval_types_mismatch_with_governed_policy"
+    },
+    {
+      "case_id": "G_feedback_loop_poisoning",
+      "failure_class": "feedback_loop_poisoning",
+      "run_id": "rax-red-01-g",
+      "trace_id": "10000000-0000-4000-8000-000000000007",
+      "input_assurance": {"passed": false, "details": ["semantic_intent_insufficient"], "failure_classification": "invalid_input", "stop_condition_triggered": true},
+      "output_assurance": {"passed": true, "details": ["output_semantically_aligned"], "failure_classification": "none", "stop_condition_triggered": false},
+      "tests_passed": true,
+      "baseline_regression_detected": false,
+      "version_authority_aligned": true,
+      "expect_failure_candidate": true
+    },
+    {
+      "case_id": "H_unknown_state_partial_signals",
+      "failure_class": "unknown_state_partial_signals",
+      "run_id": "rax-red-01-h",
+      "trace_id": "10000000-0000-4000-8000-000000000008",
+      "input_assurance": {"passed": true, "details": ["semantic_intent_sufficient"], "failure_classification": "none", "stop_condition_triggered": false},
+      "output_assurance": {"passed": true, "details": ["output_semantically_aligned"], "failure_classification": "none", "stop_condition_triggered": false},
+      "tests_passed": true,
+      "baseline_regression_detected": false,
+      "version_authority_aligned": true,
+      "drop_trace_integrity_evidence": true,
+      "expected_blocking_reason": "missing_trace_integrity_evidence"
+    }
+  ]
+}

--- a/tests/test_rax_eval_runner.py
+++ b/tests/test_rax_eval_runner.py
@@ -38,7 +38,7 @@ def _governed_evidence_ok() -> dict:
     return {
         "assurance_audit": {"acceptance_decision": "accept_candidate", "failure_classification": "none"},
         "trace_integrity_evidence": {"trace_linked": True, "trace_complete": True},
-        "lineage_provenance_evidence": {"lineage_valid": True},
+        "lineage_provenance_evidence": {"lineage_valid": True, "lineage_chain_complete": True},
         "dependency_state": {"graph_integrity": True, "unresolved_dependencies": []},
         "authority_records": {"docs/roadmaps/system_roadmap.md#RAX-INTERFACE-24-01": "1.3.112"},
     }
@@ -81,6 +81,21 @@ def test_eval_case_set_contains_novel_adversarial_semantic_case() -> None:
     assert case["case_class"] == "adversarial"
     assert case["eval_type"] == "rax_input_semantic_sufficiency"
     assert "semantic_intent_insufficient" in case["reason_codes"]
+
+
+def test_eval_case_set_contains_rax_red_01_adversarial_pack_entries() -> None:
+    case_set = load_rax_eval_case_set()
+    ids = {case["eval_case_id"] for case in case_set["cases"]}
+    assert {
+        "rax-red-01-semantic-drift",
+        "rax-red-01-readiness-inflation",
+        "rax-red-01-counter-evidence",
+        "rax-red-01-provenance-gap",
+        "rax-red-01-replay-inconsistency",
+        "rax-red-01-policy-drift",
+        "rax-red-01-feedback-poison",
+        "rax-red-01-unknown-state",
+    }.issubset(ids)
 
 def test_runner_emits_structured_eval_results_and_summary() -> None:
     out = run_rax_eval_runner(
@@ -286,9 +301,25 @@ def test_artifact_present_but_not_lineage_valid_fails_closed() -> None:
         baseline_regression_detected=False,
         version_authority_aligned=True,
     )
-    readiness = _readiness_from(out, lineage_provenance_evidence={"lineage_valid": False})
+    readiness = _readiness_from(out, lineage_provenance_evidence={"lineage_valid": False, "lineage_chain_complete": True})
     assert readiness["ready_for_control"] is False
     assert "artifact_lineage_invalid" in readiness["blocking_reasons"]
+
+
+def test_lineage_chain_incomplete_fails_closed() -> None:
+    out = run_rax_eval_runner(
+        run_id="redteam-25b",
+        target_ref="roadmap_step_contract:RAX-INTERFACE-24-01",
+        trace_id="00000000-0000-4000-8000-000000000255",
+        input_assurance=_input_assurance_ok(),
+        output_assurance=_output_assurance_ok(),
+        tests_passed=True,
+        baseline_regression_detected=False,
+        version_authority_aligned=True,
+    )
+    readiness = _readiness_from(out, lineage_provenance_evidence={"lineage_valid": True, "lineage_chain_complete": False})
+    assert readiness["ready_for_control"] is False
+    assert "artifact_lineage_incomplete" in readiness["blocking_reasons"]
 
 
 def test_fake_authority_version_alignment_fails_closed() -> None:
@@ -351,6 +382,23 @@ def test_cross_run_inconsistency_triggers_hold_not_ready() -> None:
     assert second["ready_for_control"] is False
     assert second["decision"] == "hold"
     assert "cross_run_eval_signal_inconsistency" in second["blocking_reasons"]
+
+
+def test_partial_replay_evidence_fails_closed() -> None:
+    out = run_rax_eval_runner(
+        run_id="redteam-22-partial",
+        target_ref="roadmap_step_contract:RAX-INTERFACE-24-01",
+        trace_id="00000000-0000-4000-8000-000000002229",
+        input_assurance=_input_assurance_ok(),
+        output_assurance=_output_assurance_ok(),
+        tests_passed=True,
+        baseline_regression_detected=False,
+        version_authority_aligned=True,
+    )
+    readiness = _readiness_from(out, replay_key="same-input-only")
+    assert readiness["ready_for_control"] is False
+    assert "replay_consistency_evidence_incomplete" in readiness["blocking_reasons"]
+    assert readiness["unknown_state_record"]["status"] == "unknown_blocking"
 
 
 def test_readiness_example_contract_validates() -> None:

--- a/tests/test_rax_redteam_adversarial_pack.py
+++ b/tests/test_rax_redteam_adversarial_pack.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from spectrum_systems.modules.runtime.rax_assurance import build_rax_assurance_audit_record, evaluate_rax_control_readiness
+from spectrum_systems.modules.runtime.rax_eval_runner import run_rax_eval_runner
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_PATH = REPO_ROOT / "tests" / "fixtures" / "rax_adversarial_eval_pack.json"
+
+
+def _load_pack() -> dict:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def _governed_evidence() -> dict:
+    return {
+        "assurance_audit": {"acceptance_decision": "accept_candidate", "failure_classification": "none"},
+        "trace_integrity_evidence": {"trace_linked": True, "trace_complete": True},
+        "lineage_provenance_evidence": {"lineage_valid": True, "lineage_chain_complete": True},
+        "dependency_state": {"graph_integrity": True, "unresolved_dependencies": []},
+        "authority_records": {"docs/roadmaps/system_roadmap.md#RAX-INTERFACE-24-01": "1.3.112"},
+    }
+
+
+def test_redteam_pack_covers_all_required_failure_classes() -> None:
+    pack = _load_pack()
+    classes = {case["failure_class"] for case in pack["cases"]}
+    assert classes == {
+        "semantic_drift",
+        "readiness_inflation",
+        "missing_weak_counter_evidence",
+        "provenance_gaps",
+        "replay_inconsistency",
+        "policy_drift_mismatch",
+        "feedback_loop_poisoning",
+        "unknown_state_partial_signals",
+    }
+
+
+def test_redteam_pack_executes_serial_and_fails_closed() -> None:
+    pack = _load_pack()
+
+    for case in pack["cases"]:
+        out = run_rax_eval_runner(
+            run_id=case["run_id"],
+            target_ref=pack["target_ref"],
+            trace_id=case["trace_id"],
+            input_assurance=case["input_assurance"],
+            output_assurance=case["output_assurance"],
+            tests_passed=case["tests_passed"],
+            baseline_regression_detected=case["baseline_regression_detected"],
+            version_authority_aligned=case["version_authority_aligned"],
+            omit_eval_types=case.get("omit_eval_types"),
+        )
+
+        if case.get("expect_failure_candidate"):
+            assert out["failure_pattern_records"]
+            assert out["eval_case_candidates"]
+            continue
+
+        coverage = out["required_eval_coverage"]
+        if case.get("tamper_required_coverage"):
+            coverage = dict(coverage)
+            coverage["required_eval_types"] = ["rax_control_readiness"]
+
+        evidence = _governed_evidence()
+        if "lineage_provenance_evidence" in case:
+            evidence["lineage_provenance_evidence"] = case["lineage_provenance_evidence"]
+        if case.get("drop_trace_integrity_evidence"):
+            evidence.pop("trace_integrity_evidence")
+        if case.get("replay_key_only"):
+            evidence["replay_key"] = "same-input-identity"
+
+        if case["failure_class"] == "missing_weak_counter_evidence":
+            evidence["assurance_audit"] = build_rax_assurance_audit_record(
+                roadmap_id="SYSTEM-ROADMAP-2026",
+                step_id="RAX-INTERFACE-24-01",
+                input_assurance=case["input_assurance"],
+                output_assurance=case["output_assurance"],
+            )
+
+        readiness = evaluate_rax_control_readiness(
+            batch=pack["batch"],
+            target_ref=pack["target_ref"],
+            eval_summary=out["eval_summary"],
+            eval_results=out["eval_results"],
+            required_eval_coverage=coverage,
+            **evidence,
+        )
+
+        assert readiness["ready_for_control"] is False, case["case_id"]
+        assert case["expected_blocking_reason"] in readiness["blocking_reasons"], case["case_id"]


### PR DESCRIPTION
### Motivation
- Harden the RAX boundary by adversarially exercising known failure classes so every discovered weakness becomes deterministic eval cases and permanent regression tests.
- Preserve fail-closed behavior and keep RAX as candidate-only readiness surface while surfacing gaps in trace/lineage/replay/eval integration.

### Description
- Add a written plan `docs/review-actions/PLAN-RAX-RED-01-2026-04-12.md` documenting the `VALIDATE` run and scope for the adversarial pack.
- Add deterministic adversarial fixtures in `tests/fixtures/rax_adversarial_eval_pack.json` covering eight failure classes and a serial red-team harness `tests/test_rax_redteam_adversarial_pack.py` that executes each case through the RAX eval/readiness flow and asserts fail-closed outcomes.
- Harden readiness computation in `spectrum_systems/modules/runtime/rax_eval_runner.py` to block on incomplete lineage chains (`artifact_lineage_incomplete`) and incomplete replay evidence (`replay_consistency_evidence_incomplete`) and escalate partial replay evidence into the unknown-state record.
- Extend test coverage in `tests/test_rax_eval_runner.py` for the new fail-closed checks and add RAX-RED-01 entries to the canonical eval case set in `contracts/examples/rax_eval_case_set.json` so adversarial cases are permanently encoded.

### Testing
- Ran the red-team pack tests with `pytest tests/test_rax_redteam_adversarial_pack.py`, which passed.
- Ran the expanded RAX unit tests with `pytest tests/test_rax_eval_runner.py tests/test_rax_interface_assurance.py`, which passed (51 tests total in that run).
- Ran contract validation with `pytest tests/test_contracts.py`, which passed (80 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dba40ef0208329ba21105073a11eed)