### PR TITLE
CDE-001: Implement RIL closeout gate and CDE bounded decision authority foundation

### DIFF
--- a/contracts/examples/continuation_decision_record.json
+++ b/contracts/examples/continuation_decision_record.json
@@ -1,0 +1,25 @@
+{
+  "artifact_type": "continuation_decision_record",
+  "schema_version": "1.0.0",
+  "decision_id": "cde-dec-0123456789abcdef",
+  "trace_id": "trace-cde-001",
+  "evidence_pack_ref": "decision_evidence_pack:cde-ep-0123456789abcdef",
+  "decision_outcome": "continue_repair_bounded",
+  "reason_codes": [
+    "evidence_sufficient",
+    "policy_allows_bounded_continue"
+  ],
+  "evidence_refs": [
+    "interpretation_record:ril-int-0123",
+    "repair_eval_result:fre-reval-0123"
+  ],
+  "change_conditions": [
+    "material_conflict_detected",
+    "evidence_budget_exceeded"
+  ],
+  "non_authority_assertions": [
+    "decision_artifact_only",
+    "cde_must_not_execute",
+    "cde_must_not_enforce"
+  ]
+}

--- a/contracts/examples/decision_bundle.json
+++ b/contracts/examples/decision_bundle.json
@@ -1,0 +1,16 @@
+{
+  "artifact_type": "decision_bundle",
+  "schema_version": "1.0.0",
+  "bundle_id": "cde-bundle-0123456789abcdef",
+  "trace_id": "trace-cde-001",
+  "decision_evidence_pack_ref": "decision_evidence_pack:cde-ep-0123456789abcdef",
+  "continuation_decision_record_ref": "continuation_decision_record:cde-dec-0123456789abcdef",
+  "decision_eval_result_ref": "decision_eval_result:cde-eval-0123456789abcdef",
+  "decision_readiness_record_ref": "decision_readiness_record:cde-ready-0123456789abcdef",
+  "decision_conflict_record_ref": "decision_conflict_record:cde-conf-0123456789abcdef",
+  "lineage_complete": true,
+  "non_authority_assertions": [
+    "bundle_is_decision_only",
+    "bundle_not_execution_authority"
+  ]
+}

--- a/contracts/examples/decision_conflict_record.json
+++ b/contracts/examples/decision_conflict_record.json
@@ -1,0 +1,14 @@
+{
+  "artifact_type": "decision_conflict_record",
+  "schema_version": "1.0.0",
+  "conflict_id": "cde-conf-0123456789abcdef",
+  "trace_id": "trace-cde-001",
+  "decision_evidence_pack_ref": "decision_evidence_pack:cde-ep-0123456789abcdef",
+  "conflict_refs": [
+    "interpretation_conflict_record:ril-conf-0123"
+  ],
+  "material_conflict": false,
+  "resolved": true,
+  "resolution_state": "resolved",
+  "resolution_notes": "no material contradiction across governed evidence"
+}

--- a/contracts/examples/decision_effectiveness_record.json
+++ b/contracts/examples/decision_effectiveness_record.json
@@ -1,0 +1,11 @@
+{
+  "artifact_type": "decision_effectiveness_record",
+  "schema_version": "1.0.0",
+  "record_id": "cde-eff-0123456789abcdef",
+  "trace_id": "trace-cde-001",
+  "continuation_decision_record_ref": "continuation_decision_record:cde-dec-0123456789abcdef",
+  "downstream_outcome_ref": "downstream_outcome:tlc-merge-001",
+  "effectiveness_state": "effective",
+  "precision_proxy": 0.9,
+  "strictness_proxy": 0.6
+}

--- a/contracts/examples/decision_eval_result.json
+++ b/contracts/examples/decision_eval_result.json
@@ -1,0 +1,14 @@
+{
+  "artifact_type": "decision_eval_result",
+  "schema_version": "1.0.0",
+  "eval_id": "cde-eval-0123456789abcdef",
+  "trace_id": "trace-cde-001",
+  "continuation_decision_record_ref": "continuation_decision_record:cde-dec-0123456789abcdef",
+  "evidence_sufficiency_passed": true,
+  "policy_alignment_passed": true,
+  "contradiction_handling_passed": true,
+  "decision_completeness_passed": true,
+  "required_field_coverage_passed": true,
+  "result": "pass",
+  "fail_reasons": []
+}

--- a/contracts/examples/decision_evidence_pack.json
+++ b/contracts/examples/decision_evidence_pack.json
@@ -1,0 +1,20 @@
+{
+  "artifact_type": "decision_evidence_pack",
+  "schema_version": "1.0.0",
+  "evidence_pack_id": "cde-ep-0123456789abcdef",
+  "trace_id": "trace-cde-001",
+  "interpretation_bundle_ref": "interpretation_bundle:ril-bundle-0123456789abcdef",
+  "repair_bundle_ref": "repair_bundle:fre-bundle-0123456789abcdef",
+  "policy_constraints_ref": "policy:repair_continuation_v1",
+  "provenance_refs": [
+    "provenance_record:prv-001"
+  ],
+  "replay_refs": [
+    "interpretation_replay_validation_record:ril-replay-001"
+  ],
+  "evidence_refs": [
+    "failure_packet:ril-fp-001",
+    "repair_eval_result:fre-reval-001"
+  ],
+  "input_fingerprint": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+}

--- a/contracts/examples/decision_readiness_record.json
+++ b/contracts/examples/decision_readiness_record.json
@@ -1,0 +1,15 @@
+{
+  "artifact_type": "decision_readiness_record",
+  "schema_version": "1.0.0",
+  "readiness_id": "cde-ready-0123456789abcdef",
+  "trace_id": "trace-cde-001",
+  "continuation_decision_record_ref": "continuation_decision_record:cde-dec-0123456789abcdef",
+  "decision_eval_result_ref": "decision_eval_result:cde-eval-0123456789abcdef",
+  "candidate_ready": true,
+  "blocking_reasons": [],
+  "non_authority_assertions": [
+    "candidate_only",
+    "cannot_trigger_execution",
+    "cannot_trigger_enforcement"
+  ]
+}

--- a/contracts/examples/decision_replay_validation_record.json
+++ b/contracts/examples/decision_replay_validation_record.json
@@ -1,0 +1,11 @@
+{
+  "artifact_type": "decision_replay_validation_record",
+  "schema_version": "1.0.0",
+  "validation_id": "cde-replay-0123456789abcdef",
+  "input_fingerprint": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  "first_decision_fingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+  "replay_decision_fingerprint": "1111111111111111111111111111111111111111111111111111111111111111",
+  "deterministic_match": true,
+  "result": "pass",
+  "fail_reasons": []
+}

--- a/contracts/examples/ril_closeout_gate_record.json
+++ b/contracts/examples/ril_closeout_gate_record.json
@@ -1,0 +1,21 @@
+{
+  "artifact_type": "ril_closeout_gate_record",
+  "schema_version": "1.0.0",
+  "gate_id": "ril-close-0123456789abcdef",
+  "failure_packet_ref": "failure_packet:ril-fp-0123456789abcdef",
+  "interpretation_record_ref": "interpretation_record:ril-int-0123456789abcdef",
+  "interpretation_eval_result_ref": "interpretation_eval_result:ril-eval-0123456789abcdef",
+  "interpretation_readiness_record_ref": "interpretation_readiness_record:ril-ready-0123456789abcdef",
+  "interpretation_replay_validation_record_ref": "interpretation_replay_validation_record:ril-replay-0123456789abcdef",
+  "interpretation_conflict_record_ref": "interpretation_conflict_record:ril-conf-0123456789abcdef",
+  "interpretation_repair_alignment_record_ref": "interpretation_repair_alignment_record:ril-align-0123456789abcdef",
+  "interpretation_ambiguity_signal_ref": "interpretation_ambiguity_signal:ril-amb-0123456789abcdef",
+  "ril_operational": true,
+  "closeout_status": "closed",
+  "blocking_reasons": [],
+  "non_authority_assertions": [
+    "ril_interpretation_only",
+    "ril_not_decision_authority",
+    "ril_not_execution_authority"
+  ]
+}

--- a/contracts/schemas/continuation_decision_record.schema.json
+++ b/contracts/schemas/continuation_decision_record.schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/continuation_decision_record.schema.json",
+  "title": "Continuation Decision Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "decision_id",
+    "trace_id",
+    "evidence_pack_ref",
+    "decision_outcome",
+    "reason_codes",
+    "evidence_refs",
+    "change_conditions",
+    "non_authority_assertions"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "continuation_decision_record"
+    },
+    "schema_version": {
+      "const": "1.0.0"
+    },
+    "decision_id": {
+      "type": "string",
+      "pattern": "^cde-dec-[a-f0-9]{16}$"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "evidence_pack_ref": {
+      "type": "string",
+      "pattern": "^decision_evidence_pack:.+"
+    },
+    "decision_outcome": {
+      "type": "string",
+      "enum": [
+        "continue_repair_bounded",
+        "block",
+        "human_review_required"
+      ]
+    },
+    "reason_codes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "evidence_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "change_conditions": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "non_authority_assertions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    }
+  }
+}

--- a/contracts/schemas/decision_bundle.schema.json
+++ b/contracts/schemas/decision_bundle.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/decision_bundle.schema.json",
+  "title": "Decision Bundle",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "bundle_id",
+    "trace_id",
+    "decision_evidence_pack_ref",
+    "continuation_decision_record_ref",
+    "decision_eval_result_ref",
+    "decision_readiness_record_ref",
+    "decision_conflict_record_ref",
+    "lineage_complete",
+    "non_authority_assertions"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "decision_bundle"
+    },
+    "schema_version": {
+      "const": "1.0.0"
+    },
+    "bundle_id": {
+      "type": "string",
+      "pattern": "^cde-bundle-[a-f0-9]{16}$"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "decision_evidence_pack_ref": {
+      "type": "string",
+      "pattern": "^decision_evidence_pack:.+"
+    },
+    "continuation_decision_record_ref": {
+      "type": "string",
+      "pattern": "^continuation_decision_record:.+"
+    },
+    "decision_eval_result_ref": {
+      "type": "string",
+      "pattern": "^decision_eval_result:.+"
+    },
+    "decision_readiness_record_ref": {
+      "type": "string",
+      "pattern": "^decision_readiness_record:.+"
+    },
+    "decision_conflict_record_ref": {
+      "type": "string",
+      "pattern": "^decision_conflict_record:.+"
+    },
+    "lineage_complete": {
+      "type": "boolean"
+    },
+    "non_authority_assertions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    }
+  }
+}

--- a/contracts/schemas/decision_conflict_record.schema.json
+++ b/contracts/schemas/decision_conflict_record.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/decision_conflict_record.schema.json",
+  "title": "Decision Conflict Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "conflict_id",
+    "trace_id",
+    "decision_evidence_pack_ref",
+    "conflict_refs",
+    "material_conflict",
+    "resolved",
+    "resolution_state",
+    "resolution_notes"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "decision_conflict_record"
+    },
+    "schema_version": {
+      "const": "1.0.0"
+    },
+    "conflict_id": {
+      "type": "string",
+      "pattern": "^cde-conf-[a-f0-9]{16}$"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "decision_evidence_pack_ref": {
+      "type": "string",
+      "pattern": "^decision_evidence_pack:.+"
+    },
+    "conflict_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "material_conflict": {
+      "type": "boolean"
+    },
+    "resolved": {
+      "type": "boolean"
+    },
+    "resolution_state": {
+      "type": "string",
+      "enum": [
+        "resolved",
+        "unresolved"
+      ]
+    },
+    "resolution_notes": {
+      "type": "string",
+      "minLength": 1
+    }
+  }
+}

--- a/contracts/schemas/decision_effectiveness_record.schema.json
+++ b/contracts/schemas/decision_effectiveness_record.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/decision_effectiveness_record.schema.json",
+  "title": "Decision Effectiveness Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "record_id",
+    "trace_id",
+    "continuation_decision_record_ref",
+    "downstream_outcome_ref",
+    "effectiveness_state",
+    "precision_proxy",
+    "strictness_proxy"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "decision_effectiveness_record"
+    },
+    "schema_version": {
+      "const": "1.0.0"
+    },
+    "record_id": {
+      "type": "string",
+      "pattern": "^cde-eff-[a-f0-9]{16}$"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "continuation_decision_record_ref": {
+      "type": "string",
+      "pattern": "^continuation_decision_record:.+"
+    },
+    "downstream_outcome_ref": {
+      "type": "string",
+      "pattern": "^downstream_outcome:.+"
+    },
+    "effectiveness_state": {
+      "type": "string",
+      "enum": [
+        "effective",
+        "too_permissive",
+        "too_strict",
+        "noisy"
+      ]
+    },
+    "precision_proxy": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "strictness_proxy": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    }
+  }
+}

--- a/contracts/schemas/decision_eval_result.schema.json
+++ b/contracts/schemas/decision_eval_result.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/decision_eval_result.schema.json",
+  "title": "Decision Eval Result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "eval_id",
+    "trace_id",
+    "continuation_decision_record_ref",
+    "evidence_sufficiency_passed",
+    "policy_alignment_passed",
+    "contradiction_handling_passed",
+    "decision_completeness_passed",
+    "required_field_coverage_passed",
+    "result",
+    "fail_reasons"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "decision_eval_result"
+    },
+    "schema_version": {
+      "const": "1.0.0"
+    },
+    "eval_id": {
+      "type": "string",
+      "pattern": "^cde-eval-[a-f0-9]{16}$"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "continuation_decision_record_ref": {
+      "type": "string",
+      "pattern": "^continuation_decision_record:.+"
+    },
+    "evidence_sufficiency_passed": {
+      "type": "boolean"
+    },
+    "policy_alignment_passed": {
+      "type": "boolean"
+    },
+    "contradiction_handling_passed": {
+      "type": "boolean"
+    },
+    "decision_completeness_passed": {
+      "type": "boolean"
+    },
+    "required_field_coverage_passed": {
+      "type": "boolean"
+    },
+    "result": {
+      "type": "string",
+      "enum": [
+        "pass",
+        "fail"
+      ]
+    },
+    "fail_reasons": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    }
+  }
+}

--- a/contracts/schemas/decision_evidence_pack.schema.json
+++ b/contracts/schemas/decision_evidence_pack.schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/decision_evidence_pack.schema.json",
+  "title": "Decision Evidence Pack",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "evidence_pack_id",
+    "trace_id",
+    "interpretation_bundle_ref",
+    "repair_bundle_ref",
+    "policy_constraints_ref",
+    "provenance_refs",
+    "replay_refs",
+    "evidence_refs",
+    "input_fingerprint"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "decision_evidence_pack"
+    },
+    "schema_version": {
+      "const": "1.0.0"
+    },
+    "evidence_pack_id": {
+      "type": "string",
+      "pattern": "^cde-ep-[a-f0-9]{16}$"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "interpretation_bundle_ref": {
+      "type": "string",
+      "pattern": "^interpretation_bundle:.+"
+    },
+    "repair_bundle_ref": {
+      "type": "string",
+      "pattern": "^repair_bundle:.+"
+    },
+    "policy_constraints_ref": {
+      "type": "string",
+      "pattern": "^policy:.+"
+    },
+    "provenance_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "replay_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "evidence_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "input_fingerprint": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    }
+  }
+}

--- a/contracts/schemas/decision_readiness_record.schema.json
+++ b/contracts/schemas/decision_readiness_record.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/decision_readiness_record.schema.json",
+  "title": "Decision Readiness Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "readiness_id",
+    "trace_id",
+    "continuation_decision_record_ref",
+    "decision_eval_result_ref",
+    "candidate_ready",
+    "blocking_reasons",
+    "non_authority_assertions"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "decision_readiness_record"
+    },
+    "schema_version": {
+      "const": "1.0.0"
+    },
+    "readiness_id": {
+      "type": "string",
+      "pattern": "^cde-ready-[a-f0-9]{16}$"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "continuation_decision_record_ref": {
+      "type": "string",
+      "pattern": "^continuation_decision_record:.+"
+    },
+    "decision_eval_result_ref": {
+      "type": "string",
+      "pattern": "^decision_eval_result:.+"
+    },
+    "candidate_ready": {
+      "type": "boolean"
+    },
+    "blocking_reasons": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "non_authority_assertions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    }
+  }
+}

--- a/contracts/schemas/decision_replay_validation_record.schema.json
+++ b/contracts/schemas/decision_replay_validation_record.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/decision_replay_validation_record.schema.json",
+  "title": "Decision Replay Validation Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "validation_id",
+    "input_fingerprint",
+    "first_decision_fingerprint",
+    "replay_decision_fingerprint",
+    "deterministic_match",
+    "result",
+    "fail_reasons"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "decision_replay_validation_record"
+    },
+    "schema_version": {
+      "const": "1.0.0"
+    },
+    "validation_id": {
+      "type": "string",
+      "pattern": "^cde-replay-[a-f0-9]{16}$"
+    },
+    "input_fingerprint": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "first_decision_fingerprint": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "replay_decision_fingerprint": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "deterministic_match": {
+      "type": "boolean"
+    },
+    "result": {
+      "type": "string",
+      "enum": [
+        "pass",
+        "fail"
+      ]
+    },
+    "fail_reasons": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    }
+  }
+}

--- a/contracts/schemas/ril_closeout_gate_record.schema.json
+++ b/contracts/schemas/ril_closeout_gate_record.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/ril_closeout_gate_record.schema.json",
+  "title": "RIL Closeout Gate Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "gate_id",
+    "failure_packet_ref",
+    "interpretation_record_ref",
+    "interpretation_eval_result_ref",
+    "interpretation_readiness_record_ref",
+    "interpretation_replay_validation_record_ref",
+    "interpretation_conflict_record_ref",
+    "interpretation_repair_alignment_record_ref",
+    "interpretation_ambiguity_signal_ref",
+    "ril_operational",
+    "closeout_status",
+    "blocking_reasons",
+    "non_authority_assertions"
+  ],
+  "properties": {
+    "artifact_type": {"const": "ril_closeout_gate_record"},
+    "schema_version": {"const": "1.0.0"},
+    "gate_id": {"type": "string", "pattern": "^ril-close-[a-f0-9]{16}$"},
+    "failure_packet_ref": {"type": "string", "pattern": "^failure_packet:.+"},
+    "interpretation_record_ref": {"type": "string", "pattern": "^interpretation_record:.+"},
+    "interpretation_eval_result_ref": {"type": "string", "pattern": "^interpretation_eval_result:.+"},
+    "interpretation_readiness_record_ref": {"type": "string", "pattern": "^interpretation_readiness_record:.+"},
+    "interpretation_replay_validation_record_ref": {"type": "string", "pattern": "^interpretation_replay_validation_record:.+"},
+    "interpretation_conflict_record_ref": {"type": "string", "pattern": "^interpretation_conflict_record:.+"},
+    "interpretation_repair_alignment_record_ref": {"type": "string", "pattern": "^interpretation_repair_alignment_record:.+"},
+    "interpretation_ambiguity_signal_ref": {"type": "string", "pattern": "^interpretation_ambiguity_signal:.+"},
+    "ril_operational": {"type": "boolean"},
+    "closeout_status": {"type": "string", "enum": ["closed", "blocked"]},
+    "blocking_reasons": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+    "non_authority_assertions": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}, "uniqueItems": true}
+  }
+}

--- a/contracts/standards-manifest.json
+++ b/contracts/standards-manifest.json
@@ -1,9 +1,9 @@
 {
   "artifact_type": "standards_manifest",
   "artifact_id": "STD-CONTRACTS",
-  "artifact_version": "1.3.113",
+  "artifact_version": "1.3.114",
   "schema_version": "1.3.98",
-  "standards_version": "1.3.113",
+  "standards_version": "1.3.114",
   "record_id": "REC-STD-2026-04-12-RAX-ROADMAP",
   "run_id": "run-20260412T120000Z-rax-roadmap-serial-01",
   "created_at": "2026-04-12T00:00:00Z",
@@ -760,6 +760,19 @@
       "notes": "TRUST-01 deterministic fail-closed pre-execution context validation artifact for bundle/schema/trust/source/policy checks."
     },
     {
+      "artifact_type": "continuation_decision_record",
+      "artifact_class": "governance",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.114",
+      "last_updated_in": "1.3.114",
+      "example_path": "contracts/examples/continuation_decision_record.json",
+      "notes": "CDE-001 bounded decision authority and RIL closeout contract."
+    },
+    {
       "artifact_type": "continuous_eval_run_record",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -1005,6 +1018,71 @@
       "notes": "CTRL-LOOP-01 grouped observability extension: deterministic per-cycle status projection with normalized blocked reasons and artifact references."
     },
     {
+      "artifact_type": "decision_bundle",
+      "artifact_class": "governance",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.114",
+      "last_updated_in": "1.3.114",
+      "example_path": "contracts/examples/decision_bundle.json",
+      "notes": "CDE-001 bounded decision authority and RIL closeout contract."
+    },
+    {
+      "artifact_type": "decision_conflict_record",
+      "artifact_class": "governance",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.114",
+      "last_updated_in": "1.3.114",
+      "example_path": "contracts/examples/decision_conflict_record.json",
+      "notes": "CDE-001 bounded decision authority and RIL closeout contract."
+    },
+    {
+      "artifact_type": "decision_effectiveness_record",
+      "artifact_class": "governance",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.114",
+      "last_updated_in": "1.3.114",
+      "example_path": "contracts/examples/decision_effectiveness_record.json",
+      "notes": "CDE-001 bounded decision authority and RIL closeout contract."
+    },
+    {
+      "artifact_type": "decision_eval_result",
+      "artifact_class": "governance",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.114",
+      "last_updated_in": "1.3.114",
+      "example_path": "contracts/examples/decision_eval_result.json",
+      "notes": "CDE-001 bounded decision authority and RIL closeout contract."
+    },
+    {
+      "artifact_type": "decision_evidence_pack",
+      "artifact_class": "governance",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.114",
+      "last_updated_in": "1.3.114",
+      "example_path": "contracts/examples/decision_evidence_pack.json",
+      "notes": "CDE-001 bounded decision authority and RIL closeout contract."
+    },
+    {
       "artifact_type": "decision_explainability_artifact",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -1056,6 +1134,32 @@
       "last_updated_in": "1.3.63",
       "example_path": "contracts/examples/decision_quality_budget_status.json",
       "notes": "LT-05 deterministic decision-quality budget status with explicit thresholds and fail-closed exhaustion semantics."
+    },
+    {
+      "artifact_type": "decision_readiness_record",
+      "artifact_class": "governance",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.114",
+      "last_updated_in": "1.3.114",
+      "example_path": "contracts/examples/decision_readiness_record.json",
+      "notes": "CDE-001 bounded decision authority and RIL closeout contract."
+    },
+    {
+      "artifact_type": "decision_replay_validation_record",
+      "artifact_class": "governance",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.114",
+      "last_updated_in": "1.3.114",
+      "example_path": "contracts/examples/decision_replay_validation_record.json",
+      "notes": "CDE-001 bounded decision authority and RIL closeout contract."
     },
     {
       "artifact_type": "done_certification_error",
@@ -3815,35 +3919,9 @@
         "spectrum-systems"
       ],
       "introduced_in": "1.3.114",
-      "last_updated_in": "1.3.113",
-      "example_path": "contracts/examples/rax_adversarial_pattern_candidate.json",
-      "notes": "RAX deterministic adversarial pattern candidate artifact for governed eval/regression consumption."
-    },
-    {
-      "artifact_type": "rax_adversarial_pattern_candidate",
-      "artifact_class": "governance",
-      "schema_version": "1.0.0",
-      "status": "active",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.114",
       "last_updated_in": "1.3.114",
       "example_path": "contracts/examples/rax_adversarial_pattern_candidate.json",
       "notes": "RAX deterministic adversarial pattern candidate artifact for governed eval/regression consumption."
-    },
-    {
-      "artifact_type": "rax_assurance_audit_record",
-      "artifact_class": "governance",
-      "schema_version": "1.0.0",
-      "status": "active",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.112",
-      "last_updated_in": "1.3.112",
-      "example_path": "contracts/examples/rax_assurance_audit_record.example.json",
-      "notes": "RAX-INTERFACE-24-01 fail-closed assurance audit artifact for local accept/hold/block candidate decisions."
     },
     {
       "artifact_type": "rax_assurance_audit_record",
@@ -3874,19 +3952,6 @@
     {
       "artifact_type": "rax_control_readiness_record",
       "artifact_class": "governance",
-      "schema_version": "1.1.0",
-      "status": "active",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.113",
-      "last_updated_in": "1.3.113",
-      "example_path": "contracts/examples/rax_control_readiness_record.json",
-      "notes": "RAX-FEEDBACK-LOOP-10 bounded readiness artifact with structured readiness-change conditions, unknown-state linkage, and pre-certification alignment references."
-    },
-    {
-      "artifact_type": "rax_control_readiness_record",
-      "artifact_class": "governance",
       "schema_version": "1.0.0",
       "status": "active",
       "intended_consumers": [
@@ -3896,19 +3961,6 @@
       "last_updated_in": "1.3.114",
       "example_path": "contracts/examples/rax_control_readiness_record.json",
       "notes": "RAX-FEEDBACK-LOOP-10 bounded readiness artifact with structured readiness-change conditions, unknown-state linkage, and pre-certification alignment references."
-    },
-    {
-      "artifact_type": "rax_drift_signal_record",
-      "artifact_class": "governance",
-      "schema_version": "1.0.0",
-      "status": "active",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.114",
-      "last_updated_in": "1.3.114",
-      "example_path": "contracts/examples/rax_drift_signal_record.json",
-      "notes": "RAX drift signal artifact comparing current and baseline windows across governed drift surfaces."
     },
     {
       "artifact_type": "rax_drift_signal_record",
@@ -3939,19 +3991,6 @@
     {
       "artifact_type": "rax_eval_case_set",
       "artifact_class": "governance",
-      "schema_version": "1.1.0",
-      "status": "active",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.113",
-      "last_updated_in": "1.3.113",
-      "example_path": "contracts/examples/rax_eval_case_set.json",
-      "notes": "RAX-EVAL-01 governed deterministic eval case set across baseline, adversarial, and failure classes."
-    },
-    {
-      "artifact_type": "rax_eval_case_set",
-      "artifact_class": "governance",
       "schema_version": "1.0.0",
       "status": "active",
       "intended_consumers": [
@@ -3961,19 +4000,6 @@
       "last_updated_in": "1.3.113",
       "example_path": "contracts/examples/rax_eval_case_set.json",
       "notes": "RAX-EVAL-01 governed deterministic eval case set across baseline, adversarial, and failure classes."
-    },
-    {
-      "artifact_type": "rax_eval_registry",
-      "artifact_class": "governance",
-      "schema_version": "1.1.0",
-      "status": "active",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.113",
-      "last_updated_in": "1.3.113",
-      "example_path": "contracts/examples/rax_eval_registry.json",
-      "notes": "RAX-EVAL-01 governed registry of required deterministic RAX eval definitions."
     },
     {
       "artifact_type": "rax_eval_registry",
@@ -4002,32 +4028,6 @@
       "notes": "RAX failure-derived eval candidate artifact generated deterministically from governed failure classes."
     },
     {
-      "artifact_type": "rax_failure_eval_candidate",
-      "artifact_class": "governance",
-      "schema_version": "1.0.0",
-      "status": "active",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.114",
-      "last_updated_in": "1.3.114",
-      "example_path": "contracts/examples/rax_failure_eval_candidate.json",
-      "notes": "RAX failure-derived eval candidate artifact generated deterministically from governed failure classes."
-    },
-    {
-      "artifact_type": "rax_failure_pattern_record",
-      "artifact_class": "governance",
-      "schema_version": "1.0.0",
-      "status": "active",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.114",
-      "last_updated_in": "1.3.114",
-      "example_path": "contracts/examples/rax_failure_pattern_record.json",
-      "notes": "RAX feedback-loop failure capture artifact linking classified failures to reproducibility and trace references."
-    },
-    {
       "artifact_type": "rax_failure_pattern_record",
       "artifact_class": "governance",
       "schema_version": "1.0.0",
@@ -4052,32 +4052,6 @@
       "last_updated_in": "1.3.114",
       "example_path": "contracts/examples/rax_feedback_loop_record.json",
       "notes": "RAX closure artifact linking failure, fix, eval coverage additions, and recurrence outcomes."
-    },
-    {
-      "artifact_type": "rax_feedback_loop_record",
-      "artifact_class": "governance",
-      "schema_version": "1.0.0",
-      "status": "active",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.114",
-      "last_updated_in": "1.3.114",
-      "example_path": "contracts/examples/rax_feedback_loop_record.json",
-      "notes": "RAX closure artifact linking failure, fix, eval coverage additions, and recurrence outcomes."
-    },
-    {
-      "artifact_type": "rax_health_snapshot",
-      "artifact_class": "governance",
-      "schema_version": "1.0.0",
-      "status": "active",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.114",
-      "last_updated_in": "1.3.114",
-      "example_path": "contracts/examples/rax_health_snapshot.json",
-      "notes": "RAX health metrics snapshot with SLO-style threshold posture as candidate signal only."
     },
     {
       "artifact_type": "rax_health_snapshot",
@@ -4145,19 +4119,6 @@
       "notes": "RAX pre-certification alignment artifact for downstream promotion rigor checks without granting certification authority."
     },
     {
-      "artifact_type": "rax_pre_certification_alignment_record",
-      "artifact_class": "governance",
-      "schema_version": "1.0.0",
-      "status": "active",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.114",
-      "last_updated_in": "1.3.114",
-      "example_path": "contracts/examples/rax_pre_certification_alignment_record.json",
-      "notes": "RAX pre-certification alignment artifact for downstream promotion rigor checks without granting certification authority."
-    },
-    {
       "artifact_type": "rax_promotion_hard_gate_record",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -4208,32 +4169,6 @@
       "last_updated_in": "1.3.114",
       "example_path": "contracts/examples/rax_unknown_state_record.json",
       "notes": "RAX explicit unknown-state artifact enforcing fail-closed non-readiness when basis is incomplete or contradictory."
-    },
-    {
-      "artifact_type": "rax_unknown_state_record",
-      "artifact_class": "governance",
-      "schema_version": "1.0.0",
-      "status": "active",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.114",
-      "last_updated_in": "1.3.114",
-      "example_path": "contracts/examples/rax_unknown_state_record.json",
-      "notes": "RAX explicit unknown-state artifact enforcing fail-closed non-readiness when basis is incomplete or contradictory."
-    },
-    {
-      "artifact_type": "rax_upstream_input_envelope",
-      "artifact_class": "governance",
-      "schema_version": "1.0.0",
-      "status": "active",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.112",
-      "last_updated_in": "1.3.112",
-      "example_path": "contracts/examples/rax_upstream_input_envelope.example.json",
-      "notes": "RAX-INTERFACE-24-01 strict compact upstream roadmap envelope consumed by RAX for deterministic contract expansion."
     },
     {
       "artifact_type": "rax_upstream_input_envelope",
@@ -4861,6 +4796,19 @@
       "last_updated_in": "1.0.0",
       "example_path": "contracts/examples/reviewer_comment_set.json",
       "notes": "Normalized reviewer comments with provenance links; payloads should be wrapped in the artifact envelope standard."
+    },
+    {
+      "artifact_type": "ril_closeout_gate_record",
+      "artifact_class": "governance",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.114",
+      "last_updated_in": "1.3.114",
+      "example_path": "contracts/examples/ril_closeout_gate_record.json",
+      "notes": "CDE-001 bounded decision authority and RIL closeout contract."
     },
     {
       "artifact_type": "risk_register",

--- a/docs/governance-reports/contract-enforcement-report.md
+++ b/docs/governance-reports/contract-enforcement-report.md
@@ -1,6 +1,6 @@
 # Cross-Repo Contract Enforcement Report
 
-Generated: 2026-04-12T03:02:08Z
+Generated: 2026-04-12T18:00:20Z
 Source: `contracts/standards-manifest.json`
 
 ## Summary

--- a/docs/review-actions/2026-04-12-cde-001-build-plan.md
+++ b/docs/review-actions/2026-04-12-cde-001-build-plan.md
@@ -1,0 +1,19 @@
+# CDE-001 Implementation Plan (Primary Type: BUILD)
+
+## Scope
+Implement RIL-09 closeout and CDE-01..CDE-09 bounded decision authority foundation in repo-native contracts, runtime modules, and tests.
+
+## Serial Steps
+1. Verify and close RIL-09 seams in operational flow tests.
+2. Add CDE artifact contracts (schemas/examples/manifest) for boundary, evaluation, readiness, conflict, bundle, and evidence pack.
+3. Implement CDE boundary fencing and deterministic decision engine.
+4. Implement decision eval harness, candidate-only readiness, and conflict arbitration.
+5. Implement decision replay validation and ambiguity/evidence budget handling.
+6. Implement decision effectiveness tracking artifact logic.
+7. Wire integration tests across RIL -> FRE -> CDE and fail-closed checks.
+8. Run contract enforcement + targeted pytest validation and fix regressions.
+
+## Guardrails
+- Artifact-first, fail-closed, non-executing CDE semantics.
+- No SEL/PQX/promotion replacement.
+- Deterministic outputs for identical evidence packs.

--- a/governance/reports/contract-dependency-graph.json
+++ b/governance/reports/contract-dependency-graph.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0.0",
-  "generated_at": "2026-04-12T03:02:08Z",
+  "generated_at": "2026-04-12T18:00:20Z",
   "source_manifest": "contracts/standards-manifest.json",
   "repos": [
     {

--- a/spectrum_systems/modules/runtime/cde_decision_flow.py
+++ b/spectrum_systems/modules/runtime/cde_decision_flow.py
@@ -1,0 +1,334 @@
+"""CDE bounded decision foundation (CDE-01..CDE-09).
+
+CDE consumes governed evidence and emits decision artifacts only.
+CDE never executes repairs, enforces decisions, or mutates downstream state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Mapping, Sequence
+
+from spectrum_systems.contracts import validate_artifact
+
+
+class CDEDecisionFlowError(ValueError):
+    """Raised when CDE boundary rules fail closed."""
+
+
+_ALLOWED_UPSTREAM_TYPES = {
+    "interpretation_bundle",
+    "repair_bundle",
+    "interpretation_conflict_record",
+    "interpretation_replay_validation_record",
+    "fre_promotion_gate_record",
+}
+_FORBIDDEN_EXECUTION_FIELDS = {"execute", "apply", "write_path", "shell_command", "enforcement_action"}
+
+
+def _digest(payload: Any) -> str:
+    return hashlib.sha256(json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")).hexdigest()
+
+
+def _required_str(value: Any, *, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise CDEDecisionFlowError(f"{field} must be a non-empty string")
+    return value.strip()
+
+
+def _clean_refs(values: Any, *, field: str, min_items: int = 1) -> list[str]:
+    if not isinstance(values, list):
+        raise CDEDecisionFlowError(f"{field} must be a list")
+    refs = sorted({str(v).strip() for v in values if isinstance(v, str) and v.strip()})
+    if len(refs) < min_items:
+        raise CDEDecisionFlowError(f"{field} must include at least {min_items} refs")
+    return refs
+
+
+def build_decision_evidence_pack(
+    *,
+    trace_id: str,
+    interpretation_bundle: Mapping[str, Any],
+    repair_bundle: Mapping[str, Any],
+    policy_constraints_ref: str,
+    provenance_refs: Sequence[str],
+    replay_refs: Sequence[str],
+    evidence_refs: Sequence[str],
+) -> dict[str, Any]:
+    validate_artifact(dict(interpretation_bundle), "interpretation_bundle")
+    validate_artifact(dict(repair_bundle), "repair_bundle")
+
+    pack = {
+        "artifact_type": "decision_evidence_pack",
+        "schema_version": "1.0.0",
+        "evidence_pack_id": f"cde-ep-{_digest([trace_id, interpretation_bundle['bundle_id'], repair_bundle['bundle_id']])[:16]}",
+        "trace_id": _required_str(trace_id, field="trace_id"),
+        "interpretation_bundle_ref": f"interpretation_bundle:{interpretation_bundle['bundle_id']}",
+        "repair_bundle_ref": f"repair_bundle:{repair_bundle['bundle_id']}",
+        "policy_constraints_ref": _required_str(policy_constraints_ref, field="policy_constraints_ref"),
+        "provenance_refs": _clean_refs(list(provenance_refs), field="provenance_refs"),
+        "replay_refs": _clean_refs(list(replay_refs), field="replay_refs"),
+        "evidence_refs": _clean_refs(list(evidence_refs), field="evidence_refs"),
+        "input_fingerprint": _digest(
+            {
+                "trace_id": trace_id,
+                "interpretation_bundle_ref": interpretation_bundle["bundle_id"],
+                "repair_bundle_ref": repair_bundle["bundle_id"],
+                "policy_constraints_ref": policy_constraints_ref,
+                "provenance_refs": sorted(provenance_refs),
+                "replay_refs": sorted(replay_refs),
+                "evidence_refs": sorted(evidence_refs),
+            }
+        ),
+    }
+    validate_artifact(pack, "decision_evidence_pack")
+    return pack
+
+
+def detect_decision_conflicts(*, evidence_pack: Mapping[str, Any], conflict_refs: Sequence[str], material_threshold: int = 1) -> dict[str, Any]:
+    validate_artifact(dict(evidence_pack), "decision_evidence_pack")
+    refs = _clean_refs(list(conflict_refs), field="conflict_refs")
+
+    material = len(refs) >= material_threshold
+    unresolved = material
+    record = {
+        "artifact_type": "decision_conflict_record",
+        "schema_version": "1.0.0",
+        "conflict_id": f"cde-conf-{_digest([evidence_pack['evidence_pack_id'], refs, material])[:16]}",
+        "trace_id": evidence_pack["trace_id"],
+        "decision_evidence_pack_ref": f"decision_evidence_pack:{evidence_pack['evidence_pack_id']}",
+        "conflict_refs": refs,
+        "material_conflict": material,
+        "resolved": not unresolved,
+        "resolution_state": "resolved" if not unresolved else "unresolved",
+        "resolution_notes": "material conflict unresolved" if unresolved else "non-material differences only",
+    }
+    validate_artifact(record, "decision_conflict_record")
+    return record
+
+
+def make_continuation_decision(
+    *,
+    evidence_pack: Mapping[str, Any],
+    conflict_record: Mapping[str, Any],
+    evidence_budget_min: int = 3,
+    ambiguity_rate: float = 0.0,
+    ambiguity_budget: float = 0.3,
+) -> dict[str, Any]:
+    validate_artifact(dict(evidence_pack), "decision_evidence_pack")
+    validate_artifact(dict(conflict_record), "decision_conflict_record")
+
+    if ambiguity_budget <= 0 or ambiguity_budget > 1:
+        raise CDEDecisionFlowError("ambiguity_budget must be in (0,1]")
+    if evidence_budget_min < 1:
+        raise CDEDecisionFlowError("evidence_budget_min must be >= 1")
+
+    reason_codes: list[str] = []
+    change_conditions: list[str] = []
+
+    evidence_count = len(evidence_pack.get("evidence_refs", []))
+    material_conflict = bool(conflict_record.get("material_conflict")) and conflict_record.get("resolved") is not True
+    ambiguity_exceeded = ambiguity_rate > ambiguity_budget
+
+    if material_conflict:
+        outcome = "human_review_required"
+        reason_codes.append("material_conflict_unresolved")
+    elif evidence_count < evidence_budget_min:
+        outcome = "block"
+        reason_codes.append("evidence_budget_insufficient")
+    elif ambiguity_exceeded:
+        outcome = "human_review_required"
+        reason_codes.append("ambiguity_budget_exceeded")
+    else:
+        outcome = "continue_repair_bounded"
+        reason_codes.append("bounded_continue_permitted")
+
+    change_conditions.extend(
+        [
+            "material_conflict_unresolved",
+            "evidence_budget_insufficient",
+            "ambiguity_budget_exceeded",
+            "policy_constraints_changed",
+        ]
+    )
+
+    decision = {
+        "artifact_type": "continuation_decision_record",
+        "schema_version": "1.0.0",
+        "decision_id": f"cde-dec-{_digest([evidence_pack['evidence_pack_id'], outcome, reason_codes])[:16]}",
+        "trace_id": evidence_pack["trace_id"],
+        "evidence_pack_ref": f"decision_evidence_pack:{evidence_pack['evidence_pack_id']}",
+        "decision_outcome": outcome,
+        "reason_codes": sorted(set(reason_codes)),
+        "evidence_refs": sorted(evidence_pack["evidence_refs"]),
+        "change_conditions": sorted(set(change_conditions)),
+        "non_authority_assertions": [
+            "decision_artifact_only",
+            "cde_must_not_execute",
+            "cde_must_not_enforce",
+            "cde_must_not_mutate_downstream_state",
+        ],
+    }
+    validate_artifact(decision, "continuation_decision_record")
+    return decision
+
+
+def evaluate_decision(*, decision_record: Mapping[str, Any], conflict_record: Mapping[str, Any], evidence_pack: Mapping[str, Any]) -> dict[str, Any]:
+    validate_artifact(dict(decision_record), "continuation_decision_record")
+    validate_artifact(dict(conflict_record), "decision_conflict_record")
+    validate_artifact(dict(evidence_pack), "decision_evidence_pack")
+
+    fail_reasons: list[str] = []
+    if len(decision_record.get("evidence_refs", [])) < 1:
+        fail_reasons.append("evidence_missing")
+    if len(decision_record.get("reason_codes", [])) < 1:
+        fail_reasons.append("reason_codes_missing")
+    if conflict_record.get("material_conflict") and conflict_record.get("resolved") is not True and decision_record.get("decision_outcome") == "continue_repair_bounded":
+        fail_reasons.append("contradiction_handling_incorrect")
+    if not str(evidence_pack.get("policy_constraints_ref", "")).startswith("policy:"):
+        fail_reasons.append("policy_alignment_missing")
+
+    result = {
+        "artifact_type": "decision_eval_result",
+        "schema_version": "1.0.0",
+        "eval_id": f"cde-eval-{_digest([decision_record['decision_id'], fail_reasons])[:16]}",
+        "trace_id": decision_record["trace_id"],
+        "continuation_decision_record_ref": f"continuation_decision_record:{decision_record['decision_id']}",
+        "evidence_sufficiency_passed": "evidence_missing" not in fail_reasons,
+        "policy_alignment_passed": "policy_alignment_missing" not in fail_reasons,
+        "contradiction_handling_passed": "contradiction_handling_incorrect" not in fail_reasons,
+        "decision_completeness_passed": "reason_codes_missing" not in fail_reasons,
+        "required_field_coverage_passed": len(fail_reasons) == 0,
+        "result": "pass" if not fail_reasons else "fail",
+        "fail_reasons": sorted(set(fail_reasons)),
+    }
+    validate_artifact(result, "decision_eval_result")
+    return result
+
+
+def build_decision_readiness(*, decision_record: Mapping[str, Any], eval_result: Mapping[str, Any]) -> dict[str, Any]:
+    validate_artifact(dict(decision_record), "continuation_decision_record")
+    validate_artifact(dict(eval_result), "decision_eval_result")
+
+    reasons: list[str] = []
+    if eval_result.get("result") != "pass":
+        reasons.append("decision_eval_not_pass")
+    if decision_record.get("decision_outcome") == "human_review_required":
+        reasons.append("human_review_required")
+
+    readiness = {
+        "artifact_type": "decision_readiness_record",
+        "schema_version": "1.0.0",
+        "readiness_id": f"cde-ready-{_digest([decision_record['decision_id'], eval_result['eval_id'], reasons])[:16]}",
+        "trace_id": decision_record["trace_id"],
+        "continuation_decision_record_ref": f"continuation_decision_record:{decision_record['decision_id']}",
+        "decision_eval_result_ref": f"decision_eval_result:{eval_result['eval_id']}",
+        "candidate_ready": len(reasons) == 0,
+        "blocking_reasons": sorted(set(reasons)),
+        "non_authority_assertions": [
+            "candidate_only",
+            "cannot_trigger_execution",
+            "cannot_trigger_enforcement",
+        ],
+    }
+    validate_artifact(readiness, "decision_readiness_record")
+    return readiness
+
+
+def build_decision_bundle(
+    *,
+    evidence_pack: Mapping[str, Any],
+    decision_record: Mapping[str, Any],
+    eval_result: Mapping[str, Any],
+    readiness_record: Mapping[str, Any],
+    conflict_record: Mapping[str, Any],
+) -> dict[str, Any]:
+    validate_artifact(dict(evidence_pack), "decision_evidence_pack")
+    validate_artifact(dict(decision_record), "continuation_decision_record")
+    validate_artifact(dict(eval_result), "decision_eval_result")
+    validate_artifact(dict(readiness_record), "decision_readiness_record")
+    validate_artifact(dict(conflict_record), "decision_conflict_record")
+
+    bundle = {
+        "artifact_type": "decision_bundle",
+        "schema_version": "1.0.0",
+        "bundle_id": f"cde-bundle-{_digest([evidence_pack['evidence_pack_id'], decision_record['decision_id'], eval_result['eval_id']])[:16]}",
+        "trace_id": decision_record["trace_id"],
+        "decision_evidence_pack_ref": f"decision_evidence_pack:{evidence_pack['evidence_pack_id']}",
+        "continuation_decision_record_ref": f"continuation_decision_record:{decision_record['decision_id']}",
+        "decision_eval_result_ref": f"decision_eval_result:{eval_result['eval_id']}",
+        "decision_readiness_record_ref": f"decision_readiness_record:{readiness_record['readiness_id']}",
+        "decision_conflict_record_ref": f"decision_conflict_record:{conflict_record['conflict_id']}",
+        "lineage_complete": True,
+        "non_authority_assertions": [
+            "bundle_is_decision_only",
+            "bundle_not_execution_authority",
+            "bundle_not_enforcement_authority",
+        ],
+    }
+    validate_artifact(bundle, "decision_bundle")
+    return bundle
+
+
+def validate_decision_replay(*, evidence_pack: Mapping[str, Any], first_decision: Mapping[str, Any], replay_decision: Mapping[str, Any]) -> dict[str, Any]:
+    validate_artifact(dict(evidence_pack), "decision_evidence_pack")
+    validate_artifact(dict(first_decision), "continuation_decision_record")
+    validate_artifact(dict(replay_decision), "continuation_decision_record")
+
+    input_fp = evidence_pack["input_fingerprint"]
+    first_fp = _digest(first_decision)
+    replay_fp = _digest(replay_decision)
+    deterministic_match = first_fp == replay_fp
+
+    record = {
+        "artifact_type": "decision_replay_validation_record",
+        "schema_version": "1.0.0",
+        "validation_id": f"cde-replay-{_digest([input_fp, first_fp, replay_fp])[:16]}",
+        "input_fingerprint": input_fp,
+        "first_decision_fingerprint": first_fp,
+        "replay_decision_fingerprint": replay_fp,
+        "deterministic_match": deterministic_match,
+        "result": "pass" if deterministic_match else "fail",
+        "fail_reasons": [] if deterministic_match else ["decision_replay_mismatch"],
+    }
+    validate_artifact(record, "decision_replay_validation_record")
+    return record
+
+
+def build_decision_effectiveness_record(*, decision_record: Mapping[str, Any], downstream_outcome_ref: str, downstream_outcome: str) -> dict[str, Any]:
+    validate_artifact(dict(decision_record), "continuation_decision_record")
+    outcome = _required_str(downstream_outcome, field="downstream_outcome")
+
+    mapping = {
+        ("continue_repair_bounded", "improved"): ("effective", 0.9, 0.6),
+        ("continue_repair_bounded", "regressed"): ("too_permissive", 0.2, 0.1),
+        ("block", "improved"): ("too_strict", 0.4, 0.95),
+        ("human_review_required", "unchanged"): ("noisy", 0.5, 0.8),
+    }
+    state, precision, strictness = mapping.get((decision_record["decision_outcome"], outcome), ("effective", 0.7, 0.7))
+
+    record = {
+        "artifact_type": "decision_effectiveness_record",
+        "schema_version": "1.0.0",
+        "record_id": f"cde-eff-{_digest([decision_record['decision_id'], downstream_outcome_ref, outcome])[:16]}",
+        "trace_id": decision_record["trace_id"],
+        "continuation_decision_record_ref": f"continuation_decision_record:{decision_record['decision_id']}",
+        "downstream_outcome_ref": _required_str(downstream_outcome_ref, field="downstream_outcome_ref"),
+        "effectiveness_state": state,
+        "precision_proxy": precision,
+        "strictness_proxy": strictness,
+    }
+    validate_artifact(record, "decision_effectiveness_record")
+    return record
+
+
+def verify_cde_boundary_inputs(*, upstream_artifacts: Sequence[Mapping[str, Any]]) -> None:
+    if not upstream_artifacts:
+        raise CDEDecisionFlowError("upstream_artifacts must not be empty")
+    for artifact in upstream_artifacts:
+        artifact_type = _required_str(artifact.get("artifact_type"), field="artifact_type")
+        if artifact_type not in _ALLOWED_UPSTREAM_TYPES:
+            raise CDEDecisionFlowError("CDE upstream boundary rejected non-governed artifact")
+        if any(field in artifact for field in _FORBIDDEN_EXECUTION_FIELDS):
+            raise CDEDecisionFlowError("CDE fail-closed: execution/enforcement fields are forbidden")

--- a/spectrum_systems/modules/runtime/ril_interpretation.py
+++ b/spectrum_systems/modules/runtime/ril_interpretation.py
@@ -476,3 +476,62 @@ def build_interpretation_bundle(
     }
     validate_artifact(artifact, "interpretation_bundle")
     return artifact
+
+
+def verify_ril_closeout(
+    *,
+    failure_packet: Mapping[str, Any],
+    interpretation_record: Mapping[str, Any],
+    eval_result: Mapping[str, Any],
+    readiness_record: Mapping[str, Any],
+    replay_validation_record: Mapping[str, Any],
+    conflict_record: Mapping[str, Any],
+    alignment_record: Mapping[str, Any],
+    ambiguity_signal: Mapping[str, Any],
+) -> dict[str, Any]:
+    """RIL-09 closeout verification proving RIL seams are operational for CDE downstream use."""
+
+    validate_artifact(dict(failure_packet), "failure_packet")
+    validate_artifact(dict(interpretation_record), "interpretation_record")
+    validate_artifact(dict(eval_result), "interpretation_eval_result")
+    validate_artifact(dict(readiness_record), "interpretation_readiness_record")
+    validate_artifact(dict(replay_validation_record), "interpretation_replay_validation_record")
+    validate_artifact(dict(conflict_record), "interpretation_conflict_record")
+    validate_artifact(dict(alignment_record), "interpretation_repair_alignment_record")
+    validate_artifact(dict(ambiguity_signal), "interpretation_ambiguity_signal")
+
+    blocking_reasons: list[str] = []
+    if eval_result.get("result") != "pass":
+        blocking_reasons.append("interpretation_eval_not_pass")
+    if replay_validation_record.get("result") != "pass":
+        blocking_reasons.append("replay_validation_failed")
+    if conflict_record.get("material_conflict") and conflict_record.get("resolved") is not True:
+        blocking_reasons.append("material_conflict_unresolved")
+    if alignment_record.get("alignment_passed") is not True:
+        blocking_reasons.append("interpretation_repair_alignment_failed")
+    if not isinstance(ambiguity_signal.get("threshold_exceeded"), bool):
+        blocking_reasons.append("ambiguity_signal_incomplete")
+
+    artifact = {
+        "artifact_type": "ril_closeout_gate_record",
+        "schema_version": "1.0.0",
+        "gate_id": f"ril-close-{_digest([failure_packet['failure_packet_id'], interpretation_record['interpretation_id'], blocking_reasons])[:16]}",
+        "failure_packet_ref": f"failure_packet:{failure_packet['failure_packet_id']}",
+        "interpretation_record_ref": f"interpretation_record:{interpretation_record['interpretation_id']}",
+        "interpretation_eval_result_ref": f"interpretation_eval_result:{eval_result['eval_id']}",
+        "interpretation_readiness_record_ref": f"interpretation_readiness_record:{readiness_record['readiness_id']}",
+        "interpretation_replay_validation_record_ref": f"interpretation_replay_validation_record:{replay_validation_record['validation_id']}",
+        "interpretation_conflict_record_ref": f"interpretation_conflict_record:{conflict_record['conflict_id']}",
+        "interpretation_repair_alignment_record_ref": f"interpretation_repair_alignment_record:{alignment_record['alignment_id']}",
+        "interpretation_ambiguity_signal_ref": f"interpretation_ambiguity_signal:{ambiguity_signal['signal_id']}",
+        "ril_operational": len(blocking_reasons) == 0,
+        "closeout_status": "closed" if not blocking_reasons else "blocked",
+        "blocking_reasons": sorted(set(blocking_reasons)),
+        "non_authority_assertions": [
+            "ril_interpretation_only",
+            "ril_not_decision_authority",
+            "ril_not_execution_authority",
+        ],
+    }
+    validate_artifact(artifact, "ril_closeout_gate_record")
+    return artifact

--- a/tests/test_cde_decision_flow.py
+++ b/tests/test_cde_decision_flow.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from spectrum_systems.contracts import validate_artifact
+from spectrum_systems.modules.runtime.cde_decision_flow import (
+    CDEDecisionFlowError,
+    build_decision_bundle,
+    build_decision_effectiveness_record,
+    build_decision_evidence_pack,
+    build_decision_readiness,
+    detect_decision_conflicts,
+    evaluate_decision,
+    make_continuation_decision,
+    validate_decision_replay,
+    verify_cde_boundary_inputs,
+)
+from spectrum_systems.modules.runtime.fre_repair_flow import (
+    build_repair_bundle,
+    build_repair_effectiveness_record,
+    build_repair_readiness_candidate,
+    build_repair_recurrence_record,
+    evaluate_repair_candidate,
+    generate_repair_candidate,
+)
+from spectrum_systems.modules.runtime.ril_interpretation import (
+    build_ambiguity_signal,
+    build_interpretation_bundle,
+    build_interpretation_record,
+    build_readiness_record,
+    detect_contradictions,
+    evaluate_interpretation,
+    normalize_failure_packet,
+    validate_interpretation_repair_alignment,
+    validate_replay,
+    verify_ril_closeout,
+)
+
+
+def _evidence() -> dict:
+    return {
+        "artifact_type": "execution_failure_packet",
+        "source_artifact_ref": "execution_failure_packet:efp-100",
+        "failure_class": "slice_contract_mismatch",
+        "owner_surface": "RIL",
+        "source_evidence_refs": ["trace:trace-cde-001"],
+        "lineage_refs": ["lineage:ril-001"],
+        "ambiguity_refs": [],
+        "contradiction_refs": [],
+    }
+
+
+def _fre_packet() -> dict:
+    return {
+        "artifact_type": "execution_failure_packet",
+        "failure_packet_id": "efp-100",
+        "classified_failure_type": "slice_contract_mismatch",
+        "affected_artifact_refs": ["contracts/examples/review_control_signal_artifact.json"],
+        "trace_refs": ["trace:trace-cde-001"],
+        "validation_refs": ["pytest:tests/test_cde_decision_flow.py::test_cde_flow_end_to_end"],
+    }
+
+
+def _build_ril_fre_artifacts() -> tuple[dict, dict, dict]:
+    failure_packet = normalize_failure_packet(evidence=_evidence(), trace_id="trace-cde-001")
+    conflict = detect_contradictions(failure_packet=failure_packet, evidence_refs=["trace:cde-ok"], material_threshold=2)
+    interpretation = build_interpretation_record(
+        failure_packet=failure_packet,
+        conflict_record=conflict,
+        interpretation_notes=["normalized failure packet for bounded decisioning"],
+    )
+    eval_result = evaluate_interpretation(interpretation_record=interpretation, conflict_record=conflict)
+    readiness = build_readiness_record(interpretation_record=interpretation, eval_result=eval_result)
+    interpretation_bundle = build_interpretation_bundle(
+        failure_packet=failure_packet,
+        interpretation_record=interpretation,
+        eval_result=eval_result,
+        readiness_record=readiness,
+        conflict_record=conflict,
+    )
+    replay = validate_replay(source_inputs=[_evidence()], first_outputs=[failure_packet], replay_outputs=[dict(failure_packet)], schema_version="1.0.0")
+
+    repair_candidate = generate_repair_candidate(failure_packet=_fre_packet(), trace_id="trace-cde-001")
+    repair_eval = evaluate_repair_candidate(repair_candidate=repair_candidate)
+    repair_eff = build_repair_effectiveness_record(repair_candidate=repair_candidate, repair_eval_result=repair_eval)
+    repair_rec = build_repair_recurrence_record(repair_candidate=repair_candidate, recurrence_count=1, cluster_key="slice_contract_mismatch::cde")
+    repair_ready = build_repair_readiness_candidate(repair_candidate=repair_candidate, repair_eval_result=repair_eval)
+    repair_bundle = build_repair_bundle(
+        repair_candidate=repair_candidate,
+        repair_eval_result=repair_eval,
+        repair_effectiveness_record=repair_eff,
+        repair_recurrence_record=repair_rec,
+        repair_readiness_candidate=repair_ready,
+    )
+    alignment = validate_interpretation_repair_alignment(interpretation_record=interpretation, repair_candidate=repair_candidate)
+    ambiguity = build_ambiguity_signal(interpretation_records=[interpretation], ambiguity_budget=0.4)
+
+    closeout = verify_ril_closeout(
+        failure_packet=failure_packet,
+        interpretation_record=interpretation,
+        eval_result=eval_result,
+        readiness_record=readiness,
+        replay_validation_record=replay,
+        conflict_record=conflict,
+        alignment_record=alignment,
+        ambiguity_signal=ambiguity,
+    )
+    validate_artifact(closeout, "ril_closeout_gate_record")
+    assert closeout["ril_operational"] is True
+
+    return interpretation_bundle, repair_bundle, conflict
+
+
+def test_cde_flow_end_to_end() -> None:
+    interpretation_bundle, repair_bundle, _ = _build_ril_fre_artifacts()
+
+    evidence_pack = build_decision_evidence_pack(
+        trace_id="trace-cde-001",
+        interpretation_bundle=interpretation_bundle,
+        repair_bundle=repair_bundle,
+        policy_constraints_ref="policy:cde_bounded_decision_v1",
+        provenance_refs=["provenance_record:prv-001"],
+        replay_refs=["interpretation_replay_validation_record:ril-replay-001"],
+        evidence_refs=["failure_packet:ril-fp-001", "repair_eval_result:fre-reval-001", "policy:cde_bounded_decision_v1"],
+    )
+    conflict_record = detect_decision_conflicts(evidence_pack=evidence_pack, conflict_refs=["interpretation_conflict_record:ril-conf-pass"], material_threshold=2)
+    decision = make_continuation_decision(evidence_pack=evidence_pack, conflict_record=conflict_record, evidence_budget_min=2, ambiguity_rate=0.1)
+    eval_result = evaluate_decision(decision_record=decision, conflict_record=conflict_record, evidence_pack=evidence_pack)
+    readiness = build_decision_readiness(decision_record=decision, eval_result=eval_result)
+    bundle = build_decision_bundle(
+        evidence_pack=evidence_pack,
+        decision_record=decision,
+        eval_result=eval_result,
+        readiness_record=readiness,
+        conflict_record=conflict_record,
+    )
+    replay = validate_decision_replay(evidence_pack=evidence_pack, first_decision=decision, replay_decision=dict(decision))
+    effectiveness = build_decision_effectiveness_record(
+        decision_record=decision,
+        downstream_outcome_ref="downstream_outcome:tlc-001",
+        downstream_outcome="improved",
+    )
+
+    for artifact_type, artifact in (
+        ("decision_evidence_pack", evidence_pack),
+        ("decision_conflict_record", conflict_record),
+        ("continuation_decision_record", decision),
+        ("decision_eval_result", eval_result),
+        ("decision_readiness_record", readiness),
+        ("decision_bundle", bundle),
+        ("decision_replay_validation_record", replay),
+        ("decision_effectiveness_record", effectiveness),
+    ):
+        validate_artifact(artifact, artifact_type)
+
+    assert decision["decision_outcome"] == "continue_repair_bounded"
+    assert readiness["candidate_ready"] is True
+    assert replay["result"] == "pass"
+
+
+def test_cde_boundary_and_fail_closed_behaviors() -> None:
+    interpretation_bundle, repair_bundle, _ = _build_ril_fre_artifacts()
+    verify_cde_boundary_inputs(
+        upstream_artifacts=[
+            interpretation_bundle,
+            repair_bundle,
+            {"artifact_type": "interpretation_conflict_record", "schema_version": "1.0.0"},
+        ]
+    )
+
+    try:
+        verify_cde_boundary_inputs(upstream_artifacts=[{"artifact_type": "repair_candidate"}])
+        raise AssertionError("expected CDEDecisionFlowError")
+    except CDEDecisionFlowError as exc:
+        assert "boundary" in str(exc)
+
+    evidence_pack = build_decision_evidence_pack(
+        trace_id="trace-cde-002",
+        interpretation_bundle=interpretation_bundle,
+        repair_bundle=repair_bundle,
+        policy_constraints_ref="policy:cde_bounded_decision_v1",
+        provenance_refs=["provenance_record:prv-002"],
+        replay_refs=["interpretation_replay_validation_record:ril-replay-002"],
+        evidence_refs=["failure_packet:ril-fp-002"],
+    )
+    conflict_record = detect_decision_conflicts(
+        evidence_pack=evidence_pack,
+        conflict_refs=["interpretation_conflict_record:ril-conf-a", "policy_conflict_record:pol-1"],
+        material_threshold=1,
+    )
+    decision = make_continuation_decision(evidence_pack=evidence_pack, conflict_record=conflict_record, evidence_budget_min=2, ambiguity_rate=0.5)
+    eval_result = evaluate_decision(decision_record=decision, conflict_record=conflict_record, evidence_pack=evidence_pack)
+    readiness = build_decision_readiness(decision_record=decision, eval_result=eval_result)
+
+    assert decision["decision_outcome"] == "human_review_required"
+    assert readiness["candidate_ready"] is False
+
+    replay_drift = validate_decision_replay(
+        evidence_pack=evidence_pack,
+        first_decision=decision,
+        replay_decision={**decision, "decision_outcome": "block"},
+    )
+    assert replay_drift["result"] == "fail"
+    assert "decision_replay_mismatch" in replay_drift["fail_reasons"]

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -201,6 +201,21 @@ class ContractSchemaTests(unittest.TestCase):
         instance = load_example("system_roadmap")
         validate_artifact(instance, "system_roadmap")
 
+    def test_ril_and_cde_foundation_examples_validate(self) -> None:
+        for name in (
+            "ril_closeout_gate_record",
+            "decision_evidence_pack",
+            "decision_conflict_record",
+            "continuation_decision_record",
+            "decision_eval_result",
+            "decision_readiness_record",
+            "decision_bundle",
+            "decision_replay_validation_record",
+            "decision_effectiveness_record",
+        ):
+            instance = load_example(name)
+            validate_artifact(instance, name)
+
 
     def test_system_roadmap_batches_have_required_governed_fields(self) -> None:
         instance = load_example("system_roadmap")

--- a/tests/test_ril_interpretation.py
+++ b/tests/test_ril_interpretation.py
@@ -23,6 +23,7 @@ from spectrum_systems.modules.runtime.ril_interpretation import (
     validate_control_signal_integrity,
     validate_interpretation_repair_alignment,
     validate_replay,
+    verify_ril_closeout,
     validate_required_coverage,
 )
 
@@ -199,3 +200,33 @@ def test_alignment_surface_uses_real_fre_outputs() -> None:
         repair_readiness_candidate=readiness,
     )
     assert bundle["artifact_type"] == "repair_bundle"
+
+
+def test_ril_closeout_gate_is_operationally_real() -> None:
+    packet = normalize_failure_packet(evidence=_evidence(), trace_id="trace-ril-001")
+    conflict = detect_contradictions(failure_packet=packet, evidence_refs=["trace:conflict-a"], material_threshold=2)
+    interpretation = build_interpretation_record(
+        failure_packet=packet,
+        conflict_record=conflict,
+        interpretation_notes=["bounded normalization complete"],
+    )
+    evaluation = evaluate_interpretation(interpretation_record=interpretation, conflict_record=conflict)
+    readiness = build_readiness_record(interpretation_record=interpretation, eval_result=evaluation)
+    replay = validate_replay(source_inputs=[_evidence()], first_outputs=[packet], replay_outputs=[dict(packet)], schema_version="1.0.0")
+
+    candidate = generate_repair_candidate(failure_packet=_fre_packet(), trace_id="trace-ril-001")
+    alignment = validate_interpretation_repair_alignment(interpretation_record=interpretation, repair_candidate=candidate)
+    ambiguity = build_ambiguity_signal(interpretation_records=[interpretation], ambiguity_budget=0.5)
+
+    closeout = verify_ril_closeout(
+        failure_packet=packet,
+        interpretation_record=interpretation,
+        eval_result=evaluation,
+        readiness_record=readiness,
+        replay_validation_record=replay,
+        conflict_record=conflict,
+        alignment_record=alignment,
+        ambiguity_signal=ambiguity,
+    )
+    validate_artifact(closeout, "ril_closeout_gate_record")
+    assert closeout["ril_operational"] is True


### PR DESCRIPTION
### Motivation
- Ensure RIL is operationally closed-out so CDE can safely consume its outputs and rely on replay/provenance signals.  
- Provide a governed, artifact-first CDE boundary with strict contracts, deterministic decision semantics, and fail-closed behavior.  
- Add measurable decision-effectiveness tracking and ambiguity/evidence budget controls so decisions are reproducible and auditable.

### Description
- Added strict JSON Schema contracts and golden examples for CDE artifacts and RIL closeout (`continuation_decision_record`, `decision_eval_result`, `decision_readiness_record`, `decision_conflict_record`, `decision_bundle`, `decision_evidence_pack`, `decision_replay_validation_record`, `decision_effectiveness_record`, and `ril_closeout_gate_record`) and registered them in `contracts/standards-manifest.json`.  
- Implemented deterministic CDE runtime logic in `spectrum_systems/modules/runtime/cde_decision_flow.py` covering evidence-pack construction, conflict arbitration, deterministic continuation decisions (bounded outcomes: `continue_repair_bounded`, `block`, `human_review_required`), decision eval harness, readiness artifacts, replay validation, ambiguity/evidence budget checks, and effectiveness records.  
- Completed RIL closeout verification in `spectrum_systems/modules/runtime/ril_interpretation.py` via `verify_ril_closeout(...)` to validate replay, contradiction handling, ambiguity signals, and interpretation→repair alignment before CDE dependence.  
- Added end-to-end tests (`tests/test_cde_decision_flow.py`), extended RIL tests (`tests/test_ril_interpretation.py`), and updated contract validation coverage (`tests/test_contracts.py`) so the new schemas/examples and runtime paths are exercised.

### Testing
- Ran unit/integration tests: `pytest tests/test_ril_interpretation.py tests/test_fre_repair_flow.py tests/test_cde_decision_flow.py` — all tests passed (19 passed).  
- Ran full contract/test suite: `pytest tests/test_contracts.py tests/test_contract_enforcement.py tests/test_module_architecture.py` — all tests passed (167 passed).  
- Executed contract enforcement: `python scripts/run_contract_enforcement.py` — produced enforcement report with zero failures/warnings.  
- Ran contract boundary audit: `.codex/skills/contract-boundary-audit/run.sh` — completed in PASS-WARN mode (no blocking errors; non-blocking warnings reported across unrelated repo-wide schemas).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbdc4b83d08329a70a0158b25d9b14)