### PR TITLE
Implement RAX-03..RAX-12: discovery, arbitration, non-authority, drift, admission, judgment, replay, intelligence, and promotion hard-gate

### DIFF
--- a/contracts/examples/rax_conflict_arbitration_record.json
+++ b/contracts/examples/rax_conflict_arbitration_record.json
@@ -1,0 +1,16 @@
+{
+  "artifact_type": "rax_conflict_arbitration_record",
+  "schema_version": "1.0.0",
+  "arbitration_id": "conflict:RAX-EVAL-01:12121212-1212-4121-8121-121212121212",
+  "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
+  "trace_id": "12121212-1212-4121-8121-121212121212",
+  "signal_status": {
+    "rax_control_readiness": "pass",
+    "rax_output_semantic_alignment": "fail"
+  },
+  "material_conflicts": [
+    "readiness_vs_required_eval"
+  ],
+  "resolution_status": "unresolved_fail_closed",
+  "fail_closed": true
+}

--- a/contracts/examples/rax_control_readiness_record.json
+++ b/contracts/examples/rax_control_readiness_record.json
@@ -1,6 +1,6 @@
 {
   "artifact_type": "rax_control_readiness_record",
-  "schema_version": "1.0.0",
+  "schema_version": "1.1.0",
   "batch": "RAX-EVAL-01",
   "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
   "ready_for_control": false,
@@ -47,5 +47,18 @@
     }
   ],
   "unknown_state_ref": "unknown-001",
-  "pre_certification_alignment_ref": "precert-001"
+  "pre_certification_alignment_ref": "precert-001",
+  "conflict_arbitration_ref": "conflict-001",
+  "non_authority_assertions": [
+    "readiness_is_non_authoritative",
+    "no_promotion_or_release_authority",
+    "control_transition_requires_downstream_control_artifact"
+  ],
+  "replay_identity": {
+    "policy_version": "1.0.0",
+    "semantic_rule_version": "1.0.0",
+    "eval_config_version": "1.0.0",
+    "contradiction_logic_version": "1.0.0",
+    "fingerprint": "abc12345def67890"
+  }
 }

--- a/contracts/examples/rax_eval_candidate_admission_record.json
+++ b/contracts/examples/rax_eval_candidate_admission_record.json
@@ -1,0 +1,7 @@
+{
+  "artifact_type": "rax_eval_candidate_admission_record",
+  "schema_version": "1.0.0",
+  "candidate_id": "rax-failure-abc123:eval-candidate",
+  "admitted": true,
+  "denial_reasons": []
+}

--- a/contracts/examples/rax_eval_case_set.json
+++ b/contracts/examples/rax_eval_case_set.json
@@ -1,9 +1,116 @@
 {
   "artifact_type": "rax_eval_case_set",
-  "schema_version": "1.0.0",
+  "schema_version": "1.1.0",
   "batch": "RAX-EVAL-01",
   "case_set_version": "1.0.0",
   "cases": [
+    {
+      "eval_case_id": "rax-03-ambiguity-mutation-01",
+      "eval_type": "rax_input_semantic_sufficiency",
+      "case_class": "discovery_mutation",
+      "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
+      "expected_status": "fail",
+      "reason_codes": [
+        "ambiguous_source_intent_detected"
+      ],
+      "signals": [
+        "ambiguity",
+        "mutation"
+      ],
+      "trace_id": "7742cc59-a6b8-44bd-9156-ce086c41b928"
+    },
+    {
+      "eval_case_id": "rax-03-hidden-scope-combo-01",
+      "eval_type": "rax_output_semantic_alignment",
+      "case_class": "discovery_combo",
+      "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
+      "expected_status": "fail",
+      "reason_codes": [
+        "hidden_scope_expansion_detected",
+        "semantic_expansion_mismatch"
+      ],
+      "signals": [
+        "hidden_scope_expansion",
+        "multi_signal"
+      ],
+      "trace_id": "f24314a3-77ed-4e28-a3a2-993a2da89e69"
+    },
+    {
+      "eval_case_id": "rax-03-multi-signal-exploit-combo-01",
+      "eval_type": "rax_control_readiness",
+      "case_class": "discovery_combo",
+      "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
+      "expected_status": "fail",
+      "reason_codes": [
+        "contradiction_unresolved",
+        "dependency_omission_detected"
+      ],
+      "signals": [
+        "multi_signal",
+        "combinatorial"
+      ],
+      "trace_id": "b904ff1f-748d-4444-93f5-0618dcb31162"
+    },
+    {
+      "eval_case_id": "rax-03-provenance-weakness-mutation-01",
+      "eval_type": "rax_version_authority_alignment",
+      "case_class": "discovery_mutation",
+      "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
+      "expected_status": "fail",
+      "reason_codes": [
+        "source_version_drift"
+      ],
+      "signals": [
+        "provenance_weakness",
+        "mutation"
+      ],
+      "trace_id": "ed6cfc24-9cf1-4d16-bcb6-a20db9210bda"
+    },
+    {
+      "eval_case_id": "rax-03-replay-weakness-mutation-01",
+      "eval_type": "rax_control_readiness",
+      "case_class": "discovery_mutation",
+      "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
+      "expected_status": "fail",
+      "reason_codes": [
+        "cross_run_eval_signal_inconsistency"
+      ],
+      "signals": [
+        "replay_weakness",
+        "mutation"
+      ],
+      "trace_id": "74b0cda5-4e8f-4ea7-9aa5-11fede724b7c"
+    },
+    {
+      "eval_case_id": "rax-03-semantic-drift-mutation-01",
+      "eval_type": "rax_input_semantic_sufficiency",
+      "case_class": "discovery_mutation",
+      "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
+      "expected_status": "fail",
+      "reason_codes": [
+        "semantic_intent_insufficient"
+      ],
+      "signals": [
+        "semantic_drift",
+        "mutation"
+      ],
+      "trace_id": "ffafef6b-8850-4e5f-859f-0b664d498dbf"
+    },
+    {
+      "eval_case_id": "rax-03-weak-counter-evidence-mutation-01",
+      "eval_type": "rax_control_readiness",
+      "case_class": "discovery_mutation",
+      "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
+      "expected_status": "fail",
+      "reason_codes": [
+        "weak_counter_evidence_detected"
+      ],
+      "signals": [
+        "weak_counter_evidence",
+        "mutation"
+      ],
+      "trace_id": "eef27ded-78a5-4d4c-962f-b44b7caf6fdc"
+    },
     {
       "eval_case_id": "rax-case-baseline-input",
       "eval_type": "rax_input_semantic_sufficiency",
@@ -391,64 +498,19 @@
       "trace_id": "20000000-0000-4000-8000-000000000001"
     },
     {
-      "eval_case_id": "rax-red-02-priority-inversion",
-      "eval_type": "rax_normalization_integrity",
+      "eval_case_id": "rax-red-02-ambiguous-intent",
+      "eval_type": "rax_input_semantic_sufficiency",
       "case_class": "adversarial",
       "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
       "expected_status": "fail",
       "reason_codes": [
-        "priority_inversion_detected"
+        "ambiguous_source_intent_detected"
       ],
       "signals": [
         "RAX-RED-02",
         "semantic_adversarial_pack"
       ],
-      "trace_id": "30000000-0000-4000-8000-000000000021"
-    },
-    {
-      "eval_case_id": "rax-red-02-dependency-omission",
-      "eval_type": "rax_control_readiness",
-      "case_class": "adversarial",
-      "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
-      "expected_status": "fail",
-      "reason_codes": [
-        "dependency_omission_detected"
-      ],
-      "signals": [
-        "RAX-RED-02",
-        "semantic_adversarial_pack"
-      ],
-      "trace_id": "30000000-0000-4000-8000-000000000022"
-    },
-    {
-      "eval_case_id": "rax-red-02-owner-intent-mismatch",
-      "eval_type": "rax_owner_intent_alignment",
-      "case_class": "adversarial",
-      "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
-      "expected_status": "fail",
-      "reason_codes": [
-        "owner_intent_mismatch_detected"
-      ],
-      "signals": [
-        "RAX-RED-02",
-        "semantic_adversarial_pack"
-      ],
-      "trace_id": "30000000-0000-4000-8000-000000000023"
-    },
-    {
-      "eval_case_id": "rax-red-02-weak-counter-evidence",
-      "eval_type": "rax_control_readiness",
-      "case_class": "adversarial",
-      "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
-      "expected_status": "fail",
-      "reason_codes": [
-        "weak_counter_evidence_detected"
-      ],
-      "signals": [
-        "RAX-RED-02",
-        "semantic_adversarial_pack"
-      ],
-      "trace_id": "30000000-0000-4000-8000-000000000024"
+      "trace_id": "30000000-0000-4000-8000-000000000028"
     },
     {
       "eval_case_id": "rax-red-02-contradiction-unresolved",
@@ -466,19 +528,49 @@
       "trace_id": "30000000-0000-4000-8000-000000000025"
     },
     {
-      "eval_case_id": "rax-red-02-semantic-expansion-mismatch",
-      "eval_type": "rax_output_semantic_alignment",
+      "eval_case_id": "rax-red-02-dependency-omission",
+      "eval_type": "rax_control_readiness",
       "case_class": "adversarial",
       "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
       "expected_status": "fail",
       "reason_codes": [
-        "semantic_expansion_mismatch"
+        "dependency_omission_detected"
       ],
       "signals": [
         "RAX-RED-02",
         "semantic_adversarial_pack"
       ],
-      "trace_id": "30000000-0000-4000-8000-000000000026"
+      "trace_id": "30000000-0000-4000-8000-000000000022"
+    },
+    {
+      "eval_case_id": "rax-red-02-hidden-scope-expansion",
+      "eval_type": "rax_output_semantic_alignment",
+      "case_class": "adversarial",
+      "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
+      "expected_status": "fail",
+      "reason_codes": [
+        "hidden_scope_expansion_detected"
+      ],
+      "signals": [
+        "RAX-RED-02",
+        "semantic_adversarial_pack"
+      ],
+      "trace_id": "30000000-0000-4000-8000-000000000029"
+    },
+    {
+      "eval_case_id": "rax-red-02-owner-intent-mismatch",
+      "eval_type": "rax_owner_intent_alignment",
+      "case_class": "adversarial",
+      "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
+      "expected_status": "fail",
+      "reason_codes": [
+        "owner_intent_mismatch_detected"
+      ],
+      "signals": [
+        "RAX-RED-02",
+        "semantic_adversarial_pack"
+      ],
+      "trace_id": "30000000-0000-4000-8000-000000000023"
     },
     {
       "eval_case_id": "rax-red-02-policy-meaning-drift",
@@ -496,34 +588,49 @@
       "trace_id": "30000000-0000-4000-8000-000000000027"
     },
     {
-      "eval_case_id": "rax-red-02-ambiguous-intent",
-      "eval_type": "rax_input_semantic_sufficiency",
+      "eval_case_id": "rax-red-02-priority-inversion",
+      "eval_type": "rax_normalization_integrity",
       "case_class": "adversarial",
       "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
       "expected_status": "fail",
       "reason_codes": [
-        "ambiguous_source_intent_detected"
+        "priority_inversion_detected"
       ],
       "signals": [
         "RAX-RED-02",
         "semantic_adversarial_pack"
       ],
-      "trace_id": "30000000-0000-4000-8000-000000000028"
+      "trace_id": "30000000-0000-4000-8000-000000000021"
     },
     {
-      "eval_case_id": "rax-red-02-hidden-scope-expansion",
+      "eval_case_id": "rax-red-02-semantic-expansion-mismatch",
       "eval_type": "rax_output_semantic_alignment",
       "case_class": "adversarial",
       "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
       "expected_status": "fail",
       "reason_codes": [
-        "hidden_scope_expansion_detected"
+        "semantic_expansion_mismatch"
       ],
       "signals": [
         "RAX-RED-02",
         "semantic_adversarial_pack"
       ],
-      "trace_id": "30000000-0000-4000-8000-000000000029"
+      "trace_id": "30000000-0000-4000-8000-000000000026"
+    },
+    {
+      "eval_case_id": "rax-red-02-weak-counter-evidence",
+      "eval_type": "rax_control_readiness",
+      "case_class": "adversarial",
+      "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
+      "expected_status": "fail",
+      "reason_codes": [
+        "weak_counter_evidence_detected"
+      ],
+      "signals": [
+        "RAX-RED-02",
+        "semantic_adversarial_pack"
+      ],
+      "trace_id": "30000000-0000-4000-8000-000000000024"
     }
   ]
 }

--- a/contracts/examples/rax_eval_registry.json
+++ b/contracts/examples/rax_eval_registry.json
@@ -1,6 +1,6 @@
 {
   "artifact_type": "rax_eval_registry",
-  "schema_version": "1.0.0",
+  "schema_version": "1.1.0",
   "batch": "RAX-EVAL-01",
   "registry_version": "1.0.0",
   "runner_kind": "deterministic_policy_runner",
@@ -8,83 +8,168 @@
     {
       "eval_type": "rax_input_semantic_sufficiency",
       "required": true,
-      "target_artifacts": ["rax_upstream_input_envelope"],
-      "pass_criteria": ["intent is semantically sufficient and non-placeholder"],
+      "target_artifacts": [
+        "rax_upstream_input_envelope"
+      ],
+      "pass_criteria": [
+        "intent is semantically sufficient and non-placeholder"
+      ],
       "runner_kind": "deterministic_policy_runner",
-      "expected_signals": ["semantic_intent_sufficient"],
-      "example_case_refs": ["rax-case-semantic-empty-intent", "rax-case-baseline-input"]
+      "expected_signals": [
+        "semantic_intent_sufficient"
+      ],
+      "example_case_refs": [
+        "rax-case-semantic-empty-intent",
+        "rax-case-baseline-input"
+      ]
     },
     {
       "eval_type": "rax_owner_intent_alignment",
       "required": true,
-      "target_artifacts": ["rax_upstream_input_envelope"],
-      "pass_criteria": ["owner scope does not contradict intent"],
+      "target_artifacts": [
+        "rax_upstream_input_envelope"
+      ],
+      "pass_criteria": [
+        "owner scope does not contradict intent"
+      ],
       "runner_kind": "deterministic_policy_runner",
-      "expected_signals": ["owner_intent_aligned"],
-      "example_case_refs": ["rax-case-owner-intent-contradiction", "rax-case-baseline-input"]
+      "expected_signals": [
+        "owner_intent_aligned"
+      ],
+      "example_case_refs": [
+        "rax-case-owner-intent-contradiction",
+        "rax-case-baseline-input"
+      ]
     },
     {
       "eval_type": "rax_normalization_integrity",
       "required": true,
-      "target_artifacts": ["rax_upstream_input_envelope"],
-      "pass_criteria": ["normalization does not collapse distinct source values"],
+      "target_artifacts": [
+        "rax_upstream_input_envelope"
+      ],
+      "pass_criteria": [
+        "normalization does not collapse distinct source values"
+      ],
       "runner_kind": "deterministic_policy_runner",
-      "expected_signals": ["normalization_unambiguous"],
-      "example_case_refs": ["rax-case-normalization-collapse", "rax-case-baseline-input"]
+      "expected_signals": [
+        "normalization_unambiguous"
+      ],
+      "example_case_refs": [
+        "rax-case-normalization-collapse",
+        "rax-case-baseline-input"
+      ]
     },
     {
       "eval_type": "rax_output_semantic_alignment",
       "required": true,
-      "target_artifacts": ["roadmap_step_contract"],
-      "pass_criteria": ["output target modules and checks match stated intent and owner scope"],
+      "target_artifacts": [
+        "roadmap_step_contract"
+      ],
+      "pass_criteria": [
+        "output target modules and checks match stated intent and owner scope"
+      ],
       "runner_kind": "deterministic_policy_runner",
-      "expected_signals": ["output_semantically_aligned"],
-      "example_case_refs": ["rax-case-wrong-target", "rax-case-output-overexpanded", "rax-case-baseline-output"]
+      "expected_signals": [
+        "output_semantically_aligned"
+      ],
+      "example_case_refs": [
+        "rax-case-wrong-target",
+        "rax-case-output-overexpanded",
+        "rax-case-baseline-output"
+      ]
     },
     {
       "eval_type": "rax_acceptance_check_strength",
       "required": true,
-      "target_artifacts": ["roadmap_step_contract"],
-      "pass_criteria": ["acceptance checks are strong, deterministic, and required"],
+      "target_artifacts": [
+        "roadmap_step_contract"
+      ],
+      "pass_criteria": [
+        "acceptance checks are strong, deterministic, and required"
+      ],
       "runner_kind": "deterministic_policy_runner",
-      "expected_signals": ["acceptance_checks_strong"],
-      "example_case_refs": ["rax-case-weak-acceptance-checks", "rax-case-baseline-output"]
+      "expected_signals": [
+        "acceptance_checks_strong"
+      ],
+      "example_case_refs": [
+        "rax-case-weak-acceptance-checks",
+        "rax-case-baseline-output"
+      ]
     },
     {
       "eval_type": "rax_trace_integrity",
       "required": true,
-      "target_artifacts": ["roadmap_expansion_trace"],
-      "pass_criteria": ["trace exists and contains required field derivation coverage"],
+      "target_artifacts": [
+        "roadmap_expansion_trace"
+      ],
+      "pass_criteria": [
+        "trace exists and contains required field derivation coverage"
+      ],
       "runner_kind": "deterministic_policy_runner",
-      "expected_signals": ["trace_complete"],
-      "example_case_refs": ["rax-case-missing-trace", "rax-case-baseline-trace"]
+      "expected_signals": [
+        "trace_complete"
+      ],
+      "example_case_refs": [
+        "rax-case-missing-trace",
+        "rax-case-baseline-trace"
+      ]
     },
     {
       "eval_type": "rax_version_authority_alignment",
       "required": true,
-      "target_artifacts": ["rax_upstream_input_envelope"],
-      "pass_criteria": ["source_version matches source authority mapping"],
+      "target_artifacts": [
+        "rax_upstream_input_envelope"
+      ],
+      "pass_criteria": [
+        "source_version matches source authority mapping"
+      ],
       "runner_kind": "deterministic_policy_runner",
-      "expected_signals": ["source_version_aligned"],
-      "example_case_refs": ["rax-case-source-version-drift", "rax-case-baseline-input"]
+      "expected_signals": [
+        "source_version_aligned"
+      ],
+      "example_case_refs": [
+        "rax-case-source-version-drift",
+        "rax-case-baseline-input"
+      ]
     },
     {
       "eval_type": "rax_regression_against_baseline",
       "required": true,
-      "target_artifacts": ["roadmap_step_contract"],
-      "pass_criteria": ["candidate does not regress against accepted baseline quality"],
+      "target_artifacts": [
+        "roadmap_step_contract"
+      ],
+      "pass_criteria": [
+        "candidate does not regress against accepted baseline quality"
+      ],
       "runner_kind": "deterministic_policy_runner",
-      "expected_signals": ["baseline_regression_absent"],
-      "example_case_refs": ["rax-case-regression-missing-baseline-guard", "rax-case-baseline-output"]
+      "expected_signals": [
+        "baseline_regression_absent"
+      ],
+      "example_case_refs": [
+        "rax-case-regression-missing-baseline-guard",
+        "rax-case-baseline-output"
+      ]
     },
     {
       "eval_type": "rax_control_readiness",
       "required": true,
-      "target_artifacts": ["rax_control_readiness_record"],
-      "pass_criteria": ["required eval set complete and no blocking semantic failures"],
+      "target_artifacts": [
+        "rax_control_readiness_record"
+      ],
+      "pass_criteria": [
+        "required eval set complete and no blocking semantic failures"
+      ],
       "runner_kind": "deterministic_policy_runner",
-      "expected_signals": ["control_readiness_true"],
-      "example_case_refs": ["rax-case-missing-control-readiness-evidence", "rax-case-baseline-readiness"]
+      "expected_signals": [
+        "control_readiness_true"
+      ],
+      "example_case_refs": [
+        "rax-case-missing-control-readiness-evidence",
+        "rax-case-baseline-readiness"
+      ]
     }
-  ]
+  ],
+  "policy_version": "1.0.0",
+  "semantic_rule_version": "1.0.0",
+  "eval_config_version": "1.0.0"
 }

--- a/contracts/examples/rax_improvement_recommendation_record.json
+++ b/contracts/examples/rax_improvement_recommendation_record.json
@@ -1,0 +1,11 @@
+{
+  "artifact_type": "rax_improvement_recommendation_record",
+  "schema_version": "1.0.0",
+  "recommendation_id": "improve-001",
+  "posture_snapshot_ref": "trust-posture-001",
+  "trend_report_ref": "trend-001",
+  "recommendations": [
+    "maintain_current_hardening"
+  ],
+  "authority_note": "non_authoritative_advisory_only"
+}

--- a/contracts/examples/rax_judgment_record.json
+++ b/contracts/examples/rax_judgment_record.json
@@ -1,0 +1,13 @@
+{
+  "artifact_type": "rax_judgment_record",
+  "schema_version": "1.0.0",
+  "judgment_id": "judgment-001",
+  "target_ref": "roadmap_step_contract:RAX-INTERFACE-24-01",
+  "judgment_outcome": "more_evidence_needed",
+  "rationale": [
+    "material_conflict_unresolved",
+    "missing_required_eval_types"
+  ],
+  "conflict_ref": "conflict:RAX-EVAL-01:12121212-1212-4121-8121-121212121212",
+  "authority_note": "judgment_only_non_authoritative"
+}

--- a/contracts/examples/rax_promotion_hard_gate_record.json
+++ b/contracts/examples/rax_promotion_hard_gate_record.json
@@ -1,0 +1,11 @@
+{
+  "artifact_type": "rax_promotion_hard_gate_record",
+  "schema_version": "1.0.0",
+  "gate_id": "promote-gate-001",
+  "passed": false,
+  "missing_evidence": [
+    "replay_evidence_missing",
+    "policy_regression_evidence_missing"
+  ],
+  "decision": "block"
+}

--- a/contracts/examples/rax_trend_report.json
+++ b/contracts/examples/rax_trend_report.json
@@ -1,0 +1,14 @@
+{
+  "artifact_type": "rax_trend_report",
+  "schema_version": "1.0.0",
+  "report_id": "trend-001",
+  "window_ref": "window://rax/2026-w15",
+  "exploit_hit_rate": 0.2,
+  "block_rate": 0.4,
+  "contradiction_rate": 0.1,
+  "override_escalation_proxy_rate": 0.05,
+  "false_block_proxy_rate": 0.03,
+  "false_allow_proxy_rate": 0.01,
+  "confidence_mean": 0.79,
+  "sample_size": 40
+}

--- a/contracts/examples/rax_trust_posture_snapshot.json
+++ b/contracts/examples/rax_trust_posture_snapshot.json
@@ -1,0 +1,12 @@
+{
+  "artifact_type": "rax_trust_posture_snapshot",
+  "schema_version": "1.0.0",
+  "snapshot_id": "trust-posture-001",
+  "trend_report_ref": "trend-001",
+  "posture": "stable",
+  "primary_signals": [
+    "block_rate:0.400",
+    "contradiction_rate:0.100",
+    "false_allow_proxy_rate:0.010"
+  ]
+}

--- a/contracts/schemas/rax_adversarial_pattern_candidate.schema.json
+++ b/contracts/schemas/rax_adversarial_pattern_candidate.schema.json
@@ -36,7 +36,14 @@
         "mutated_literal_variant",
         "nested_variant",
         "cross_step_contamination_variant",
-        "partial_signal_contradiction"
+        "partial_signal_contradiction",
+        "semantic_drift_variant",
+        "provenance_weakness_variant",
+        "replay_weakness_variant",
+        "ambiguity_variant",
+        "weak_counter_evidence_variant",
+        "hidden_scope_expansion_variant",
+        "multi_signal_exploit_combo"
       ]
     },
     "target_ref": {

--- a/contracts/schemas/rax_conflict_arbitration_record.schema.json
+++ b/contracts/schemas/rax_conflict_arbitration_record.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/rax_conflict_arbitration_record.schema.json",
+  "title": "RAX Conflict Arbitration Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "arbitration_id",
+    "target_ref",
+    "trace_id",
+    "signal_status",
+    "material_conflicts",
+    "resolution_status",
+    "fail_closed"
+  ],
+  "properties": {
+    "artifact_type": {"type": "string", "const": "rax_conflict_arbitration_record"},
+    "schema_version": {"type": "string", "const": "1.0.0"},
+    "arbitration_id": {"type": "string", "minLength": 1},
+    "target_ref": {"type": "string", "minLength": 1},
+    "trace_id": {"type": "string", "minLength": 1},
+    "signal_status": {
+      "type": "object",
+      "additionalProperties": {"type": "string", "enum": ["pass", "fail", "unknown"]}
+    },
+    "material_conflicts": {"type": "array", "items": {"type": "string", "minLength": 1}},
+    "resolution_status": {"type": "string", "enum": ["no_conflict", "unresolved_fail_closed"]},
+    "fail_closed": {"type": "boolean"}
+  }
+}

--- a/contracts/schemas/rax_control_readiness_record.schema.json
+++ b/contracts/schemas/rax_control_readiness_record.schema.json
@@ -21,7 +21,10 @@
     "version_authority_aligned",
     "conditions_under_which_ready_changes",
     "unknown_state_ref",
-    "pre_certification_alignment_ref"
+    "pre_certification_alignment_ref",
+    "conflict_arbitration_ref",
+    "non_authority_assertions",
+    "replay_identity"
   ],
   "properties": {
     "artifact_type": {
@@ -30,7 +33,7 @@
     },
     "schema_version": {
       "type": "string",
-      "const": "1.0.0"
+      "const": "1.1.0"
     },
     "batch": {
       "type": "string",
@@ -131,6 +134,51 @@
     "pre_certification_alignment_ref": {
       "type": "string",
       "minLength": 1
+    },
+    "conflict_arbitration_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "non_authority_assertions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "replay_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "policy_version",
+        "semantic_rule_version",
+        "eval_config_version",
+        "contradiction_logic_version",
+        "fingerprint"
+      ],
+      "properties": {
+        "policy_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "semantic_rule_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "eval_config_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "contradiction_logic_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "fingerprint": {
+          "type": "string",
+          "minLength": 8
+        }
+      }
     }
   }
 }

--- a/contracts/schemas/rax_eval_candidate_admission_record.schema.json
+++ b/contracts/schemas/rax_eval_candidate_admission_record.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/rax_eval_candidate_admission_record.schema.json",
+  "title": "RAX Eval Candidate Admission Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "candidate_id",
+    "admitted",
+    "denial_reasons"
+  ],
+  "properties": {
+    "artifact_type": {"type": "string", "const": "rax_eval_candidate_admission_record"},
+    "schema_version": {"type": "string", "const": "1.0.0"},
+    "candidate_id": {"type": "string", "minLength": 1},
+    "admitted": {"type": "boolean"},
+    "denial_reasons": {"type": "array", "items": {"type": "string", "minLength": 1}}
+  }
+}

--- a/contracts/schemas/rax_eval_case_set.schema.json
+++ b/contracts/schemas/rax_eval_case_set.schema.json
@@ -5,12 +5,30 @@
   "description": "Governed deterministic RAX eval cases across adversarial, baseline, and failure-class coverage.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["artifact_type", "schema_version", "batch", "case_set_version", "cases"],
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "batch",
+    "case_set_version",
+    "cases"
+  ],
   "properties": {
-    "artifact_type": {"type": "string", "const": "rax_eval_case_set"},
-    "schema_version": {"type": "string", "const": "1.0.0"},
-    "batch": {"type": "string", "minLength": 1},
-    "case_set_version": {"type": "string", "minLength": 1},
+    "artifact_type": {
+      "type": "string",
+      "const": "rax_eval_case_set"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.1.0"
+    },
+    "batch": {
+      "type": "string",
+      "minLength": 1
+    },
+    "case_set_version": {
+      "type": "string",
+      "minLength": 1
+    },
     "cases": {
       "type": "array",
       "minItems": 1,
@@ -28,14 +46,56 @@
           "trace_id"
         ],
         "properties": {
-          "eval_case_id": {"type": "string", "minLength": 1},
-          "eval_type": {"type": "string", "minLength": 1},
-          "case_class": {"type": "string", "enum": ["baseline", "adversarial", "failure_class"]},
-          "target_ref": {"type": "string", "minLength": 1},
-          "expected_status": {"type": "string", "enum": ["pass", "fail", "indeterminate"]},
-          "reason_codes": {"type": "array", "items": {"type": "string", "minLength": 1}, "minItems": 1},
-          "signals": {"type": "array", "items": {"type": "string", "minLength": 1}, "minItems": 1},
-          "trace_id": {"type": "string", "format": "uuid"}
+          "eval_case_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "eval_type": {
+            "type": "string",
+            "minLength": 1
+          },
+          "case_class": {
+            "type": "string",
+            "enum": [
+              "baseline",
+              "adversarial",
+              "failure_class",
+              "discovery_mutation",
+              "discovery_combo"
+            ]
+          },
+          "target_ref": {
+            "type": "string",
+            "minLength": 1
+          },
+          "expected_status": {
+            "type": "string",
+            "enum": [
+              "pass",
+              "fail",
+              "indeterminate"
+            ]
+          },
+          "reason_codes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "minItems": 1
+          },
+          "signals": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "minItems": 1
+          },
+          "trace_id": {
+            "type": "string",
+            "format": "uuid"
+          }
         }
       }
     }

--- a/contracts/schemas/rax_eval_registry.schema.json
+++ b/contracts/schemas/rax_eval_registry.schema.json
@@ -11,14 +11,32 @@
     "batch",
     "registry_version",
     "runner_kind",
-    "eval_definitions"
+    "eval_definitions",
+    "policy_version",
+    "semantic_rule_version",
+    "eval_config_version"
   ],
   "properties": {
-    "artifact_type": {"type": "string", "const": "rax_eval_registry"},
-    "schema_version": {"type": "string", "const": "1.0.0"},
-    "batch": {"type": "string", "minLength": 1},
-    "registry_version": {"type": "string", "minLength": 1},
-    "runner_kind": {"type": "string", "const": "deterministic_policy_runner"},
+    "artifact_type": {
+      "type": "string",
+      "const": "rax_eval_registry"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.1.0"
+    },
+    "batch": {
+      "type": "string",
+      "minLength": 1
+    },
+    "registry_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "runner_kind": {
+      "type": "string",
+      "const": "deterministic_policy_runner"
+    },
     "eval_definitions": {
       "type": "array",
       "minItems": 1,
@@ -35,15 +53,63 @@
           "example_case_refs"
         ],
         "properties": {
-          "eval_type": {"type": "string", "minLength": 1},
-          "required": {"type": "boolean"},
-          "target_artifacts": {"type": "array", "items": {"type": "string", "minLength": 1}, "minItems": 1},
-          "pass_criteria": {"type": "array", "items": {"type": "string", "minLength": 1}, "minItems": 1},
-          "runner_kind": {"type": "string", "const": "deterministic_policy_runner"},
-          "expected_signals": {"type": "array", "items": {"type": "string", "minLength": 1}, "minItems": 1},
-          "example_case_refs": {"type": "array", "items": {"type": "string", "minLength": 1}, "minItems": 1}
+          "eval_type": {
+            "type": "string",
+            "minLength": 1
+          },
+          "required": {
+            "type": "boolean"
+          },
+          "target_artifacts": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "minItems": 1
+          },
+          "pass_criteria": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "minItems": 1
+          },
+          "runner_kind": {
+            "type": "string",
+            "const": "deterministic_policy_runner"
+          },
+          "expected_signals": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "minItems": 1
+          },
+          "example_case_refs": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "minItems": 1
+          }
         }
       }
+    },
+    "policy_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "semantic_rule_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "eval_config_version": {
+      "type": "string",
+      "minLength": 1
     }
   }
 }

--- a/contracts/schemas/rax_improvement_recommendation_record.schema.json
+++ b/contracts/schemas/rax_improvement_recommendation_record.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/rax_improvement_recommendation_record.schema.json",
+  "title": "RAX Improvement Recommendation Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "recommendation_id",
+    "posture_snapshot_ref",
+    "trend_report_ref",
+    "recommendations",
+    "authority_note"
+  ],
+  "properties": {
+    "artifact_type": {"type": "string", "const": "rax_improvement_recommendation_record"},
+    "schema_version": {"type": "string", "const": "1.0.0"},
+    "recommendation_id": {"type": "string", "minLength": 1},
+    "posture_snapshot_ref": {"type": "string", "minLength": 1},
+    "trend_report_ref": {"type": "string", "minLength": 1},
+    "recommendations": {"type": "array", "items": {"type": "string", "minLength": 1}, "minItems": 1},
+    "authority_note": {"type": "string", "const": "non_authoritative_advisory_only"}
+  }
+}

--- a/contracts/schemas/rax_judgment_record.schema.json
+++ b/contracts/schemas/rax_judgment_record.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/rax_judgment_record.schema.json",
+  "title": "RAX Judgment Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "judgment_id",
+    "target_ref",
+    "judgment_outcome",
+    "rationale",
+    "conflict_ref",
+    "authority_note"
+  ],
+  "properties": {
+    "artifact_type": {"type": "string", "const": "rax_judgment_record"},
+    "schema_version": {"type": "string", "const": "1.0.0"},
+    "judgment_id": {"type": "string", "minLength": 1},
+    "target_ref": {"type": "string", "minLength": 1},
+    "judgment_outcome": {"type": "string", "enum": ["ready", "revise", "more_evidence_needed"]},
+    "rationale": {"type": "array", "items": {"type": "string", "minLength": 1}},
+    "conflict_ref": {"type": "string", "minLength": 1},
+    "authority_note": {"type": "string", "const": "judgment_only_non_authoritative"}
+  }
+}

--- a/contracts/schemas/rax_promotion_hard_gate_record.schema.json
+++ b/contracts/schemas/rax_promotion_hard_gate_record.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/rax_promotion_hard_gate_record.schema.json",
+  "title": "RAX Promotion Hard Gate Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "gate_id",
+    "passed",
+    "missing_evidence",
+    "decision"
+  ],
+  "properties": {
+    "artifact_type": {"type": "string", "const": "rax_promotion_hard_gate_record"},
+    "schema_version": {"type": "string", "const": "1.0.0"},
+    "gate_id": {"type": "string", "minLength": 1},
+    "passed": {"type": "boolean"},
+    "missing_evidence": {"type": "array", "items": {"type": "string", "minLength": 1}},
+    "decision": {"type": "string", "enum": ["promote", "block"]}
+  }
+}

--- a/contracts/schemas/rax_trend_report.schema.json
+++ b/contracts/schemas/rax_trend_report.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/rax_trend_report.schema.json",
+  "title": "RAX Trend Report",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "report_id",
+    "window_ref",
+    "exploit_hit_rate",
+    "block_rate",
+    "contradiction_rate",
+    "override_escalation_proxy_rate",
+    "false_block_proxy_rate",
+    "false_allow_proxy_rate",
+    "confidence_mean",
+    "sample_size"
+  ],
+  "properties": {
+    "artifact_type": {"type": "string", "const": "rax_trend_report"},
+    "schema_version": {"type": "string", "const": "1.0.0"},
+    "report_id": {"type": "string", "minLength": 1},
+    "window_ref": {"type": "string", "minLength": 1},
+    "exploit_hit_rate": {"type": "number", "minimum": 0, "maximum": 1},
+    "block_rate": {"type": "number", "minimum": 0, "maximum": 1},
+    "contradiction_rate": {"type": "number", "minimum": 0, "maximum": 1},
+    "override_escalation_proxy_rate": {"type": "number", "minimum": 0, "maximum": 1},
+    "false_block_proxy_rate": {"type": "number", "minimum": 0, "maximum": 1},
+    "false_allow_proxy_rate": {"type": "number", "minimum": 0, "maximum": 1},
+    "confidence_mean": {"type": "number", "minimum": 0, "maximum": 1},
+    "sample_size": {"type": "integer", "minimum": 0}
+  }
+}

--- a/contracts/schemas/rax_trust_posture_snapshot.schema.json
+++ b/contracts/schemas/rax_trust_posture_snapshot.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/rax_trust_posture_snapshot.schema.json",
+  "title": "RAX Trust Posture Snapshot",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "snapshot_id",
+    "trend_report_ref",
+    "posture",
+    "primary_signals"
+  ],
+  "properties": {
+    "artifact_type": {"type": "string", "const": "rax_trust_posture_snapshot"},
+    "schema_version": {"type": "string", "const": "1.0.0"},
+    "snapshot_id": {"type": "string", "minLength": 1},
+    "trend_report_ref": {"type": "string", "minLength": 1},
+    "posture": {"type": "string", "enum": ["stable", "degraded", "critical"]},
+    "primary_signals": {"type": "array", "items": {"type": "string", "minLength": 1}, "minItems": 1}
+  }
+}

--- a/contracts/standards-manifest.json
+++ b/contracts/standards-manifest.json
@@ -1,11 +1,11 @@
 {
   "artifact_type": "standards_manifest",
   "artifact_id": "STD-CONTRACTS",
-  "artifact_version": "1.3.112",
+  "artifact_version": "1.3.113",
   "schema_version": "1.3.98",
-  "standards_version": "1.3.112",
-  "record_id": "REC-STD-2026-04-12-RAX",
-  "run_id": "run-20260412T000000Z-rax-interface",
+  "standards_version": "1.3.113",
+  "record_id": "REC-STD-2026-04-12-RAX-ROADMAP",
+  "run_id": "run-20260412T120000Z-rax-roadmap-serial-01",
   "created_at": "2026-04-12T00:00:00Z",
   "created_by": {
     "name": "Spectrum Systems Architecture Team",
@@ -15,7 +15,7 @@
     "contact": "architecture@spectrum-systems.test"
   },
   "source_repo": "nicklasorte/spectrum-systems",
-  "source_repo_version": "1.3.112",
+  "source_repo_version": "1.3.113",
   "input_artifacts": [
     {
       "artifact_id": "STD-CONTRACTS",
@@ -3482,6 +3482,266 @@
       "notes": "Reusable provenance structure aligned to data-provenance-standard."
     },
     {
+      "artifact_type": "rax_adversarial_pattern_candidate",
+      "artifact_class": "governance",
+      "schema_version": "1.0.0",
+      "status": "active",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.114",
+      "last_updated_in": "1.3.113",
+      "example_path": "contracts/examples/rax_adversarial_pattern_candidate.json",
+      "notes": "RAX deterministic adversarial pattern candidate artifact for governed eval/regression consumption."
+    },
+    {
+      "artifact_type": "rax_assurance_audit_record",
+      "artifact_class": "governance",
+      "schema_version": "1.0.0",
+      "status": "active",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.112",
+      "last_updated_in": "1.3.112",
+      "example_path": "contracts/examples/rax_assurance_audit_record.example.json",
+      "notes": "RAX-INTERFACE-24-01 fail-closed assurance audit artifact for local accept/hold/block candidate decisions."
+    },
+    {
+      "artifact_type": "rax_conflict_arbitration_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.113",
+      "last_updated_in": "1.3.113",
+      "example_path": "contracts/examples/rax_conflict_arbitration_record.json",
+      "notes": "Deterministic cross-eval conflict arbitration artifact; unresolved material conflicts fail closed."
+    },
+    {
+      "artifact_type": "rax_control_readiness_record",
+      "artifact_class": "governance",
+      "schema_version": "1.1.0",
+      "status": "active",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.113",
+      "last_updated_in": "1.3.113",
+      "example_path": "contracts/examples/rax_control_readiness_record.json",
+      "notes": "RAX-FEEDBACK-LOOP-10 bounded readiness artifact with structured readiness-change conditions, unknown-state linkage, and pre-certification alignment references."
+    },
+    {
+      "artifact_type": "rax_drift_signal_record",
+      "artifact_class": "governance",
+      "schema_version": "1.0.0",
+      "status": "active",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.114",
+      "last_updated_in": "1.3.114",
+      "example_path": "contracts/examples/rax_drift_signal_record.json",
+      "notes": "RAX drift signal artifact comparing current and baseline windows across governed drift surfaces."
+    },
+    {
+      "artifact_type": "rax_eval_candidate_admission_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.113",
+      "last_updated_in": "1.3.113",
+      "example_path": "contracts/examples/rax_eval_candidate_admission_record.json",
+      "notes": "Governed failure-to-eval candidate admission decision artifact with dedupe and deny reasons."
+    },
+    {
+      "artifact_type": "rax_eval_case_set",
+      "artifact_class": "governance",
+      "schema_version": "1.1.0",
+      "status": "active",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.113",
+      "last_updated_in": "1.3.113",
+      "example_path": "contracts/examples/rax_eval_case_set.json",
+      "notes": "RAX-EVAL-01 governed deterministic eval case set across baseline, adversarial, and failure classes."
+    },
+    {
+      "artifact_type": "rax_eval_registry",
+      "artifact_class": "governance",
+      "schema_version": "1.1.0",
+      "status": "active",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.113",
+      "last_updated_in": "1.3.113",
+      "example_path": "contracts/examples/rax_eval_registry.json",
+      "notes": "RAX-EVAL-01 governed registry of required deterministic RAX eval definitions."
+    },
+    {
+      "artifact_type": "rax_failure_eval_candidate",
+      "artifact_class": "governance",
+      "schema_version": "1.0.0",
+      "status": "active",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.114",
+      "last_updated_in": "1.3.114",
+      "example_path": "contracts/examples/rax_failure_eval_candidate.json",
+      "notes": "RAX failure-derived eval candidate artifact generated deterministically from governed failure classes."
+    },
+    {
+      "artifact_type": "rax_failure_pattern_record",
+      "artifact_class": "governance",
+      "schema_version": "1.0.0",
+      "status": "active",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.114",
+      "last_updated_in": "1.3.114",
+      "example_path": "contracts/examples/rax_failure_pattern_record.json",
+      "notes": "RAX feedback-loop failure capture artifact linking classified failures to reproducibility and trace references."
+    },
+    {
+      "artifact_type": "rax_feedback_loop_record",
+      "artifact_class": "governance",
+      "schema_version": "1.0.0",
+      "status": "active",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.114",
+      "last_updated_in": "1.3.114",
+      "example_path": "contracts/examples/rax_feedback_loop_record.json",
+      "notes": "RAX closure artifact linking failure, fix, eval coverage additions, and recurrence outcomes."
+    },
+    {
+      "artifact_type": "rax_health_snapshot",
+      "artifact_class": "governance",
+      "schema_version": "1.0.0",
+      "status": "active",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.114",
+      "last_updated_in": "1.3.114",
+      "example_path": "contracts/examples/rax_health_snapshot.json",
+      "notes": "RAX health metrics snapshot with SLO-style threshold posture as candidate signal only."
+    },
+    {
+      "artifact_type": "rax_improvement_recommendation_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.113",
+      "last_updated_in": "1.3.113",
+      "example_path": "contracts/examples/rax_improvement_recommendation_record.json",
+      "notes": "Non-authoritative RAX improvement recommendation record derived from trends."
+    },
+    {
+      "artifact_type": "rax_judgment_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.113",
+      "last_updated_in": "1.3.113",
+      "example_path": "contracts/examples/rax_judgment_record.json",
+      "notes": "Non-authoritative judgment compilation for semantic conflict outcomes."
+    },
+    {
+      "artifact_type": "rax_pre_certification_alignment_record",
+      "artifact_class": "governance",
+      "schema_version": "1.0.0",
+      "status": "active",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.114",
+      "last_updated_in": "1.3.114",
+      "example_path": "contracts/examples/rax_pre_certification_alignment_record.json",
+      "notes": "RAX pre-certification alignment artifact for downstream promotion rigor checks without granting certification authority."
+    },
+    {
+      "artifact_type": "rax_promotion_hard_gate_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.113",
+      "last_updated_in": "1.3.113",
+      "example_path": "contracts/examples/rax_promotion_hard_gate_record.json",
+      "notes": "Hard promotion gate requiring replay, eval, observability, and policy-regression evidence."
+    },
+    {
+      "artifact_type": "rax_trend_report",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.113",
+      "last_updated_in": "1.3.113",
+      "example_path": "contracts/examples/rax_trend_report.json",
+      "notes": "Longitudinal drift and calibration trend report derived from governed RAX signals."
+    },
+    {
+      "artifact_type": "rax_trust_posture_snapshot",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.113",
+      "last_updated_in": "1.3.113",
+      "example_path": "contracts/examples/rax_trust_posture_snapshot.json",
+      "notes": "Derived trust posture snapshot from governed RAX trend report."
+    },
+    {
+      "artifact_type": "rax_unknown_state_record",
+      "artifact_class": "governance",
+      "schema_version": "1.0.0",
+      "status": "active",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.114",
+      "last_updated_in": "1.3.114",
+      "example_path": "contracts/examples/rax_unknown_state_record.json",
+      "notes": "RAX explicit unknown-state artifact enforcing fail-closed non-readiness when basis is incomplete or contradictory."
+    },
+    {
+      "artifact_type": "rax_upstream_input_envelope",
+      "artifact_class": "governance",
+      "schema_version": "1.0.0",
+      "status": "active",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.112",
+      "last_updated_in": "1.3.112",
+      "example_path": "contracts/examples/rax_upstream_input_envelope.example.json",
+      "notes": "RAX-INTERFACE-24-01 strict compact upstream roadmap envelope consumed by RAX for deterministic contract expansion."
+    },
+    {
       "artifact_type": "readiness_review_dashboard_artifact",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -4717,175 +4977,6 @@
       "last_updated_in": "1.0.82",
       "example_path": "contracts/examples/xrun_signal_quality_result.json",
       "notes": "VAL-06 governed validation artifact proving deterministic XRUN-01 pattern/action/signal quality and fail-closed handling under insufficient/malformed inputs."
-    },
-    {
-      "artifact_type": "rax_upstream_input_envelope",
-      "artifact_class": "governance",
-      "schema_version": "1.0.0",
-      "status": "active",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.112",
-      "last_updated_in": "1.3.112",
-      "example_path": "contracts/examples/rax_upstream_input_envelope.example.json",
-      "notes": "RAX-INTERFACE-24-01 strict compact upstream roadmap envelope consumed by RAX for deterministic contract expansion."
-    },
-    {
-      "artifact_type": "rax_assurance_audit_record",
-      "artifact_class": "governance",
-      "schema_version": "1.0.0",
-      "status": "active",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.112",
-      "last_updated_in": "1.3.112",
-      "example_path": "contracts/examples/rax_assurance_audit_record.example.json",
-      "notes": "RAX-INTERFACE-24-01 fail-closed assurance audit artifact for local accept/hold/block candidate decisions."
-    },
-    {
-      "artifact_type": "rax_eval_registry",
-      "artifact_class": "governance",
-      "schema_version": "1.0.0",
-      "status": "active",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.113",
-      "last_updated_in": "1.3.113",
-      "example_path": "contracts/examples/rax_eval_registry.json",
-      "notes": "RAX-EVAL-01 governed registry of required deterministic RAX eval definitions."
-    },
-    {
-      "artifact_type": "rax_eval_case_set",
-      "artifact_class": "governance",
-      "schema_version": "1.0.0",
-      "status": "active",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.113",
-      "last_updated_in": "1.3.113",
-      "example_path": "contracts/examples/rax_eval_case_set.json",
-      "notes": "RAX-EVAL-01 governed deterministic eval case set across baseline, adversarial, and failure classes."
-    },
-    {
-      "artifact_type": "rax_control_readiness_record",
-      "artifact_class": "governance",
-      "schema_version": "1.0.0",
-      "status": "active",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.113",
-      "last_updated_in": "1.3.114",
-      "example_path": "contracts/examples/rax_control_readiness_record.json",
-      "notes": "RAX-FEEDBACK-LOOP-10 bounded readiness artifact with structured readiness-change conditions, unknown-state linkage, and pre-certification alignment references."
-    },
-    {
-      "artifact_type": "rax_failure_pattern_record",
-      "artifact_class": "governance",
-      "schema_version": "1.0.0",
-      "status": "active",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.114",
-      "last_updated_in": "1.3.114",
-      "example_path": "contracts/examples/rax_failure_pattern_record.json",
-      "notes": "RAX feedback-loop failure capture artifact linking classified failures to reproducibility and trace references."
-    },
-    {
-      "artifact_type": "rax_failure_eval_candidate",
-      "artifact_class": "governance",
-      "schema_version": "1.0.0",
-      "status": "active",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.114",
-      "last_updated_in": "1.3.114",
-      "example_path": "contracts/examples/rax_failure_eval_candidate.json",
-      "notes": "RAX failure-derived eval candidate artifact generated deterministically from governed failure classes."
-    },
-    {
-      "artifact_type": "rax_feedback_loop_record",
-      "artifact_class": "governance",
-      "schema_version": "1.0.0",
-      "status": "active",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.114",
-      "last_updated_in": "1.3.114",
-      "example_path": "contracts/examples/rax_feedback_loop_record.json",
-      "notes": "RAX closure artifact linking failure, fix, eval coverage additions, and recurrence outcomes."
-    },
-    {
-      "artifact_type": "rax_health_snapshot",
-      "artifact_class": "governance",
-      "schema_version": "1.0.0",
-      "status": "active",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.114",
-      "last_updated_in": "1.3.114",
-      "example_path": "contracts/examples/rax_health_snapshot.json",
-      "notes": "RAX health metrics snapshot with SLO-style threshold posture as candidate signal only."
-    },
-    {
-      "artifact_type": "rax_drift_signal_record",
-      "artifact_class": "governance",
-      "schema_version": "1.0.0",
-      "status": "active",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.114",
-      "last_updated_in": "1.3.114",
-      "example_path": "contracts/examples/rax_drift_signal_record.json",
-      "notes": "RAX drift signal artifact comparing current and baseline windows across governed drift surfaces."
-    },
-    {
-      "artifact_type": "rax_unknown_state_record",
-      "artifact_class": "governance",
-      "schema_version": "1.0.0",
-      "status": "active",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.114",
-      "last_updated_in": "1.3.114",
-      "example_path": "contracts/examples/rax_unknown_state_record.json",
-      "notes": "RAX explicit unknown-state artifact enforcing fail-closed non-readiness when basis is incomplete or contradictory."
-    },
-    {
-      "artifact_type": "rax_pre_certification_alignment_record",
-      "artifact_class": "governance",
-      "schema_version": "1.0.0",
-      "status": "active",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.114",
-      "last_updated_in": "1.3.114",
-      "example_path": "contracts/examples/rax_pre_certification_alignment_record.json",
-      "notes": "RAX pre-certification alignment artifact for downstream promotion rigor checks without granting certification authority."
-    },
-    {
-      "artifact_type": "rax_adversarial_pattern_candidate",
-      "artifact_class": "governance",
-      "schema_version": "1.0.0",
-      "status": "active",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.114",
-      "last_updated_in": "1.3.114",
-      "example_path": "contracts/examples/rax_adversarial_pattern_candidate.json",
-      "notes": "RAX deterministic adversarial pattern candidate artifact for governed eval/regression consumption."
     }
   ]
 }

--- a/docs/review-actions/PLAN-RAX-ROADMAP-SERIAL-01-2026-04-12.md
+++ b/docs/review-actions/PLAN-RAX-ROADMAP-SERIAL-01-2026-04-12.md
@@ -1,0 +1,55 @@
+# Plan — RAX-ROADMAP-SERIAL-01 — 2026-04-12
+
+## Prompt type
+PLAN
+
+## Roadmap item
+RAX-ROADMAP-SERIAL-01
+
+## Objective
+Implement RAX-03 through RAX-12 as deterministic, fail-closed, artifact-first runtime and contract updates covering discovery, conflict arbitration, non-authority fencing, drift observability, governed eval admission, policy regression, judgment compilation, replay expansion, artifact intelligence, and promotion hard-gating.
+
+## Declared files
+
+| File | Change type | Reason |
+| --- | --- | --- |
+| docs/review-actions/PLAN-RAX-ROADMAP-SERIAL-01-2026-04-12.md | CREATE | Required multi-file BUILD plan declaration |
+| spectrum_systems/modules/runtime/rax_eval_runner.py | MODIFY | Add serial roadmap logic and deterministic artifact generation/gating |
+| contracts/schemas/rax_eval_case_set.schema.json | MODIFY | Extend governed eval case structure for mutation/combinatorial discovery classes |
+| contracts/examples/rax_eval_case_set.json | MODIFY | Add RAX-03 discovery fixtures and combinatorial cases |
+| contracts/schemas/rax_conflict_arbitration_record.schema.json | CREATE | Contract for deterministic cross-eval conflict arbitration artifact |
+| contracts/examples/rax_conflict_arbitration_record.json | CREATE | Golden example for conflict arbitration artifact |
+| contracts/schemas/rax_judgment_record.schema.json | CREATE | Contract for non-authoritative RAX judgment compilation artifact |
+| contracts/examples/rax_judgment_record.json | CREATE | Golden example for judgment artifact |
+| contracts/schemas/rax_trend_report.schema.json | CREATE | Contract for longitudinal trend report artifact |
+| contracts/examples/rax_trend_report.json | CREATE | Golden example for trend report |
+| contracts/schemas/rax_trust_posture_snapshot.schema.json | CREATE | Contract for trust posture snapshot |
+| contracts/examples/rax_trust_posture_snapshot.json | CREATE | Golden example for trust posture snapshot |
+| contracts/schemas/rax_improvement_recommendation_record.schema.json | CREATE | Contract for derived recommendation artifact |
+| contracts/examples/rax_improvement_recommendation_record.json | CREATE | Golden example for recommendation record |
+| contracts/schemas/rax_promotion_hard_gate_record.schema.json | CREATE | Contract for promotion evidence hard-gate result |
+| contracts/examples/rax_promotion_hard_gate_record.json | CREATE | Golden example for promotion hard-gate artifact |
+| contracts/standards-manifest.json | MODIFY | Register new/updated RAX contracts and versions |
+| tests/test_rax_eval_runner.py | MODIFY | Add RAX-03..RAX-12 unit coverage |
+| tests/test_roadmap_expansion_contracts.py | MODIFY | Validate new RAX contract examples and schema guards |
+
+## Contracts touched
+rax_eval_case_set, rax_conflict_arbitration_record, rax_judgment_record, rax_trend_report, rax_trust_posture_snapshot, rax_improvement_recommendation_record, rax_promotion_hard_gate_record, standards-manifest entries.
+
+## Tests that must pass after execution
+
+1. `pytest tests/test_rax_eval_runner.py tests/test_rax_redteam_adversarial_pack.py tests/test_rax_interface_assurance.py`
+2. `pytest tests/test_roadmap_expansion_contracts.py tests/test_contracts.py tests/test_contract_enforcement.py`
+3. `python scripts/run_contract_enforcement.py`
+4. `.codex/skills/contract-boundary-audit/run.sh`
+
+## Scope exclusions
+
+- Do not modify non-RAX runtime subsystems.
+- Do not alter canonical ownership in `docs/architecture/system_registry.md`.
+- Do not introduce authority-bearing control decisions from RAX artifacts.
+
+## Dependencies
+
+- RAX-RED-01 complete.
+- RAX-RED-02 complete.

--- a/spectrum_systems/modules/runtime/rax_assurance.py
+++ b/spectrum_systems/modules/runtime/rax_assurance.py
@@ -552,6 +552,10 @@ def evaluate_rax_control_readiness(
     authority_records: dict[str, Any] | None = None,
     replay_baseline_store: dict[str, Any] | None = None,
     replay_key: str | None = None,
+    policy_version: str = "1.0.0",
+    semantic_rule_version: str = "1.0.0",
+    eval_config_version: str = "1.0.0",
+    contradiction_logic_version: str = "1.0.0",
 ) -> dict[str, Any]:
     """Build bounded RAX control-readiness artifact from governed eval artifacts."""
     from spectrum_systems.modules.runtime.rax_eval_runner import build_rax_control_readiness_record
@@ -569,4 +573,8 @@ def evaluate_rax_control_readiness(
         authority_records=authority_records,
         replay_baseline_store=replay_baseline_store,
         replay_key=replay_key,
+        policy_version=policy_version,
+        semantic_rule_version=semantic_rule_version,
+        eval_config_version=eval_config_version,
+        contradiction_logic_version=contradiction_logic_version,
     )

--- a/spectrum_systems/modules/runtime/rax_eval_runner.py
+++ b/spectrum_systems/modules/runtime/rax_eval_runner.py
@@ -11,7 +11,7 @@ from typing import Any
 from spectrum_systems.contracts import load_example, validate_artifact
 
 RUNNER_NAME = "rax_eval_runner"
-RUNNER_VERSION = "1.1.0"
+RUNNER_VERSION = "1.2.0"
 
 _FAILURE_TO_EVAL_TYPE = {
     "semantic_contradiction": "rax_output_semantic_alignment",
@@ -375,6 +375,244 @@ def build_rax_drift_signal_record(
     return record
 
 
+def build_rax_conflict_arbitration_record(
+    *,
+    arbitration_id: str,
+    target_ref: str,
+    trace_id: str,
+    eval_results: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Build deterministic cross-eval conflict arbitration artifact."""
+    statuses: dict[str, str] = {}
+    reasons_by_type: dict[str, set[str]] = {}
+    for item in eval_results:
+        eval_type = _eval_type_from_result(item) or "unknown"
+        statuses[eval_type] = str(item.get("result_status", "unknown"))
+        reasons_by_type[eval_type] = {
+            mode for mode in item.get("failure_modes", []) if isinstance(mode, str) and mode and ":" not in mode
+        }
+
+    material_conflicts: list[str] = []
+    if statuses.get("rax_control_readiness") == "pass" and any(
+        statuses.get(name) == "fail"
+        for name in (
+            "rax_input_semantic_sufficiency",
+            "rax_owner_intent_alignment",
+            "rax_output_semantic_alignment",
+            "rax_trace_integrity",
+            "rax_version_authority_alignment",
+        )
+    ):
+        material_conflicts.append("readiness_vs_required_eval")
+
+    if "source_version_drift" in reasons_by_type.get("rax_version_authority_alignment", set()) and statuses.get("rax_control_readiness") == "pass":
+        material_conflicts.append("version_authority_vs_readiness")
+
+    if "contradiction_unresolved" in reasons_by_type.get("rax_control_readiness", set()) and statuses.get("rax_output_semantic_alignment") == "pass":
+        material_conflicts.append("contradiction_vs_semantic_alignment")
+
+    if "missing_required_expansion_trace" in reasons_by_type.get("rax_trace_integrity", set()) and statuses.get("rax_control_readiness") == "pass":
+        material_conflicts.append("trace_integrity_vs_readiness")
+
+    record = {
+        "artifact_type": "rax_conflict_arbitration_record",
+        "schema_version": "1.0.0",
+        "arbitration_id": arbitration_id,
+        "target_ref": target_ref,
+        "trace_id": trace_id,
+        "signal_status": {k: statuses[k] for k in sorted(statuses)},
+        "material_conflicts": sorted(set(material_conflicts)),
+        "resolution_status": "unresolved_fail_closed" if material_conflicts else "no_conflict",
+        "fail_closed": bool(material_conflicts),
+    }
+    validate_artifact(record, "rax_conflict_arbitration_record")
+    return record
+
+
+def build_rax_trend_report(*, report_id: str, window_ref: str, run_records: list[dict[str, Any]]) -> dict[str, Any]:
+    total = max(len(run_records), 1)
+    exploit_hits = sum(1 for run in run_records if run.get("exploit_hit"))
+    blocks = sum(1 for run in run_records if run.get("blocked"))
+    contradictions = sum(1 for run in run_records if run.get("contradiction"))
+    overrides = sum(1 for run in run_records if run.get("override_or_escalation"))
+    false_blocks = sum(1 for run in run_records if run.get("false_block_proxy"))
+    false_allows = sum(1 for run in run_records if run.get("false_allow_proxy"))
+    confidence_values = [float(run["confidence"]) for run in run_records if isinstance(run.get("confidence"), (int, float))]
+    confidence_mean = (sum(confidence_values) / len(confidence_values)) if confidence_values else 0.0
+
+    report = {
+        "artifact_type": "rax_trend_report",
+        "schema_version": "1.0.0",
+        "report_id": report_id,
+        "window_ref": window_ref,
+        "exploit_hit_rate": exploit_hits / total,
+        "block_rate": blocks / total,
+        "contradiction_rate": contradictions / total,
+        "override_escalation_proxy_rate": overrides / total,
+        "false_block_proxy_rate": false_blocks / total,
+        "false_allow_proxy_rate": false_allows / total,
+        "confidence_mean": confidence_mean,
+        "sample_size": len(run_records),
+    }
+    validate_artifact(report, "rax_trend_report")
+    return report
+
+
+def build_rax_trust_posture_snapshot(*, snapshot_id: str, trend_report: dict[str, Any]) -> dict[str, Any]:
+    posture = "stable"
+    if trend_report["block_rate"] > 0.4 or trend_report["contradiction_rate"] > 0.2:
+        posture = "degraded"
+    if trend_report["false_allow_proxy_rate"] > 0.1:
+        posture = "critical"
+
+    snapshot = {
+        "artifact_type": "rax_trust_posture_snapshot",
+        "schema_version": "1.0.0",
+        "snapshot_id": snapshot_id,
+        "trend_report_ref": trend_report["report_id"],
+        "posture": posture,
+        "primary_signals": [
+            f"block_rate:{trend_report['block_rate']:.3f}",
+            f"contradiction_rate:{trend_report['contradiction_rate']:.3f}",
+            f"false_allow_proxy_rate:{trend_report['false_allow_proxy_rate']:.3f}",
+        ],
+    }
+    validate_artifact(snapshot, "rax_trust_posture_snapshot")
+    return snapshot
+
+
+def build_rax_improvement_recommendation_record(
+    *,
+    recommendation_id: str,
+    posture_snapshot: dict[str, Any],
+    trend_report: dict[str, Any],
+) -> dict[str, Any]:
+    recs: list[str] = []
+    if trend_report["contradiction_rate"] > 0:
+        recs.append("tighten_conflict_arbitration_eval_coverage")
+    if trend_report["false_allow_proxy_rate"] > 0:
+        recs.append("increase_semantic_blocking_regression_cases")
+    if trend_report["exploit_hit_rate"] > 0.2:
+        recs.append("expand_mutation_combinatorial_discovery_pack")
+
+    record = {
+        "artifact_type": "rax_improvement_recommendation_record",
+        "schema_version": "1.0.0",
+        "recommendation_id": recommendation_id,
+        "posture_snapshot_ref": posture_snapshot["snapshot_id"],
+        "trend_report_ref": trend_report["report_id"],
+        "recommendations": sorted(set(recs)) or ["maintain_current_hardening"],
+        "authority_note": "non_authoritative_advisory_only",
+    }
+    validate_artifact(record, "rax_improvement_recommendation_record")
+    return record
+
+
+def admit_failure_eval_candidate(
+    *,
+    candidate: dict[str, Any],
+    admission_policy: dict[str, Any],
+    canonical_registry: dict[str, Any],
+) -> dict[str, Any]:
+    validate_artifact(candidate, "rax_failure_eval_candidate")
+    min_reasons = int(admission_policy.get("min_reason_codes", 1))
+    allowed_eval_types = set(admission_policy.get("allowed_eval_types") or [])
+
+    reasons = candidate.get("reason_codes", [])
+    admitted = True
+    denial_reasons: list[str] = []
+    if len(reasons) < min_reasons:
+        admitted = False
+        denial_reasons.append("insufficient_reason_codes")
+    if allowed_eval_types and candidate.get("eval_type") not in allowed_eval_types:
+        admitted = False
+        denial_reasons.append("eval_type_not_admissible")
+
+    existing_ids = {item.get("candidate_id") for item in canonical_registry.get("admitted_candidates", [])}
+    if candidate["candidate_id"] in existing_ids:
+        admitted = False
+        denial_reasons.append("duplicate_candidate")
+
+    if admitted:
+        canonical_registry.setdefault("admitted_candidates", []).append({
+            "candidate_id": candidate["candidate_id"],
+            "eval_case_id": candidate["eval_case_id"],
+            "eval_type": candidate["eval_type"],
+            "version": candidate.get("version", "1.0.0"),
+        })
+
+    record = {
+        "artifact_type": "rax_eval_candidate_admission_record",
+        "schema_version": "1.0.0",
+        "candidate_id": candidate["candidate_id"],
+        "admitted": admitted,
+        "denial_reasons": sorted(set(denial_reasons)),
+    }
+    validate_artifact(record, "rax_eval_candidate_admission_record")
+    return record
+
+
+def compile_rax_judgment_record(
+    *,
+    judgment_id: str,
+    target_ref: str,
+    conflict_record: dict[str, Any],
+    readiness_record: dict[str, Any],
+) -> dict[str, Any]:
+    if conflict_record.get("fail_closed"):
+        outcome = "more_evidence_needed"
+    elif readiness_record.get("ready_for_control"):
+        outcome = "ready"
+    else:
+        outcome = "revise"
+
+    record = {
+        "artifact_type": "rax_judgment_record",
+        "schema_version": "1.0.0",
+        "judgment_id": judgment_id,
+        "target_ref": target_ref,
+        "judgment_outcome": outcome,
+        "rationale": sorted(set(readiness_record.get("blocking_reasons", [])))[:10],
+        "conflict_ref": conflict_record["arbitration_id"],
+        "authority_note": "judgment_only_non_authoritative",
+    }
+    validate_artifact(record, "rax_judgment_record")
+    return record
+
+
+def enforce_rax_promotion_hard_gate(
+    *,
+    gate_id: str,
+    readiness_record: dict[str, Any],
+    replay_evidence_present: bool,
+    eval_evidence_present: bool,
+    observability_evidence_present: bool,
+    policy_regression_evidence_present: bool,
+) -> dict[str, Any]:
+    missing: list[str] = []
+    if not replay_evidence_present:
+        missing.append("replay_evidence_missing")
+    if not eval_evidence_present:
+        missing.append("eval_evidence_missing")
+    if not observability_evidence_present:
+        missing.append("observability_evidence_missing")
+    if not policy_regression_evidence_present:
+        missing.append("policy_regression_evidence_missing")
+    if readiness_record.get("ready_for_control") is not True:
+        missing.append("readiness_not_ready")
+
+    out = {
+        "artifact_type": "rax_promotion_hard_gate_record",
+        "schema_version": "1.0.0",
+        "gate_id": gate_id,
+        "passed": len(missing) == 0,
+        "missing_evidence": sorted(set(missing)),
+        "decision": "promote" if len(missing) == 0 else "block",
+    }
+    validate_artifact(out, "rax_promotion_hard_gate_record")
+    return out
+
+
 def build_rax_unknown_state_record(
     *,
     record_id: str,
@@ -398,13 +636,20 @@ def build_rax_unknown_state_record(
     return record
 
 
-def generate_adversarial_pattern_candidates(*, seed: str, target_ref: str, count: int = 5) -> list[dict[str, Any]]:
+def generate_adversarial_pattern_candidates(*, seed: str, target_ref: str, count: int = 10) -> list[dict[str, Any]]:
     classes = [
         "schema_valid_semantic_boundary",
         "mutated_literal_variant",
         "nested_variant",
         "cross_step_contamination_variant",
         "partial_signal_contradiction",
+        "semantic_drift_variant",
+        "provenance_weakness_variant",
+        "replay_weakness_variant",
+        "ambiguity_variant",
+        "weak_counter_evidence_variant",
+        "hidden_scope_expansion_variant",
+        "multi_signal_exploit_combo",
     ]
     base = int(hashlib.sha256(seed.encode("utf-8")).hexdigest(), 16)
     out: list[dict[str, Any]] = []
@@ -600,6 +845,10 @@ def build_rax_control_readiness_record(
     drift_signal_record: dict[str, Any] | None = None,
     unknown_state_record: dict[str, Any] | None = None,
     pre_certification_alignment_record: dict[str, Any] | None = None,
+    policy_version: str = "1.0.0",
+    semantic_rule_version: str = "1.0.0",
+    eval_config_version: str = "1.0.0",
+    contradiction_logic_version: str = "1.0.0",
 ) -> dict[str, Any]:
     policy = _load_policy()
     required_eval_types = list(policy.get("required_eval_types", []))
@@ -742,6 +991,19 @@ def build_rax_control_readiness_record(
     if unknown_state_record.get("status") == "unknown_blocking":
         blocking_reasons.append("unknown_state_detected")
 
+    conflict_arbitration_record = build_rax_conflict_arbitration_record(
+        arbitration_id=f"conflict:{batch}:{eval_summary.get('trace_id', 'missing')}",
+        target_ref=target_ref,
+        trace_id=str(eval_summary.get("trace_id", "missing")),
+        eval_results=eval_results,
+    )
+    if conflict_arbitration_record["fail_closed"]:
+        blocking_reasons.append("material_conflict_unresolved")
+
+    replay_identity_fingerprint = hashlib.sha256(
+        f"{target_ref}|{policy_version}|{semantic_rule_version}|{eval_config_version}|{contradiction_logic_version}".encode("utf-8")
+    ).hexdigest()[:24]
+
     trace_complete = (
         "rax_trace_integrity" in present_eval_types
         and "rax_trace_integrity" not in missing_required_eval_types
@@ -817,7 +1079,7 @@ def build_rax_control_readiness_record(
 
     record = {
         "artifact_type": "rax_control_readiness_record",
-        "schema_version": "1.0.0",
+        "schema_version": "1.1.0",
         "batch": batch,
         "target_ref": target_ref,
         "ready_for_control": ready_for_control,
@@ -832,6 +1094,19 @@ def build_rax_control_readiness_record(
         "conditions_under_which_ready_changes": readiness_conditions,
         "unknown_state_ref": unknown_state_record["record_id"],
         "pre_certification_alignment_ref": pre_certification_alignment_record["record_id"],
+        "conflict_arbitration_ref": conflict_arbitration_record["arbitration_id"],
+        "non_authority_assertions": [
+            "readiness_is_non_authoritative",
+            "no_promotion_or_release_authority",
+            "control_transition_requires_downstream_control_artifact",
+        ],
+        "replay_identity": {
+            "policy_version": policy_version,
+            "semantic_rule_version": semantic_rule_version,
+            "eval_config_version": eval_config_version,
+            "contradiction_logic_version": contradiction_logic_version,
+            "fingerprint": replay_identity_fingerprint,
+        },
     }
     validate_artifact(record, "rax_control_readiness_record")
 
@@ -839,6 +1114,7 @@ def build_rax_control_readiness_record(
         **record,
         "unknown_state_record": deepcopy(unknown_state_record),
         "pre_certification_alignment_record": deepcopy(pre_certification_alignment_record),
+        "conflict_arbitration_record": deepcopy(conflict_arbitration_record),
     }
 
 

--- a/tests/test_rax_eval_runner.py
+++ b/tests/test_rax_eval_runner.py
@@ -14,6 +14,13 @@ from spectrum_systems.modules.runtime.rax_eval_runner import (
     build_rax_health_snapshot,
     build_rax_drift_signal_record,
     build_rax_unknown_state_record,
+    build_rax_conflict_arbitration_record,
+    build_rax_trend_report,
+    build_rax_trust_posture_snapshot,
+    build_rax_improvement_recommendation_record,
+    admit_failure_eval_candidate,
+    compile_rax_judgment_record,
+    enforce_rax_promotion_hard_gate,
     generate_adversarial_pattern_candidates,
 )
 
@@ -482,7 +489,7 @@ def test_adversarial_pattern_generation_is_deterministic() -> None:
     first = generate_adversarial_pattern_candidates(seed="seed-1", target_ref="roadmap_step_contract:RAX-INTERFACE-24-01")
     second = generate_adversarial_pattern_candidates(seed="seed-1", target_ref="roadmap_step_contract:RAX-INTERFACE-24-01")
     assert first == second
-    assert len(first) == 5
+    assert len(first) == 10
     validate_artifact(first[0], "rax_adversarial_pattern_candidate")
 
 
@@ -584,3 +591,128 @@ def test_precert_alignment_blocks_candidate_ready_when_not_aligned() -> None:
     )
     readiness = _readiness_from(out)
     assert "pre_certification_alignment_not_ready" in readiness["blocking_reasons"]
+
+
+def test_rax03_eval_case_set_contains_discovery_mutation_and_combo_entries() -> None:
+    case_set = load_rax_eval_case_set()
+    ids = {case["eval_case_id"] for case in case_set["cases"]}
+    assert {
+        "rax-03-semantic-drift-mutation-01",
+        "rax-03-provenance-weakness-mutation-01",
+        "rax-03-replay-weakness-mutation-01",
+        "rax-03-ambiguity-mutation-01",
+        "rax-03-weak-counter-evidence-mutation-01",
+        "rax-03-hidden-scope-combo-01",
+        "rax-03-multi-signal-exploit-combo-01",
+    }.issubset(ids)
+
+
+def test_rax04_conflict_arbitration_fails_closed_on_material_disagreement() -> None:
+    out = run_rax_eval_runner(
+        run_id="rax-conflict-001",
+        target_ref="roadmap_step_contract:RAX-INTERFACE-24-01",
+        trace_id="21212121-2121-4121-8121-212121212121",
+        input_assurance={**_input_assurance_ok(), "details": ["semantic_intent_sufficient", "semantic_intent_insufficient"]},
+        output_assurance=_output_assurance_ok(),
+        tests_passed=True,
+        baseline_regression_detected=False,
+        version_authority_aligned=True,
+    )
+    conflict = build_rax_conflict_arbitration_record(
+        arbitration_id="conflict-test-001",
+        target_ref="roadmap_step_contract:RAX-INTERFACE-24-01",
+        trace_id="21212121-2121-4121-8121-212121212121",
+        eval_results=out["eval_results"],
+    )
+    validate_artifact(conflict, "rax_conflict_arbitration_record")
+
+
+def test_rax05_readiness_non_authority_fields_are_present() -> None:
+    out = run_rax_eval_runner(
+        run_id="rax-non-auth-001",
+        target_ref="roadmap_step_contract:RAX-INTERFACE-24-01",
+        trace_id="22222222-2222-4222-8222-222222222222",
+        input_assurance=_input_assurance_ok(),
+        output_assurance=_output_assurance_ok(),
+        tests_passed=True,
+        baseline_regression_detected=False,
+        version_authority_aligned=True,
+    )
+    readiness = _readiness_from(out)
+    assert "readiness_is_non_authoritative" in readiness["non_authority_assertions"]
+    assert readiness["decision"] != "ready"
+
+
+def test_rax06_trend_and_trust_posture_artifacts_validate() -> None:
+    trend = build_rax_trend_report(
+        report_id="trend-test-001",
+        window_ref="window://rax/test",
+        run_records=[
+            {"exploit_hit": True, "blocked": True, "contradiction": False, "override_or_escalation": False, "false_block_proxy": False, "false_allow_proxy": False, "confidence": 0.8},
+            {"exploit_hit": False, "blocked": True, "contradiction": True, "override_or_escalation": True, "false_block_proxy": True, "false_allow_proxy": False, "confidence": 0.6},
+        ],
+    )
+    posture = build_rax_trust_posture_snapshot(snapshot_id="posture-test-001", trend_report=trend)
+    recommendation = build_rax_improvement_recommendation_record(
+        recommendation_id="recommend-test-001",
+        posture_snapshot=posture,
+        trend_report=trend,
+    )
+    validate_artifact(trend, "rax_trend_report")
+    validate_artifact(posture, "rax_trust_posture_snapshot")
+    validate_artifact(recommendation, "rax_improvement_recommendation_record")
+
+
+def test_rax07_failure_to_eval_admission_pipeline_is_governed_and_deduped() -> None:
+    candidate = load_example("rax_failure_eval_candidate")
+    registry = {"admitted_candidates": []}
+    policy = {"min_reason_codes": 1, "allowed_eval_types": ["rax_output_semantic_alignment", "rax_control_readiness"]}
+    first = admit_failure_eval_candidate(candidate=candidate, admission_policy=policy, canonical_registry=registry)
+    second = admit_failure_eval_candidate(candidate=candidate, admission_policy=policy, canonical_registry=registry)
+    validate_artifact(first, "rax_eval_candidate_admission_record")
+    assert first["admitted"] is True
+    assert second["admitted"] is False
+    assert "duplicate_candidate" in second["denial_reasons"]
+
+
+def test_rax09_judgment_record_remains_non_authoritative() -> None:
+    conflict = load_example("rax_conflict_arbitration_record")
+    readiness = load_example("rax_control_readiness_record")
+    record = compile_rax_judgment_record(
+        judgment_id="judgment-test-001",
+        target_ref="roadmap_step_contract:RAX-INTERFACE-24-01",
+        conflict_record=conflict,
+        readiness_record=readiness,
+    )
+    validate_artifact(record, "rax_judgment_record")
+    assert record["authority_note"] == "judgment_only_non_authoritative"
+
+
+def test_rax10_replay_identity_fingerprint_changes_with_policy_versions() -> None:
+    out = run_rax_eval_runner(
+        run_id="rax-replay-identity-001",
+        target_ref="roadmap_step_contract:RAX-INTERFACE-24-01",
+        trace_id="23232323-2323-4232-8232-232323232323",
+        input_assurance=_input_assurance_ok(),
+        output_assurance=_output_assurance_ok(),
+        tests_passed=True,
+        baseline_regression_detected=False,
+        version_authority_aligned=True,
+    )
+    base = _readiness_from(out, policy_version="1.0.0", semantic_rule_version="1.0.0")
+    changed = _readiness_from(out, policy_version="1.0.1", semantic_rule_version="1.0.0")
+    assert base["replay_identity"]["fingerprint"] != changed["replay_identity"]["fingerprint"]
+
+
+def test_rax12_promotion_hard_gate_blocks_missing_evidence() -> None:
+    gate = enforce_rax_promotion_hard_gate(
+        gate_id="gate-test-001",
+        readiness_record=load_example("rax_control_readiness_record"),
+        replay_evidence_present=False,
+        eval_evidence_present=True,
+        observability_evidence_present=False,
+        policy_regression_evidence_present=False,
+    )
+    validate_artifact(gate, "rax_promotion_hard_gate_record")
+    assert gate["passed"] is False
+    assert "replay_evidence_missing" in gate["missing_evidence"]

--- a/tests/test_roadmap_expansion_contracts.py
+++ b/tests/test_roadmap_expansion_contracts.py
@@ -160,6 +160,13 @@ def test_rax_feedback_loop_contract_examples_validate() -> None:
         "rax_unknown_state_record",
         "rax_pre_certification_alignment_record",
         "rax_adversarial_pattern_candidate",
+        "rax_conflict_arbitration_record",
+        "rax_judgment_record",
+        "rax_trend_report",
+        "rax_trust_posture_snapshot",
+        "rax_improvement_recommendation_record",
+        "rax_eval_candidate_admission_record",
+        "rax_promotion_hard_gate_record",
     ):
         validate_artifact(load_example(name), name)
 
@@ -167,5 +174,12 @@ def test_rax_feedback_loop_contract_examples_validate() -> None:
 def test_rax_control_readiness_requires_structured_change_conditions() -> None:
     instance = load_example("rax_control_readiness_record")
     instance.pop("conditions_under_which_ready_changes", None)
+    with pytest.raises(ValidationError):
+        validate_artifact(instance, "rax_control_readiness_record")
+
+
+def test_rax_control_readiness_requires_replay_identity() -> None:
+    instance = load_example("rax_control_readiness_record")
+    instance.pop("replay_identity", None)
     with pytest.raises(ValidationError):
         validate_artifact(instance, "rax_control_readiness_record")


### PR DESCRIPTION
### Motivation
- Complete the next RAX trust-hardening roadmap slices (RAX-03 → RAX-12) in the repo-native RAX runtime seam to move RAX from a static hardened boundary to discovery-capable, contradiction-aware, non-authoritative, drift-observable, governed-learning, and promotion-gated behavior.
- Preserve artifact-first, fail-closed, and non-authority architecture guarantees while adding measurable/traced artifacts for replay, policy/version gating, and trend intelligence.

### Description
- Added deterministic discovery/adversarial expansion and combinatorial mutation support by extending `generate_adversarial_pattern_candidates` and adding discovery cases in `contracts/examples/rax_eval_case_set.json` and schema changes to `rax_eval_case_set` and `rax_adversarial_pattern_candidate`.
- Implemented cross-eval conflict arbitration and integrated it into readiness: `build_rax_conflict_arbitration_record` and fail-closed blocking when material conflicts exist, plus contract `rax_conflict_arbitration_record` and example.
- Enforced non-authority fencing in readiness: readiness artifacts now include explicit `non_authority_assertions`, `conflict_arbitration_ref`, and a versioned `replay_identity` fingerprint computed from policy/semantic/eval/contradiction versions; updated `rax_control_readiness_record` schema and example.
- Added longitudinal/trend intelligence primitives: `build_rax_trend_report`, `build_rax_trust_posture_snapshot`, and `build_rax_improvement_recommendation_record` with corresponding schemas/examples.
- Built governed failure→eval admission pipeline: `admit_failure_eval_candidate` with policy checks, dedupe, and `rax_eval_candidate_admission_record` schema/example.
- Added narrow non-authoritative judgment compilation: `compile_rax_judgment_record` and `rax_judgment_record` schema/example.
- Added a promotion hard gate API `enforce_rax_promotion_hard_gate` and `rax_promotion_hard_gate_record` schema/example that requires replay/eval/observability/policy-regression evidence.
- Expanded `rax_eval_registry` to surface `policy_version`, `semantic_rule_version`, and `eval_config_version` and propagated version surfaces through `rax_assurance.evaluate_rax_control_readiness` into the readiness builder.
- Updated standards manifest to register new/updated RAX contracts and bumped manifest version; updated/added tests to cover RAX-03..RAX-12 behaviors and examples.

### Testing
- Ran unit and contract suites: `pytest tests/test_rax_eval_runner.py tests/test_rax_redteam_adversarial_pack.py tests/test_rax_interface_assurance.py` — all relevant RAX tests passed (63 passed). 
- Ran broader contract validation: `pytest tests/test_roadmap_expansion_contracts.py tests/test_contracts.py tests/test_contract_enforcement.py` — contract and manifest tests passed (136 passed across suites run).
- Ran module architecture tests: `pytest tests/test_module_architecture.py` — passed.
- Ran `python scripts/run_contract_enforcement.py` — completed with summary `failures=0 warnings=0`.
- Attempted `.codex/skills/contract-boundary-audit/run.sh`; a bounded run timed out and produced high-volume baseline warnings (timed out/EXIT:124), so full audit was not completed in this session but unit/contract tests were green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbaba48fa08329b3f3bc125545409a)