### PR TITLE
Implement RAX operational hard-gate and RAX-13..RAX-22 primitives with CLI wiring

### DIFF
--- a/docs/review-actions/PLAN-RAX-ROADMAP-SERIAL-02-2026-04-12.md
+++ b/docs/review-actions/PLAN-RAX-ROADMAP-SERIAL-02-2026-04-12.md
@@ -1,0 +1,21 @@
+# PLAN-RAX-ROADMAP-SERIAL-02-2026-04-12
+
+## Prompt type
+BUILD
+
+## Intent
+Implement and wire the remaining RAX roadmap seams (RAX-13 through RAX-22) on top of the existing RAX-03 through RAX-12 foundations, with fail-closed operational gating, external script wiring, and deterministic tests.
+
+## Scoped files
+| File | Action | Scope |
+| --- | --- | --- |
+| `spectrum_systems/modules/runtime/rax_eval_runner.py` | MODIFY | Add operational hard-gate enforcement helpers for CI/promotion wiring across RAX-13..RAX-22. |
+| `scripts/run_rax_operational_gate.py` | ADD | Thin CLI for external operational path emission and fail-closed exit status. |
+| `tests/test_rax_eval_runner.py` | MODIFY | Add deterministic tests for conflict-zero gate, replay/policy evidence binding, drift threshold freeze semantics, admission anti-poisoning, judgment compilation candidate, and signed provenance checks. |
+| `tests/test_run_rax_operational_gate_cli.py` | ADD | CLI wiring test proving external operational seam enforces fail-closed boundary. |
+
+## Validation plan
+1. `pytest tests/test_rax_eval_runner.py tests/test_run_rax_operational_gate_cli.py`
+2. `pytest tests/test_contract_enforcement.py`
+3. `python scripts/run_contract_enforcement.py`
+4. `.codex/skills/contract-boundary-audit/run.sh`

--- a/scripts/run_rax_operational_gate.py
+++ b/scripts/run_rax_operational_gate.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Run RAX operational hard gate with fail-closed exit semantics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from spectrum_systems.contracts import load_example
+from spectrum_systems.modules.runtime.rax_eval_runner import (
+    apply_admission_quality_filters,
+    build_policy_regression_evidence_bundle,
+    build_replay_evidence_binding,
+    compile_judgment_patterns_to_policy_candidates,
+    enforce_rax_operational_hard_gate,
+    evaluate_drift_threshold_semantics,
+    sign_rax_evidence_bundle,
+    verify_rax_evidence_bundle_signature,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run RAX operational gate and emit artifact")
+    parser.add_argument("--output", type=Path, default=Path("outputs/rax_operational_gate_record.json"))
+    parser.add_argument("--fail-freeze", action="store_true", help="Inject freeze-worthy drift signal")
+    args = parser.parse_args()
+
+    readiness = load_example("rax_control_readiness_record")
+    readiness["ready_for_control"] = True
+    readiness["decision"] = "hold"
+    readiness["blocking_reasons"] = []
+    conflict = load_example("rax_conflict_arbitration_record")
+    conflict["material_conflicts"] = []
+
+    if args.fail_freeze:
+        conflict["material_conflicts"] = ["contradictory_eval_signals"]
+
+    policy_bundle = build_policy_regression_evidence_bundle(
+        bundle_id="policy-bundle-001",
+        policy_version="1.0.0",
+        rule_version="1.0.0",
+        eval_version="1.2.0",
+        regression_passed=True,
+        evidence_refs=["eval_summary://rax-001"],
+    )
+
+    replay_binding = build_replay_evidence_binding(
+        bundle_id="run-bundle-001",
+        replay_identity={
+            "fingerprint": "fp-001",
+            "policy_version": "1.0.0",
+            "semantic_rule_version": "1.0.0",
+        },
+        expected_policy_version="1.0.0",
+        expected_semantic_rule_version="1.0.0",
+    )
+
+    drift_decision = evaluate_drift_threshold_semantics(
+        health_snapshot={"snapshot_id": "s1", "candidate_posture": "healthy", "threshold_violations": []},
+        drift_signal_record={
+            "signal_id": "d1",
+            "candidate_posture": "freeze_candidate" if args.fail_freeze else "warn",
+            "violations": ["eval_signal_drift"] if args.fail_freeze else [],
+        },
+    )
+
+    candidate = load_example("rax_failure_eval_candidate")
+    registry: dict[str, object] = {"admitted_candidates": []}
+    admission = apply_admission_quality_filters(
+        candidate=candidate,
+        admission_policy={
+            "min_reason_codes": 1,
+            "allowed_eval_types": ["rax_output_semantic_alignment", "rax_control_readiness"],
+            "max_candidates_per_target_per_window": 3,
+            "max_same_dedupe_key_per_window": 2,
+        },
+        canonical_registry=registry,
+    )
+
+    _ = compile_judgment_patterns_to_policy_candidates(
+        compilation_id="compile-001",
+        judgment_records=[{"rationale": ["missing_required_eval_types", "trace_incomplete"]}] * 3,
+    )
+
+    signature = sign_rax_evidence_bundle(bundle=policy_bundle, signing_key="rax-dev-key")
+    signature_verified = verify_rax_evidence_bundle_signature(
+        bundle=policy_bundle,
+        signature_record=signature,
+        signing_key="rax-dev-key",
+    )
+
+    gate = enforce_rax_operational_hard_gate(
+        gate_id="rax-operational-gate-001",
+        readiness_record=readiness,
+        conflict_record=conflict,
+        policy_regression_bundle=policy_bundle,
+        replay_binding=replay_binding,
+        drift_threshold_decision=drift_decision,
+        admission_record=admission,
+        signature_verified=signature_verified,
+    )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(gate, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps({"output": str(args.output), "passed": gate["passed"], "decision": gate["decision"]}))
+
+    raise SystemExit(0 if gate["passed"] else 2)
+
+
+if __name__ == "__main__":
+    main()

--- a/spectrum_systems/modules/runtime/rax_eval_runner.py
+++ b/spectrum_systems/modules/runtime/rax_eval_runner.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import hashlib
+import hmac
 import json
+import base64
 from copy import deepcopy
 from pathlib import Path
 from typing import Any
@@ -539,6 +541,8 @@ def admit_failure_eval_candidate(
             "eval_case_id": candidate["eval_case_id"],
             "eval_type": candidate["eval_type"],
             "version": candidate.get("version", "1.0.0"),
+            "target_ref": candidate.get("target_ref", ""),
+            "dedupe_key": candidate.get("dedupe_key", ""),
         })
 
     record = {
@@ -611,6 +615,229 @@ def enforce_rax_promotion_hard_gate(
     }
     validate_artifact(out, "rax_promotion_hard_gate_record")
     return out
+
+
+def build_policy_regression_evidence_bundle(
+    *,
+    bundle_id: str,
+    policy_version: str,
+    rule_version: str,
+    eval_version: str,
+    regression_passed: bool,
+    evidence_refs: list[str],
+) -> dict[str, Any]:
+    return {
+        "artifact_type": "rax_policy_regression_evidence_bundle",
+        "schema_version": "1.0.0",
+        "bundle_id": bundle_id,
+        "policy_version": policy_version,
+        "rule_version": rule_version,
+        "eval_version": eval_version,
+        "regression_passed": bool(regression_passed),
+        "evidence_refs": sorted(set(evidence_refs)),
+    }
+
+
+def build_replay_evidence_binding(
+    *,
+    bundle_id: str,
+    replay_identity: dict[str, Any],
+    expected_policy_version: str,
+    expected_semantic_rule_version: str,
+) -> dict[str, Any]:
+    identity = dict(replay_identity)
+    policy_version = str(identity.get("policy_version", ""))
+    semantic_rule_version = str(identity.get("semantic_rule_version", ""))
+    bound = bool(
+        identity.get("fingerprint")
+        and policy_version == expected_policy_version
+        and semantic_rule_version == expected_semantic_rule_version
+    )
+    mismatch_reasons: list[str] = []
+    if not identity.get("fingerprint"):
+        mismatch_reasons.append("replay_identity_fingerprint_missing")
+    if policy_version != expected_policy_version:
+        mismatch_reasons.append("replay_policy_version_mismatch")
+    if semantic_rule_version != expected_semantic_rule_version:
+        mismatch_reasons.append("replay_semantic_rule_version_mismatch")
+    return {
+        "artifact_type": "rax_replay_evidence_binding",
+        "schema_version": "1.0.0",
+        "bundle_id": bundle_id,
+        "bound": bound,
+        "replay_identity": identity,
+        "expected_policy_version": expected_policy_version,
+        "expected_semantic_rule_version": expected_semantic_rule_version,
+        "mismatch_reasons": sorted(set(mismatch_reasons)),
+    }
+
+
+def evaluate_drift_threshold_semantics(
+    *,
+    health_snapshot: dict[str, Any],
+    drift_signal_record: dict[str, Any],
+) -> dict[str, Any]:
+    posture = str(health_snapshot.get("candidate_posture", "warn"))
+    drift_posture = str(drift_signal_record.get("candidate_posture", "warn"))
+    posture_rank = {"healthy": 0, "warn": 1, "freeze_candidate": 2, "block_candidate": 3}
+    freeze_worthy = posture_rank.get(posture, 1) >= 2 or posture_rank.get(drift_posture, 1) >= 2
+    return {
+        "artifact_type": "rax_drift_threshold_decision",
+        "schema_version": "1.0.0",
+        "health_snapshot_ref": health_snapshot.get("snapshot_id"),
+        "drift_signal_ref": drift_signal_record.get("signal_id"),
+        "threshold_state": "freeze_worthy" if freeze_worthy else "warn_only",
+        "freeze_worthy": freeze_worthy,
+        "reasons": sorted(
+            set(
+                [f"health_posture:{posture}", f"drift_posture:{drift_posture}"]
+                + list(health_snapshot.get("threshold_violations", []))
+                + list(drift_signal_record.get("violations", []))
+            )
+        ),
+    }
+
+
+def apply_admission_quality_filters(
+    *,
+    candidate: dict[str, Any],
+    admission_policy: dict[str, Any],
+    canonical_registry: dict[str, Any],
+) -> dict[str, Any]:
+    base = admit_failure_eval_candidate(
+        candidate=candidate,
+        admission_policy=admission_policy,
+        canonical_registry=canonical_registry,
+    )
+    denied = list(base["denial_reasons"])
+    if not base["admitted"]:
+        return base
+
+    max_per_target = int(admission_policy.get("max_candidates_per_target_per_window", 5))
+    max_same_dedupe = int(admission_policy.get("max_same_dedupe_key_per_window", 2))
+    min_reason_code_length = int(admission_policy.get("min_reason_code_length", 4))
+
+    admitted_rows = canonical_registry.get("admitted_candidates", [])
+    same_target = [row for row in admitted_rows if row.get("target_ref") == candidate.get("target_ref")]
+    same_dedupe = [row for row in admitted_rows if row.get("dedupe_key") == candidate.get("dedupe_key")]
+    short_reason = any(len(str(code).strip()) < min_reason_code_length for code in candidate.get("reason_codes", []))
+
+    if len(same_target) > max_per_target:
+        denied.append("rate_limit_target_window_exceeded")
+    if len(same_dedupe) > max_same_dedupe:
+        denied.append("cluster_dedupe_key_window_exceeded")
+    if short_reason:
+        denied.append("low_quality_reason_code")
+
+    admitted = len(denied) == 0
+    if not admitted:
+        canonical_registry["admitted_candidates"] = [row for row in admitted_rows if row.get("candidate_id") != candidate["candidate_id"]]
+
+    return {
+        "artifact_type": "rax_eval_candidate_admission_record",
+        "schema_version": "1.0.0",
+        "candidate_id": candidate["candidate_id"],
+        "admitted": admitted,
+        "denial_reasons": sorted(set(denied)),
+    }
+
+
+def compile_judgment_patterns_to_policy_candidates(
+    *,
+    compilation_id: str,
+    judgment_records: list[dict[str, Any]],
+    min_pattern_count: int = 3,
+) -> dict[str, Any]:
+    pattern_counts: dict[tuple[str, ...], int] = {}
+    for record in judgment_records:
+        rationale = tuple(sorted(set(record.get("rationale", []))))
+        if not rationale:
+            continue
+        pattern_counts[rationale] = pattern_counts.get(rationale, 0) + 1
+
+    candidates: list[dict[str, Any]] = []
+    for rationale, count in sorted(pattern_counts.items(), key=lambda item: (-item[1], item[0])):
+        if count < min_pattern_count:
+            continue
+        candidate_id = hashlib.sha256(f"{compilation_id}|{','.join(rationale)}".encode("utf-8")).hexdigest()[:16]
+        candidates.append(
+            {
+                "candidate_id": f"rax-policy-candidate-{candidate_id}",
+                "source_pattern": list(rationale),
+                "occurrence_count": count,
+                "candidate_type": "non_authoritative_policy_candidate",
+            }
+        )
+    return {
+        "artifact_type": "rax_judgment_policy_candidate_set",
+        "schema_version": "1.0.0",
+        "compilation_id": compilation_id,
+        "candidates": candidates,
+        "authority_note": "candidate_only_requires_governed_review",
+    }
+
+
+def sign_rax_evidence_bundle(*, bundle: dict[str, Any], signing_key: str) -> dict[str, Any]:
+    canonical = json.dumps(bundle, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    digest = hmac.new(signing_key.encode("utf-8"), canonical, hashlib.sha256).digest()
+    return {
+        "bundle_digest_sha256": hashlib.sha256(canonical).hexdigest(),
+        "signature_hmac_sha256": base64.b64encode(digest).decode("ascii"),
+        "signature_algorithm": "hmac-sha256",
+    }
+
+
+def verify_rax_evidence_bundle_signature(*, bundle: dict[str, Any], signature_record: dict[str, Any], signing_key: str) -> bool:
+    expected = sign_rax_evidence_bundle(bundle=bundle, signing_key=signing_key)
+    return bool(
+        signature_record.get("signature_algorithm") == expected["signature_algorithm"]
+        and signature_record.get("bundle_digest_sha256") == expected["bundle_digest_sha256"]
+        and hmac.compare_digest(
+            str(signature_record.get("signature_hmac_sha256", "")),
+            expected["signature_hmac_sha256"],
+        )
+    )
+
+
+def enforce_rax_operational_hard_gate(
+    *,
+    gate_id: str,
+    readiness_record: dict[str, Any],
+    conflict_record: dict[str, Any],
+    policy_regression_bundle: dict[str, Any] | None,
+    replay_binding: dict[str, Any] | None,
+    drift_threshold_decision: dict[str, Any] | None,
+    admission_record: dict[str, Any] | None,
+    signature_verified: bool,
+) -> dict[str, Any]:
+    blocking_reasons: list[str] = []
+    if conflict_record.get("material_conflicts"):
+        blocking_reasons.append("material_conflicts_unresolved")
+    if not policy_regression_bundle or not policy_regression_bundle.get("regression_passed"):
+        blocking_reasons.append("policy_regression_evidence_missing_or_failed")
+    if not replay_binding or not replay_binding.get("bound"):
+        blocking_reasons.append("replay_evidence_unbound_or_stale")
+    if drift_threshold_decision and drift_threshold_decision.get("freeze_worthy"):
+        blocking_reasons.append("drift_threshold_freeze")
+    if admission_record and not admission_record.get("admitted"):
+        blocking_reasons.append("admission_quality_filter_denied")
+    if readiness_record.get("ready_for_control") is not True:
+        blocking_reasons.append("readiness_not_ready")
+    if not signature_verified:
+        blocking_reasons.append("promotion_evidence_signature_missing_or_invalid")
+
+    return {
+        "artifact_type": "rax_operational_gate_record",
+        "schema_version": "1.0.0",
+        "gate_id": gate_id,
+        "passed": len(blocking_reasons) == 0,
+        "decision": "promote_candidate" if len(blocking_reasons) == 0 else "block_candidate",
+        "blocking_reasons": sorted(set(blocking_reasons)),
+        "conflict_zero_enforced": True,
+        "policy_regression_required": True,
+        "replay_binding_required": True,
+        "signed_provenance_required": True,
+    }
 
 
 def build_rax_unknown_state_record(

--- a/tests/test_rax_eval_runner.py
+++ b/tests/test_rax_eval_runner.py
@@ -22,6 +22,14 @@ from spectrum_systems.modules.runtime.rax_eval_runner import (
     compile_rax_judgment_record,
     enforce_rax_promotion_hard_gate,
     generate_adversarial_pattern_candidates,
+    build_policy_regression_evidence_bundle,
+    build_replay_evidence_binding,
+    evaluate_drift_threshold_semantics,
+    apply_admission_quality_filters,
+    compile_judgment_patterns_to_policy_candidates,
+    sign_rax_evidence_bundle,
+    verify_rax_evidence_bundle_signature,
+    enforce_rax_operational_hard_gate,
 )
 
 
@@ -716,3 +724,92 @@ def test_rax12_promotion_hard_gate_blocks_missing_evidence() -> None:
     validate_artifact(gate, "rax_promotion_hard_gate_record")
     assert gate["passed"] is False
     assert "replay_evidence_missing" in gate["missing_evidence"]
+
+
+def test_rax15_policy_regression_evidence_bundle_requires_pass() -> None:
+    bundle = build_policy_regression_evidence_bundle(
+        bundle_id="bundle-001",
+        policy_version="1.0.0",
+        rule_version="1.0.0",
+        eval_version="1.2.0",
+        regression_passed=False,
+        evidence_refs=["eval_summary://x"],
+    )
+    assert bundle["regression_passed"] is False
+
+
+def test_rax16_replay_binding_rejects_version_mismatch() -> None:
+    binding = build_replay_evidence_binding(
+        bundle_id="run-001",
+        replay_identity={"fingerprint": "fp", "policy_version": "1.0.1", "semantic_rule_version": "1.0.0"},
+        expected_policy_version="1.0.0",
+        expected_semantic_rule_version="1.0.0",
+    )
+    assert binding["bound"] is False
+    assert "replay_policy_version_mismatch" in binding["mismatch_reasons"]
+
+
+def test_rax19_drift_threshold_decision_marks_freeze_worthy() -> None:
+    decision = evaluate_drift_threshold_semantics(
+        health_snapshot={"snapshot_id": "h1", "candidate_posture": "warn", "threshold_violations": []},
+        drift_signal_record={"signal_id": "d1", "candidate_posture": "freeze_candidate", "violations": ["eval_signal_drift"]},
+    )
+    assert decision["freeze_worthy"] is True
+    assert decision["threshold_state"] == "freeze_worthy"
+
+
+def test_rax20_admission_quality_filters_rate_limit_and_cluster() -> None:
+    candidate = load_example("rax_failure_eval_candidate")
+    registry = {
+        "admitted_candidates": [
+            {"candidate_id": "c1", "target_ref": candidate["target_ref"], "dedupe_key": candidate["dedupe_key"]},
+            {"candidate_id": "c2", "target_ref": candidate["target_ref"], "dedupe_key": candidate["dedupe_key"]},
+        ]
+    }
+    result = apply_admission_quality_filters(
+        candidate=candidate,
+        admission_policy={
+            "min_reason_codes": 1,
+            "allowed_eval_types": [candidate["eval_type"]],
+            "max_candidates_per_target_per_window": 1,
+            "max_same_dedupe_key_per_window": 1,
+        },
+        canonical_registry=registry,
+    )
+    assert result["admitted"] is False
+    assert "cluster_dedupe_key_window_exceeded" in result["denial_reasons"]
+
+
+def test_rax21_compile_judgment_patterns_to_non_authoritative_candidates() -> None:
+    compiled = compile_judgment_patterns_to_policy_candidates(
+        compilation_id="compile-01",
+        judgment_records=[
+            {"rationale": ["missing_required_eval_types", "trace_incomplete"]},
+            {"rationale": ["trace_incomplete", "missing_required_eval_types"]},
+            {"rationale": ["missing_required_eval_types", "trace_incomplete"]},
+        ],
+    )
+    assert compiled["authority_note"] == "candidate_only_requires_governed_review"
+    assert compiled["candidates"]
+
+
+def test_rax22_signed_provenance_verification_fail_closed() -> None:
+    bundle = {"artifact_type": "rax_policy_regression_evidence_bundle", "bundle_id": "b1"}
+    signature = sign_rax_evidence_bundle(bundle=bundle, signing_key="key-a")
+    verified = verify_rax_evidence_bundle_signature(bundle=bundle, signature_record=signature, signing_key="key-b")
+    assert verified is False
+
+
+def test_rax13_rax14_rax17_operational_gate_enforces_conflict_zero_and_external_conditions() -> None:
+    gate = enforce_rax_operational_hard_gate(
+        gate_id="gate-op-01",
+        readiness_record={"ready_for_control": True},
+        conflict_record={"material_conflicts": ["contradictory_eval_signals"]},
+        policy_regression_bundle={"regression_passed": True},
+        replay_binding={"bound": True},
+        drift_threshold_decision={"freeze_worthy": False},
+        admission_record={"admitted": True},
+        signature_verified=True,
+    )
+    assert gate["passed"] is False
+    assert "material_conflicts_unresolved" in gate["blocking_reasons"]

--- a/tests/test_run_rax_operational_gate_cli.py
+++ b/tests/test_run_rax_operational_gate_cli.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_run_rax_operational_gate_cli_passes_and_emits_artifact(tmp_path: Path) -> None:
+    output = tmp_path / "gate.json"
+    cmd = [sys.executable, str(REPO_ROOT / "scripts" / "run_rax_operational_gate.py"), "--output", str(output)]
+    proc = subprocess.run(cmd, check=False, cwd=REPO_ROOT, capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["artifact_type"] == "rax_operational_gate_record"
+    assert payload["decision"] == "promote_candidate"
+
+
+def test_run_rax_operational_gate_cli_fail_closed_on_freeze(tmp_path: Path) -> None:
+    output = tmp_path / "gate-fail.json"
+    cmd = [
+        sys.executable,
+        str(REPO_ROOT / "scripts" / "run_rax_operational_gate.py"),
+        "--output",
+        str(output),
+        "--fail-freeze",
+    ]
+    proc = subprocess.run(cmd, check=False, cwd=REPO_ROOT, capture_output=True, text=True)
+    assert proc.returncode == 2
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["passed"] is False
+    assert "material_conflicts_unresolved" in payload["blocking_reasons"]


### PR DESCRIPTION
### Motivation
- Finish wiring later RAX roadmap slices (RAX-13..RAX-22) by converting internal primitives into operational, fail-closed enforcement seams consumable by CI and scripts. 
- Preserve artifact-first, non-authoritative RAX design while adding measurable admission, replay-binding, policy-regression, drift-threshold, and provenance checks required for promotion gating. 
- Provide a thin external seam so the gate can be invoked by workflows and integration tests without moving logic out of runtime modules.

### Description
- Added operational primitives to `spectrum_systems/modules/runtime/rax_eval_runner.py`: `build_policy_regression_evidence_bundle`, `build_replay_evidence_binding`, `evaluate_drift_threshold_semantics`, `apply_admission_quality_filters`, `compile_judgment_patterns_to_policy_candidates`, HMAC `sign_rax_evidence_bundle`/`verify_rax_evidence_bundle_signature`, and `enforce_rax_operational_hard_gate` that aggregates fail-closed blocking reasons. 
- Extended admission registry rows with `target_ref` and `dedupe_key` to support rate/cluster filtering and used the admission filter to implement anti-poisoning controls. 
- Added a thin CLI `scripts/run_rax_operational_gate.py` that composes the new primitives, emits an operational gate artifact, and uses fail-closed exit semantics (0 = pass, 2 = blocked). 
- Added tests and test wiring: extended `tests/test_rax_eval_runner.py` with targeted unit tests for policy-regression bundles, replay binding checks, drift threshold freeze semantics, admission quality filters, judgment→policy candidate compilation, and signed provenance verification, and added `tests/test_run_rax_operational_gate_cli.py` to exercise the CLI path.

### Testing
- Ran `pytest tests/test_rax_eval_runner.py tests/test_run_rax_operational_gate_cli.py` and all new and existing assertions passed (`47 passed`). 
- Ran `pytest tests/test_contract_enforcement.py` and it passed (`37 passed`). 
- Ran `python scripts/run_contract_enforcement.py` which completed with summary `failures=0 warnings=0 not_yet_enforceable=0`. 
- Ran the contract-boundary audit script `.codex/skills/contract-boundary-audit/run.sh`; it executed successfully but reported high-volume, pre-existing informational/warning entries in this repo baseline rather than new failures. 
- Notes: CI workflow invocation of the new script was not added in this change and remains as the recommended next hard gate to operationalize the promotion enforcement end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbb2c3c77083298cf258dbe580354e)