### PR TITLE
SEL-001: Add SEL bounded enforcement foundation and CDE closeout gate

### DIFF
--- a/contracts/examples/cde_closeout_gate_record.json
+++ b/contracts/examples/cde_closeout_gate_record.json
@@ -1,0 +1,17 @@
+{
+  "artifact_type": "cde_closeout_gate_record",
+  "schema_version": "1.0.0",
+  "gate_id": "cde-close-0123456789abcdef",
+  "decision_bundle_ref": "decision_bundle:cde-bundle-0123456789abcdef",
+  "decision_eval_result_ref": "decision_eval_result:cde-eval-0123456789abcdef",
+  "decision_replay_validation_record_ref": "decision_replay_validation_record:cde-replay-0123456789abcdef",
+  "decision_effectiveness_record_ref": "decision_effectiveness_record:cde-eff-0123456789abcdef",
+  "cde_operational": true,
+  "closeout_status": "closed",
+  "blocking_reasons": [],
+  "non_authority_assertions": [
+    "cde_emits_decision_artifacts_only",
+    "cde_is_not_execution_authority",
+    "cde_is_not_enforcement_authority"
+  ]
+}

--- a/contracts/examples/enforcement_action_record.json
+++ b/contracts/examples/enforcement_action_record.json
@@ -1,0 +1,20 @@
+{
+  "artifact_type": "enforcement_action_record",
+  "schema_version": "1.0.0",
+  "action_id": "sel-act-0123456789abcdef",
+  "trace_id": "trace-sel-001",
+  "continuation_decision_record_ref": "continuation_decision_record:cde-dec-0123456789abcdef",
+  "decision_bundle_ref": "decision_bundle:cde-bundle-0123456789abcdef",
+  "action": "continue_repair_path",
+  "action_reason_codes": [
+    "bounded_continue_permitted"
+  ],
+  "evidence_refs": [
+    "decision_evidence_pack:cde-ep-0123456789abcdef"
+  ],
+  "non_authority_assertions": [
+    "sel_enforcement_only",
+    "sel_must_not_reinterpret_cde",
+    "sel_must_not_issue_new_decisions"
+  ]
+}

--- a/contracts/examples/enforcement_bundle.json
+++ b/contracts/examples/enforcement_bundle.json
@@ -1,0 +1,12 @@
+{
+  "artifact_type": "enforcement_bundle",
+  "schema_version": "1.0.0",
+  "bundle_id": "sel-bundle-0123456789abcdef",
+  "trace_id": "trace-sel-001",
+  "enforcement_action_record_ref": "enforcement_action_record:sel-act-0123456789abcdef",
+  "enforcement_result_record_ref": "enforcement_result_record:sel-res-0123456789abcdef",
+  "enforcement_eval_result_ref": "enforcement_eval_result:sel-eval-0123456789abcdef",
+  "enforcement_readiness_record_ref": "enforcement_readiness_record:sel-ready-0123456789abcdef",
+  "enforcement_conflict_record_ref": "enforcement_conflict_record:sel-conf-0123456789abcdef",
+  "lineage_complete": true
+}

--- a/contracts/examples/enforcement_conflict_record.json
+++ b/contracts/examples/enforcement_conflict_record.json
@@ -1,0 +1,11 @@
+{
+  "artifact_type": "enforcement_conflict_record",
+  "schema_version": "1.0.0",
+  "conflict_id": "sel-conf-0123456789abcdef",
+  "trace_id": "trace-sel-001",
+  "continuation_decision_record_ref": "continuation_decision_record:cde-dec-0123456789abcdef",
+  "enforcement_action_record_ref": "enforcement_action_record:sel-act-0123456789abcdef",
+  "conflict_refs": [],
+  "integrity_passed": true,
+  "result": "pass"
+}

--- a/contracts/examples/enforcement_effectiveness_record.json
+++ b/contracts/examples/enforcement_effectiveness_record.json
@@ -1,0 +1,12 @@
+{
+  "artifact_type": "enforcement_effectiveness_record",
+  "schema_version": "1.0.0",
+  "record_id": "sel-eff-0123456789abcdef",
+  "trace_id": "trace-sel-001",
+  "continuation_decision_record_ref": "continuation_decision_record:cde-dec-0123456789abcdef",
+  "enforcement_action_record_ref": "enforcement_action_record:sel-act-0123456789abcdef",
+  "enforcement_result_record_ref": "enforcement_result_record:sel-res-0123456789abcdef",
+  "observed_outcome_ref": "outcome:sel-001",
+  "effectiveness_state": "effective",
+  "success": true
+}

--- a/contracts/examples/enforcement_eval_result.json
+++ b/contracts/examples/enforcement_eval_result.json
@@ -1,0 +1,14 @@
+{
+  "artifact_type": "enforcement_eval_result",
+  "schema_version": "1.0.0",
+  "eval_id": "sel-eval-0123456789abcdef",
+  "trace_id": "trace-sel-001",
+  "enforcement_action_record_ref": "enforcement_action_record:sel-act-0123456789abcdef",
+  "scope_compliance_passed": true,
+  "decision_alignment_passed": true,
+  "policy_compliance_passed": true,
+  "evidence_completeness_passed": true,
+  "non_decision_assertion_passed": true,
+  "result": "pass",
+  "fail_reasons": []
+}

--- a/contracts/examples/enforcement_readiness_record.json
+++ b/contracts/examples/enforcement_readiness_record.json
@@ -1,0 +1,15 @@
+{
+  "artifact_type": "enforcement_readiness_record",
+  "schema_version": "1.0.0",
+  "readiness_id": "sel-ready-0123456789abcdef",
+  "trace_id": "trace-sel-001",
+  "enforcement_action_record_ref": "enforcement_action_record:sel-act-0123456789abcdef",
+  "enforcement_eval_result_ref": "enforcement_eval_result:sel-eval-0123456789abcdef",
+  "candidate_ready": true,
+  "blocking_reasons": [],
+  "non_authority_assertions": [
+    "candidate_only",
+    "cannot_create_new_decision_authority",
+    "promotion_requires_separate_gate"
+  ]
+}

--- a/contracts/examples/enforcement_result_record.json
+++ b/contracts/examples/enforcement_result_record.json
@@ -1,0 +1,12 @@
+{
+  "artifact_type": "enforcement_result_record",
+  "schema_version": "1.0.0",
+  "result_id": "sel-res-0123456789abcdef",
+  "trace_id": "trace-sel-001",
+  "enforcement_action_record_ref": "enforcement_action_record:sel-act-0123456789abcdef",
+  "enforcement_eval_result_ref": "enforcement_eval_result:sel-eval-0123456789abcdef",
+  "enforcement_readiness_record_ref": "enforcement_readiness_record:sel-ready-0123456789abcdef",
+  "enforcement_conflict_record_ref": "enforcement_conflict_record:sel-conf-0123456789abcdef",
+  "enforcement_status": "enforced",
+  "reason_codes": []
+}

--- a/contracts/schemas/cde_closeout_gate_record.schema.json
+++ b/contracts/schemas/cde_closeout_gate_record.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/cde_closeout_gate_record.schema.json",
+  "title": "CDE Closeout Gate Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "gate_id",
+    "decision_bundle_ref",
+    "decision_eval_result_ref",
+    "decision_replay_validation_record_ref",
+    "decision_effectiveness_record_ref",
+    "cde_operational",
+    "closeout_status",
+    "blocking_reasons",
+    "non_authority_assertions"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "cde_closeout_gate_record"
+    },
+    "schema_version": {
+      "const": "1.0.0"
+    },
+    "gate_id": {
+      "type": "string",
+      "pattern": "^cde-close-[a-f0-9]{16}$"
+    },
+    "decision_bundle_ref": {
+      "type": "string",
+      "pattern": "^decision_bundle:.+"
+    },
+    "decision_eval_result_ref": {
+      "type": "string",
+      "pattern": "^decision_eval_result:.+"
+    },
+    "decision_replay_validation_record_ref": {
+      "type": "string",
+      "pattern": "^decision_replay_validation_record:.+"
+    },
+    "decision_effectiveness_record_ref": {
+      "type": "string",
+      "pattern": "^decision_effectiveness_record:.+"
+    },
+    "cde_operational": {
+      "type": "boolean"
+    },
+    "closeout_status": {
+      "type": "string",
+      "enum": [
+        "closed",
+        "blocked"
+      ]
+    },
+    "blocking_reasons": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "non_authority_assertions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    }
+  }
+}

--- a/contracts/schemas/enforcement_action_record.schema.json
+++ b/contracts/schemas/enforcement_action_record.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/enforcement_action_record.schema.json",
+  "title": "Enforcement Action Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "action_id",
+    "trace_id",
+    "continuation_decision_record_ref",
+    "decision_bundle_ref",
+    "action",
+    "action_reason_codes",
+    "evidence_refs",
+    "non_authority_assertions"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "enforcement_action_record"
+    },
+    "schema_version": {
+      "const": "1.0.0"
+    },
+    "action_id": {
+      "type": "string",
+      "pattern": "^sel-act-[a-f0-9]{16}$"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "continuation_decision_record_ref": {
+      "type": "string",
+      "pattern": "^continuation_decision_record:.+"
+    },
+    "decision_bundle_ref": {
+      "type": "string",
+      "pattern": "^decision_bundle:.+"
+    },
+    "action": {
+      "type": "string",
+      "enum": [
+        "continue_repair_path",
+        "quarantine",
+        "require_human_review",
+        "halt",
+        "none"
+      ]
+    },
+    "action_reason_codes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "evidence_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "non_authority_assertions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    }
+  }
+}

--- a/contracts/schemas/enforcement_bundle.schema.json
+++ b/contracts/schemas/enforcement_bundle.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/enforcement_bundle.schema.json",
+  "title": "Enforcement Bundle",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "bundle_id",
+    "trace_id",
+    "enforcement_action_record_ref",
+    "enforcement_result_record_ref",
+    "enforcement_eval_result_ref",
+    "enforcement_readiness_record_ref",
+    "enforcement_conflict_record_ref",
+    "lineage_complete"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "enforcement_bundle"
+    },
+    "schema_version": {
+      "const": "1.0.0"
+    },
+    "bundle_id": {
+      "type": "string",
+      "pattern": "^sel-bundle-[a-f0-9]{16}$"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "enforcement_action_record_ref": {
+      "type": "string",
+      "pattern": "^enforcement_action_record:.+"
+    },
+    "enforcement_result_record_ref": {
+      "type": "string",
+      "pattern": "^enforcement_result_record:.+"
+    },
+    "enforcement_eval_result_ref": {
+      "type": "string",
+      "pattern": "^enforcement_eval_result:.+"
+    },
+    "enforcement_readiness_record_ref": {
+      "type": "string",
+      "pattern": "^enforcement_readiness_record:.+"
+    },
+    "enforcement_conflict_record_ref": {
+      "type": "string",
+      "pattern": "^enforcement_conflict_record:.+"
+    },
+    "lineage_complete": {
+      "type": "boolean"
+    }
+  }
+}

--- a/contracts/schemas/enforcement_conflict_record.schema.json
+++ b/contracts/schemas/enforcement_conflict_record.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/enforcement_conflict_record.schema.json",
+  "title": "Enforcement Conflict Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "conflict_id",
+    "trace_id",
+    "continuation_decision_record_ref",
+    "enforcement_action_record_ref",
+    "conflict_refs",
+    "integrity_passed",
+    "result"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "enforcement_conflict_record"
+    },
+    "schema_version": {
+      "const": "1.0.0"
+    },
+    "conflict_id": {
+      "type": "string",
+      "pattern": "^sel-conf-[a-f0-9]{16}$"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "continuation_decision_record_ref": {
+      "type": "string",
+      "pattern": "^continuation_decision_record:.+"
+    },
+    "enforcement_action_record_ref": {
+      "type": "string",
+      "pattern": "^enforcement_action_record:.+"
+    },
+    "conflict_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "integrity_passed": {
+      "type": "boolean"
+    },
+    "result": {
+      "type": "string",
+      "enum": [
+        "pass",
+        "fail"
+      ]
+    }
+  }
+}

--- a/contracts/schemas/enforcement_effectiveness_record.schema.json
+++ b/contracts/schemas/enforcement_effectiveness_record.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/enforcement_effectiveness_record.schema.json",
+  "title": "Enforcement Effectiveness Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "record_id",
+    "trace_id",
+    "continuation_decision_record_ref",
+    "enforcement_action_record_ref",
+    "enforcement_result_record_ref",
+    "observed_outcome_ref",
+    "effectiveness_state",
+    "success"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "enforcement_effectiveness_record"
+    },
+    "schema_version": {
+      "const": "1.0.0"
+    },
+    "record_id": {
+      "type": "string",
+      "pattern": "^sel-eff-[a-f0-9]{16}$"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "continuation_decision_record_ref": {
+      "type": "string",
+      "pattern": "^continuation_decision_record:.+"
+    },
+    "enforcement_action_record_ref": {
+      "type": "string",
+      "pattern": "^enforcement_action_record:.+"
+    },
+    "enforcement_result_record_ref": {
+      "type": "string",
+      "pattern": "^enforcement_result_record:.+"
+    },
+    "observed_outcome_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "effectiveness_state": {
+      "type": "string",
+      "enum": [
+        "effective",
+        "ineffective",
+        "pending"
+      ]
+    },
+    "success": {
+      "type": "boolean"
+    }
+  }
+}

--- a/contracts/schemas/enforcement_eval_result.schema.json
+++ b/contracts/schemas/enforcement_eval_result.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/enforcement_eval_result.schema.json",
+  "title": "Enforcement Eval Result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "eval_id",
+    "trace_id",
+    "enforcement_action_record_ref",
+    "scope_compliance_passed",
+    "decision_alignment_passed",
+    "policy_compliance_passed",
+    "evidence_completeness_passed",
+    "non_decision_assertion_passed",
+    "result",
+    "fail_reasons"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "enforcement_eval_result"
+    },
+    "schema_version": {
+      "const": "1.0.0"
+    },
+    "eval_id": {
+      "type": "string",
+      "pattern": "^sel-eval-[a-f0-9]{16}$"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "enforcement_action_record_ref": {
+      "type": "string",
+      "pattern": "^enforcement_action_record:.+"
+    },
+    "scope_compliance_passed": {
+      "type": "boolean"
+    },
+    "decision_alignment_passed": {
+      "type": "boolean"
+    },
+    "policy_compliance_passed": {
+      "type": "boolean"
+    },
+    "evidence_completeness_passed": {
+      "type": "boolean"
+    },
+    "non_decision_assertion_passed": {
+      "type": "boolean"
+    },
+    "result": {
+      "type": "string",
+      "enum": [
+        "pass",
+        "fail"
+      ]
+    },
+    "fail_reasons": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    }
+  }
+}

--- a/contracts/schemas/enforcement_readiness_record.schema.json
+++ b/contracts/schemas/enforcement_readiness_record.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/enforcement_readiness_record.schema.json",
+  "title": "Enforcement Readiness Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "readiness_id",
+    "trace_id",
+    "enforcement_action_record_ref",
+    "enforcement_eval_result_ref",
+    "candidate_ready",
+    "blocking_reasons",
+    "non_authority_assertions"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "enforcement_readiness_record"
+    },
+    "schema_version": {
+      "const": "1.0.0"
+    },
+    "readiness_id": {
+      "type": "string",
+      "pattern": "^sel-ready-[a-f0-9]{16}$"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "enforcement_action_record_ref": {
+      "type": "string",
+      "pattern": "^enforcement_action_record:.+"
+    },
+    "enforcement_eval_result_ref": {
+      "type": "string",
+      "pattern": "^enforcement_eval_result:.+"
+    },
+    "candidate_ready": {
+      "type": "boolean"
+    },
+    "blocking_reasons": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "non_authority_assertions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    }
+  }
+}

--- a/contracts/schemas/enforcement_result_record.schema.json
+++ b/contracts/schemas/enforcement_result_record.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/enforcement_result_record.schema.json",
+  "title": "Enforcement Result Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "result_id",
+    "trace_id",
+    "enforcement_action_record_ref",
+    "enforcement_eval_result_ref",
+    "enforcement_readiness_record_ref",
+    "enforcement_conflict_record_ref",
+    "enforcement_status",
+    "reason_codes"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "enforcement_result_record"
+    },
+    "schema_version": {
+      "const": "1.0.0"
+    },
+    "result_id": {
+      "type": "string",
+      "pattern": "^sel-res-[a-f0-9]{16}$"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "enforcement_action_record_ref": {
+      "type": "string",
+      "pattern": "^enforcement_action_record:.+"
+    },
+    "enforcement_eval_result_ref": {
+      "type": "string",
+      "pattern": "^enforcement_eval_result:.+"
+    },
+    "enforcement_readiness_record_ref": {
+      "type": "string",
+      "pattern": "^enforcement_readiness_record:.+"
+    },
+    "enforcement_conflict_record_ref": {
+      "type": "string",
+      "pattern": "^enforcement_conflict_record:.+"
+    },
+    "enforcement_status": {
+      "type": "string",
+      "enum": [
+        "enforced",
+        "blocked"
+      ]
+    },
+    "reason_codes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    }
+  }
+}

--- a/contracts/standards-manifest.json
+++ b/contracts/standards-manifest.json
@@ -1,9 +1,9 @@
 {
   "artifact_type": "standards_manifest",
   "artifact_id": "STD-CONTRACTS",
-  "artifact_version": "1.3.114",
+  "artifact_version": "1.3.115",
   "schema_version": "1.3.98",
-  "standards_version": "1.3.114",
+  "standards_version": "1.3.115",
   "record_id": "REC-STD-2026-04-12-RAX-ROADMAP",
   "run_id": "run-20260412T120000Z-rax-roadmap-serial-01",
   "created_at": "2026-04-12T00:00:00Z",
@@ -519,6 +519,19 @@
       "last_updated_in": "1.3.58",
       "example_path": "contracts/examples/capability_readiness_record.json",
       "notes": "BATCH-A2 deterministic capability readiness posture signal for unattended-operation supervision gating."
+    },
+    {
+      "artifact_type": "cde_closeout_gate_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.115",
+      "last_updated_in": "1.3.115",
+      "example_path": "contracts/examples/cde_closeout_gate_record.json",
+      "notes": "CDE-10 closeout gate proving CDE decision outputs are operationally consumable by SEL."
     },
     {
       "artifact_type": "cde_repair_continuation_input",
@@ -1279,6 +1292,84 @@
       "notes": "VAL-08 deterministic end-to-end multi-layer failure simulation result proving fail-closed blocking and artifact traceability."
     },
     {
+      "artifact_type": "enforcement_action_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.115",
+      "last_updated_in": "1.3.115",
+      "example_path": "contracts/examples/enforcement_action_record.json",
+      "notes": "SEL bounded enforcement action derived from CDE decision artifacts without decision reinterpretation."
+    },
+    {
+      "artifact_type": "enforcement_bundle",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.115",
+      "last_updated_in": "1.3.115",
+      "example_path": "contracts/examples/enforcement_bundle.json",
+      "notes": "SEL aggregate bounded enforcement artifact bundle with trace-linked lineage completeness."
+    },
+    {
+      "artifact_type": "enforcement_conflict_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.115",
+      "last_updated_in": "1.3.115",
+      "example_path": "contracts/examples/enforcement_conflict_record.json",
+      "notes": "SEL integrity and replay conflict record for decision-to-enforcement mismatch/drift detection."
+    },
+    {
+      "artifact_type": "enforcement_effectiveness_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.115",
+      "last_updated_in": "1.3.115",
+      "example_path": "contracts/examples/enforcement_effectiveness_record.json",
+      "notes": "SEL effectiveness tracking artifact linking observed outcomes to bounded enforcement actions."
+    },
+    {
+      "artifact_type": "enforcement_eval_result",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.115",
+      "last_updated_in": "1.3.115",
+      "example_path": "contracts/examples/enforcement_eval_result.json",
+      "notes": "SEL pre-enforcement evaluation result covering scope, decision alignment, policy, and evidence completeness."
+    },
+    {
+      "artifact_type": "enforcement_readiness_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.115",
+      "last_updated_in": "1.3.115",
+      "example_path": "contracts/examples/enforcement_readiness_record.json",
+      "notes": "SEL candidate-only readiness artifact explicitly fenced from decision/promotion authority."
+    },
+    {
       "artifact_type": "enforcement_result",
       "artifact_class": "coordination",
       "schema_version": "1.1.0",
@@ -1288,6 +1379,19 @@
       "last_updated_in": "1.0.11",
       "example_path": "contracts/examples/enforcement_result.json",
       "notes": "Deterministic enforcement artifact generated exclusively from evaluation_control_decision via the BAF single-path enforcement mapper."
+    },
+    {
+      "artifact_type": "enforcement_result_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.115",
+      "last_updated_in": "1.3.115",
+      "example_path": "contracts/examples/enforcement_result_record.json",
+      "notes": "SEL enforcement result artifact with deterministic status and explicit fail reasons."
     },
     {
       "artifact_type": "error_budget_policy",

--- a/docs/governance-reports/contract-enforcement-report.md
+++ b/docs/governance-reports/contract-enforcement-report.md
@@ -1,6 +1,6 @@
 # Cross-Repo Contract Enforcement Report
 
-Generated: 2026-04-12T18:00:20Z
+Generated: 2026-04-12T18:26:20Z
 Source: `contracts/standards-manifest.json`
 
 ## Summary

--- a/docs/review-actions/2026-04-12-sel-001-build-plan.md
+++ b/docs/review-actions/2026-04-12-sel-001-build-plan.md
@@ -1,0 +1,24 @@
+# SEL-001 Build Plan (Primary Type: BUILD)
+
+- **Batch:** SEL-001
+- **Mode:** SERIAL + IMPLEMENTATION-REQUIRED + ADVERSARIAL + REPO-NATIVE
+- **Date:** 2026-04-12
+
+## Ordered execution plan
+1. **CDE-10 closeout gate:** verify CDE decision flow is operational in real repository paths and add a closeout gate artifact + tests if missing.
+2. **SEL-01 contracts:** add schema-bound SEL artifacts (`enforcement_action_record`, `enforcement_result_record`, `enforcement_eval_result`, `enforcement_readiness_record`, `enforcement_conflict_record`, `enforcement_effectiveness_record`, `enforcement_bundle`) with examples and standards-manifest entries.
+3. **SEL-02 to SEL-08 implementation:** add deterministic SEL enforcement foundation module that:
+   - fences upstream/downstream boundaries,
+   - maps bounded actions deterministically,
+   - evaluates enforcement artifacts,
+   - enforces candidate-only readiness,
+   - validates decision-to-enforcement integrity,
+   - validates replay determinism,
+   - computes effectiveness tracking.
+4. **Built-in red-team loop (RT1-RT5 + FX1-FX5):** encode adversarial fixtures and fail-closed assertions directly in eval-style tests; harden module logic for every discovered exploit and add permanent regressions.
+5. **Validation & closeout:** run contract/schema enforcement and targeted runtime tests for CDE + SEL seams.
+
+## Scope controls
+- Keep CLIs thin; enforce behavior in runtime modules.
+- Keep changes bounded to CDE/SEL contracts, runtime modules, tests, and standards manifest.
+- Preserve canonical boundaries: CDE decides, SEL enforces bounded actions only, promotion remains separately gated.

--- a/governance/reports/contract-dependency-graph.json
+++ b/governance/reports/contract-dependency-graph.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0.0",
-  "generated_at": "2026-04-12T18:00:20Z",
+  "generated_at": "2026-04-12T18:26:20Z",
   "source_manifest": "contracts/standards-manifest.json",
   "repos": [
     {

--- a/spectrum_systems/modules/runtime/cde_decision_flow.py
+++ b/spectrum_systems/modules/runtime/cde_decision_flow.py
@@ -332,3 +332,45 @@ def verify_cde_boundary_inputs(*, upstream_artifacts: Sequence[Mapping[str, Any]
             raise CDEDecisionFlowError("CDE upstream boundary rejected non-governed artifact")
         if any(field in artifact for field in _FORBIDDEN_EXECUTION_FIELDS):
             raise CDEDecisionFlowError("CDE fail-closed: execution/enforcement fields are forbidden")
+
+
+def build_cde_closeout_gate_record(
+    *,
+    decision_bundle: Mapping[str, Any],
+    decision_eval_result: Mapping[str, Any],
+    decision_replay_validation_record: Mapping[str, Any],
+    decision_effectiveness_record: Mapping[str, Any],
+) -> dict[str, Any]:
+    """CDE-10 closeout gate proving CDE artifacts are operational for SEL downstream use."""
+    validate_artifact(dict(decision_bundle), "decision_bundle")
+    validate_artifact(dict(decision_eval_result), "decision_eval_result")
+    validate_artifact(dict(decision_replay_validation_record), "decision_replay_validation_record")
+    validate_artifact(dict(decision_effectiveness_record), "decision_effectiveness_record")
+
+    blocking_reasons: list[str] = []
+    if decision_eval_result.get("result") != "pass":
+        blocking_reasons.append("decision_eval_not_pass")
+    if decision_replay_validation_record.get("result") != "pass":
+        blocking_reasons.append("decision_replay_not_deterministic")
+    if decision_effectiveness_record.get("effectiveness_state") in {"too_permissive", "too_strict"}:
+        blocking_reasons.append("decision_effectiveness_out_of_bounds")
+
+    record = {
+        "artifact_type": "cde_closeout_gate_record",
+        "schema_version": "1.0.0",
+        "gate_id": f"cde-close-{_digest([decision_bundle['bundle_id'], decision_eval_result['eval_id'], decision_replay_validation_record['validation_id']])[:16]}",
+        "decision_bundle_ref": f"decision_bundle:{decision_bundle['bundle_id']}",
+        "decision_eval_result_ref": f"decision_eval_result:{decision_eval_result['eval_id']}",
+        "decision_replay_validation_record_ref": f"decision_replay_validation_record:{decision_replay_validation_record['validation_id']}",
+        "decision_effectiveness_record_ref": f"decision_effectiveness_record:{decision_effectiveness_record['record_id']}",
+        "cde_operational": len(blocking_reasons) == 0,
+        "closeout_status": "closed" if len(blocking_reasons) == 0 else "blocked",
+        "blocking_reasons": sorted(set(blocking_reasons)),
+        "non_authority_assertions": [
+            "cde_emits_decision_artifacts_only",
+            "cde_is_not_execution_authority",
+            "cde_is_not_enforcement_authority",
+        ],
+    }
+    validate_artifact(record, "cde_closeout_gate_record")
+    return record

--- a/spectrum_systems/modules/runtime/sel_enforcement_foundation.py
+++ b/spectrum_systems/modules/runtime/sel_enforcement_foundation.py
@@ -1,0 +1,323 @@
+"""SEL bounded enforcement foundation (SEL-01..SEL-08 + RT hardening).
+
+SEL consumes governed CDE decision artifacts and evidence bundles only,
+and emits bounded enforcement artifacts only.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Mapping, Sequence
+
+from spectrum_systems.contracts import validate_artifact
+
+
+class SELEnforcementError(ValueError):
+    """Raised when SEL boundary rules fail closed."""
+
+
+_ALLOWED_ACTIONS = {
+    "continue_repair_path",
+    "quarantine",
+    "require_human_review",
+    "halt",
+    "none",
+}
+
+_ALLOWED_UPSTREAM_TYPES = {
+    "continuation_decision_record",
+    "decision_bundle",
+    "decision_evidence_pack",
+}
+
+_DECISION_ACTION_MAP = {
+    "continue_repair_bounded": "continue_repair_path",
+    "human_review_required": "require_human_review",
+    "block": "halt",
+}
+
+
+def _digest(payload: Any) -> str:
+    return hashlib.sha256(json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")).hexdigest()
+
+
+def _required_str(value: Any, *, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise SELEnforcementError(f"{field} must be a non-empty string")
+    return value.strip()
+
+
+def _clean_refs(values: Any, *, field: str, min_items: int = 1) -> list[str]:
+    if not isinstance(values, list):
+        raise SELEnforcementError(f"{field} must be a list")
+    refs = sorted({str(v).strip() for v in values if isinstance(v, str) and v.strip()})
+    if len(refs) < min_items:
+        raise SELEnforcementError(f"{field} must include at least {min_items} refs")
+    return refs
+
+
+def verify_sel_boundary_inputs(*, decision_record: Mapping[str, Any], decision_bundle: Mapping[str, Any], evidence_bundle: Mapping[str, Any]) -> None:
+    validate_artifact(dict(decision_record), "continuation_decision_record")
+    validate_artifact(dict(decision_bundle), "decision_bundle")
+
+    artifact_type = _required_str(evidence_bundle.get("artifact_type"), field="artifact_type")
+    if artifact_type not in _ALLOWED_UPSTREAM_TYPES:
+        raise SELEnforcementError("SEL upstream boundary rejected non-governed artifact")
+    if "decision_outcome" in evidence_bundle and artifact_type != "continuation_decision_record":
+        raise SELEnforcementError("SEL fail-closed: mixed decision payloads are not allowed in evidence_bundle")
+
+
+def build_enforcement_action_record(
+    *,
+    decision_record: Mapping[str, Any],
+    decision_bundle: Mapping[str, Any],
+    evidence_refs: Sequence[str],
+    requested_action: str | None = None,
+) -> dict[str, Any]:
+    validate_artifact(dict(decision_record), "continuation_decision_record")
+    validate_artifact(dict(decision_bundle), "decision_bundle")
+
+    expected = _DECISION_ACTION_MAP.get(decision_record["decision_outcome"], "none")
+    action = (requested_action or expected).strip()
+    if action not in _ALLOWED_ACTIONS:
+        raise SELEnforcementError("requested_action must be one of bounded SEL actions")
+
+    record = {
+        "artifact_type": "enforcement_action_record",
+        "schema_version": "1.0.0",
+        "action_id": f"sel-act-{_digest([decision_record['decision_id'], action, list(evidence_refs)])[:16]}",
+        "trace_id": decision_record["trace_id"],
+        "continuation_decision_record_ref": f"continuation_decision_record:{decision_record['decision_id']}",
+        "decision_bundle_ref": f"decision_bundle:{decision_bundle['bundle_id']}",
+        "action": action,
+        "action_reason_codes": sorted(set(decision_record.get("reason_codes", []))),
+        "evidence_refs": _clean_refs(list(evidence_refs), field="evidence_refs"),
+        "non_authority_assertions": [
+            "sel_enforcement_only",
+            "sel_must_not_reinterpret_cde",
+            "sel_must_not_issue_new_decisions",
+        ],
+    }
+    validate_artifact(record, "enforcement_action_record")
+    return record
+
+
+def evaluate_enforcement_action(
+    *,
+    decision_record: Mapping[str, Any],
+    action_record: Mapping[str, Any],
+    evidence_bundle: Mapping[str, Any],
+) -> dict[str, Any]:
+    validate_artifact(dict(decision_record), "continuation_decision_record")
+    validate_artifact(dict(action_record), "enforcement_action_record")
+
+    fail_reasons: list[str] = []
+    expected_action = _DECISION_ACTION_MAP.get(decision_record["decision_outcome"], "none")
+
+    if action_record.get("action") != expected_action:
+        fail_reasons.append("decision_action_mismatch")
+    if len(action_record.get("evidence_refs", [])) < 1:
+        fail_reasons.append("evidence_incomplete")
+    if not str(action_record.get("decision_bundle_ref", "")).startswith("decision_bundle:"):
+        fail_reasons.append("scope_compliance_failed")
+    if not str(evidence_bundle.get("artifact_type", "")).startswith("decision_") and evidence_bundle.get("artifact_type") != "continuation_decision_record":
+        fail_reasons.append("policy_compliance_failed")
+    if "sel_must_not_issue_new_decisions" not in action_record.get("non_authority_assertions", []):
+        fail_reasons.append("non_decision_assertion_missing")
+
+    result = {
+        "artifact_type": "enforcement_eval_result",
+        "schema_version": "1.0.0",
+        "eval_id": f"sel-eval-{_digest([action_record['action_id'], fail_reasons])[:16]}",
+        "trace_id": decision_record["trace_id"],
+        "enforcement_action_record_ref": f"enforcement_action_record:{action_record['action_id']}",
+        "scope_compliance_passed": "scope_compliance_failed" not in fail_reasons,
+        "decision_alignment_passed": "decision_action_mismatch" not in fail_reasons,
+        "policy_compliance_passed": "policy_compliance_failed" not in fail_reasons,
+        "evidence_completeness_passed": "evidence_incomplete" not in fail_reasons,
+        "non_decision_assertion_passed": "non_decision_assertion_missing" not in fail_reasons,
+        "result": "pass" if not fail_reasons else "fail",
+        "fail_reasons": sorted(set(fail_reasons)),
+    }
+    validate_artifact(result, "enforcement_eval_result")
+    return result
+
+
+def build_enforcement_readiness(
+    *,
+    decision_record: Mapping[str, Any],
+    action_record: Mapping[str, Any],
+    eval_result: Mapping[str, Any],
+) -> dict[str, Any]:
+    validate_artifact(dict(decision_record), "continuation_decision_record")
+    validate_artifact(dict(action_record), "enforcement_action_record")
+    validate_artifact(dict(eval_result), "enforcement_eval_result")
+
+    blocking_reasons: list[str] = []
+    if eval_result.get("result") != "pass":
+        blocking_reasons.append("enforcement_eval_not_pass")
+    if action_record.get("action") == "none":
+        blocking_reasons.append("no_op_not_ready")
+
+    readiness = {
+        "artifact_type": "enforcement_readiness_record",
+        "schema_version": "1.0.0",
+        "readiness_id": f"sel-ready-{_digest([action_record['action_id'], eval_result['eval_id'], blocking_reasons])[:16]}",
+        "trace_id": decision_record["trace_id"],
+        "enforcement_action_record_ref": f"enforcement_action_record:{action_record['action_id']}",
+        "enforcement_eval_result_ref": f"enforcement_eval_result:{eval_result['eval_id']}",
+        "candidate_ready": len(blocking_reasons) == 0,
+        "blocking_reasons": sorted(set(blocking_reasons)),
+        "non_authority_assertions": [
+            "candidate_only",
+            "cannot_create_new_decision_authority",
+            "promotion_requires_separate_gate",
+        ],
+    }
+    validate_artifact(readiness, "enforcement_readiness_record")
+    return readiness
+
+
+def build_enforcement_conflict_record(*, decision_record: Mapping[str, Any], action_record: Mapping[str, Any], eval_result: Mapping[str, Any]) -> dict[str, Any]:
+    validate_artifact(dict(decision_record), "continuation_decision_record")
+    validate_artifact(dict(action_record), "enforcement_action_record")
+    validate_artifact(dict(eval_result), "enforcement_eval_result")
+
+    expected_action = _DECISION_ACTION_MAP.get(decision_record["decision_outcome"], "none")
+    conflict_refs: list[str] = []
+    if action_record["action"] != expected_action:
+        conflict_refs.append("decision_action_mismatch")
+    if eval_result["result"] != "pass":
+        conflict_refs.extend(eval_result.get("fail_reasons", []))
+
+    record = {
+        "artifact_type": "enforcement_conflict_record",
+        "schema_version": "1.0.0",
+        "conflict_id": f"sel-conf-{_digest([decision_record['decision_id'], action_record['action_id'], conflict_refs])[:16]}",
+        "trace_id": decision_record["trace_id"],
+        "continuation_decision_record_ref": f"continuation_decision_record:{decision_record['decision_id']}",
+        "enforcement_action_record_ref": f"enforcement_action_record:{action_record['action_id']}",
+        "conflict_refs": sorted(set(conflict_refs)),
+        "integrity_passed": len(conflict_refs) == 0,
+        "result": "pass" if len(conflict_refs) == 0 else "fail",
+    }
+    validate_artifact(record, "enforcement_conflict_record")
+    return record
+
+
+def build_enforcement_result_record(
+    *,
+    decision_record: Mapping[str, Any],
+    action_record: Mapping[str, Any],
+    eval_result: Mapping[str, Any],
+    readiness_record: Mapping[str, Any],
+    conflict_record: Mapping[str, Any],
+) -> dict[str, Any]:
+    validate_artifact(dict(decision_record), "continuation_decision_record")
+    validate_artifact(dict(action_record), "enforcement_action_record")
+    validate_artifact(dict(eval_result), "enforcement_eval_result")
+    validate_artifact(dict(readiness_record), "enforcement_readiness_record")
+    validate_artifact(dict(conflict_record), "enforcement_conflict_record")
+
+    blocked = eval_result["result"] != "pass" or conflict_record["result"] != "pass" or not readiness_record["candidate_ready"]
+    result_record = {
+        "artifact_type": "enforcement_result_record",
+        "schema_version": "1.0.0",
+        "result_id": f"sel-res-{_digest([action_record['action_id'], eval_result['eval_id'], conflict_record['conflict_id']])[:16]}",
+        "trace_id": decision_record["trace_id"],
+        "enforcement_action_record_ref": f"enforcement_action_record:{action_record['action_id']}",
+        "enforcement_eval_result_ref": f"enforcement_eval_result:{eval_result['eval_id']}",
+        "enforcement_readiness_record_ref": f"enforcement_readiness_record:{readiness_record['readiness_id']}",
+        "enforcement_conflict_record_ref": f"enforcement_conflict_record:{conflict_record['conflict_id']}",
+        "enforcement_status": "blocked" if blocked else "enforced",
+        "reason_codes": sorted(set(eval_result.get("fail_reasons", []) + conflict_record.get("conflict_refs", []) + (["candidate_not_ready"] if not readiness_record["candidate_ready"] else []))),
+    }
+    validate_artifact(result_record, "enforcement_result_record")
+    return result_record
+
+
+def build_enforcement_bundle(
+    *,
+    action_record: Mapping[str, Any],
+    result_record: Mapping[str, Any],
+    eval_result: Mapping[str, Any],
+    readiness_record: Mapping[str, Any],
+    conflict_record: Mapping[str, Any],
+) -> dict[str, Any]:
+    validate_artifact(dict(action_record), "enforcement_action_record")
+    validate_artifact(dict(result_record), "enforcement_result_record")
+    validate_artifact(dict(eval_result), "enforcement_eval_result")
+    validate_artifact(dict(readiness_record), "enforcement_readiness_record")
+    validate_artifact(dict(conflict_record), "enforcement_conflict_record")
+
+    bundle = {
+        "artifact_type": "enforcement_bundle",
+        "schema_version": "1.0.0",
+        "bundle_id": f"sel-bundle-{_digest([action_record['action_id'], result_record['result_id'], eval_result['eval_id']])[:16]}",
+        "trace_id": action_record["trace_id"],
+        "enforcement_action_record_ref": f"enforcement_action_record:{action_record['action_id']}",
+        "enforcement_result_record_ref": f"enforcement_result_record:{result_record['result_id']}",
+        "enforcement_eval_result_ref": f"enforcement_eval_result:{eval_result['eval_id']}",
+        "enforcement_readiness_record_ref": f"enforcement_readiness_record:{readiness_record['readiness_id']}",
+        "enforcement_conflict_record_ref": f"enforcement_conflict_record:{conflict_record['conflict_id']}",
+        "lineage_complete": True,
+    }
+    validate_artifact(bundle, "enforcement_bundle")
+    return bundle
+
+
+def validate_enforcement_replay(*, decision_record: Mapping[str, Any], action_record: Mapping[str, Any], first_result: Mapping[str, Any], replay_result: Mapping[str, Any], evidence_refs: Sequence[str]) -> dict[str, Any]:
+    validate_artifact(dict(decision_record), "continuation_decision_record")
+    validate_artifact(dict(action_record), "enforcement_action_record")
+    validate_artifact(dict(first_result), "enforcement_result_record")
+    validate_artifact(dict(replay_result), "enforcement_result_record")
+
+    refs = _clean_refs(list(evidence_refs), field="evidence_refs")
+    first_fp = _digest(first_result)
+    replay_fp = _digest(replay_result)
+    deterministic_match = first_fp == replay_fp
+
+    record = {
+        "artifact_type": "enforcement_conflict_record",
+        "schema_version": "1.0.0",
+        "conflict_id": f"sel-conf-{_digest([decision_record['decision_id'], action_record['action_id'], refs, first_fp, replay_fp])[:16]}",
+        "trace_id": decision_record["trace_id"],
+        "continuation_decision_record_ref": f"continuation_decision_record:{decision_record['decision_id']}",
+        "enforcement_action_record_ref": f"enforcement_action_record:{action_record['action_id']}",
+        "conflict_refs": [] if deterministic_match else ["enforcement_replay_mismatch"],
+        "integrity_passed": deterministic_match,
+        "result": "pass" if deterministic_match else "fail",
+    }
+    validate_artifact(record, "enforcement_conflict_record")
+    return record
+
+
+def build_enforcement_effectiveness_record(*, decision_record: Mapping[str, Any], action_record: Mapping[str, Any], result_record: Mapping[str, Any], observed_outcome: str, observed_outcome_ref: str) -> dict[str, Any]:
+    validate_artifact(dict(decision_record), "continuation_decision_record")
+    validate_artifact(dict(action_record), "enforcement_action_record")
+    validate_artifact(dict(result_record), "enforcement_result_record")
+
+    outcome = _required_str(observed_outcome, field="observed_outcome")
+    mapping = {
+        ("continue_repair_path", "improved"): ("effective", True),
+        ("halt", "contained"): ("effective", True),
+        ("require_human_review", "awaiting_review"): ("pending", False),
+        ("none", "unchanged"): ("ineffective", False),
+    }
+    state, success = mapping.get((action_record["action"], outcome), ("ineffective", False))
+
+    record = {
+        "artifact_type": "enforcement_effectiveness_record",
+        "schema_version": "1.0.0",
+        "record_id": f"sel-eff-{_digest([decision_record['decision_id'], action_record['action_id'], result_record['result_id'], outcome])[:16]}",
+        "trace_id": decision_record["trace_id"],
+        "continuation_decision_record_ref": f"continuation_decision_record:{decision_record['decision_id']}",
+        "enforcement_action_record_ref": f"enforcement_action_record:{action_record['action_id']}",
+        "enforcement_result_record_ref": f"enforcement_result_record:{result_record['result_id']}",
+        "observed_outcome_ref": _required_str(observed_outcome_ref, field="observed_outcome_ref"),
+        "effectiveness_state": state,
+        "success": success,
+    }
+    validate_artifact(record, "enforcement_effectiveness_record")
+    return record

--- a/tests/test_cde_decision_flow.py
+++ b/tests/test_cde_decision_flow.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import json
+
 from spectrum_systems.contracts import validate_artifact
 from spectrum_systems.modules.runtime.cde_decision_flow import (
     CDEDecisionFlowError,
+    build_cde_closeout_gate_record,
     build_decision_bundle,
     build_decision_effectiveness_record,
     build_decision_evidence_pack,
@@ -139,6 +142,13 @@ def test_cde_flow_end_to_end() -> None:
         downstream_outcome="improved",
     )
 
+    closeout = build_cde_closeout_gate_record(
+        decision_bundle=bundle,
+        decision_eval_result=eval_result,
+        decision_replay_validation_record=replay,
+        decision_effectiveness_record=effectiveness,
+    )
+
     for artifact_type, artifact in (
         ("decision_evidence_pack", evidence_pack),
         ("decision_conflict_record", conflict_record),
@@ -148,12 +158,14 @@ def test_cde_flow_end_to_end() -> None:
         ("decision_bundle", bundle),
         ("decision_replay_validation_record", replay),
         ("decision_effectiveness_record", effectiveness),
+        ("cde_closeout_gate_record", closeout),
     ):
         validate_artifact(artifact, artifact_type)
 
     assert decision["decision_outcome"] == "continue_repair_bounded"
     assert readiness["candidate_ready"] is True
     assert replay["result"] == "pass"
+    assert closeout["closeout_status"] == "closed"
 
 
 def test_cde_boundary_and_fail_closed_behaviors() -> None:
@@ -200,3 +212,52 @@ def test_cde_boundary_and_fail_closed_behaviors() -> None:
     )
     assert replay_drift["result"] == "fail"
     assert "decision_replay_mismatch" in replay_drift["fail_reasons"]
+
+
+def test_cde_closeout_gate_artifacts_are_operationally_real_on_repo_paths(tmp_path) -> None:
+    interpretation_bundle, repair_bundle, _ = _build_ril_fre_artifacts()
+    evidence_pack = build_decision_evidence_pack(
+        trace_id="trace-cde-closeout-001",
+        interpretation_bundle=interpretation_bundle,
+        repair_bundle=repair_bundle,
+        policy_constraints_ref="policy:cde_bounded_decision_v1",
+        provenance_refs=["provenance_record:prv-closeout-001"],
+        replay_refs=["interpretation_replay_validation_record:ril-replay-closeout-001"],
+        evidence_refs=["failure_packet:ril-fp-closeout-001", "repair_eval_result:fre-reval-closeout-001", "policy:cde_bounded_decision_v1"],
+    )
+    conflict_record = detect_decision_conflicts(evidence_pack=evidence_pack, conflict_refs=["interpretation_conflict_record:ril-conf-closeout-001"], material_threshold=2)
+    decision = make_continuation_decision(evidence_pack=evidence_pack, conflict_record=conflict_record, evidence_budget_min=2, ambiguity_rate=0.1)
+    eval_result = evaluate_decision(decision_record=decision, conflict_record=conflict_record, evidence_pack=evidence_pack)
+    readiness = build_decision_readiness(decision_record=decision, eval_result=eval_result)
+    bundle = build_decision_bundle(
+        evidence_pack=evidence_pack,
+        decision_record=decision,
+        eval_result=eval_result,
+        readiness_record=readiness,
+        conflict_record=conflict_record,
+    )
+    replay = validate_decision_replay(evidence_pack=evidence_pack, first_decision=decision, replay_decision=dict(decision))
+    effectiveness = build_decision_effectiveness_record(
+        decision_record=decision,
+        downstream_outcome_ref="downstream_outcome:tlc-closeout-001",
+        downstream_outcome="improved",
+    )
+    closeout = build_cde_closeout_gate_record(
+        decision_bundle=bundle,
+        decision_eval_result=eval_result,
+        decision_replay_validation_record=replay,
+        decision_effectiveness_record=effectiveness,
+    )
+
+    output_dir = tmp_path / "artifacts" / "cde_closeout"
+    output_dir.mkdir(parents=True)
+    (output_dir / "decision_bundle.json").write_text(json.dumps(bundle), encoding="utf-8")
+    (output_dir / "continuation_decision_record.json").write_text(json.dumps(decision), encoding="utf-8")
+    (output_dir / "decision_eval_result.json").write_text(json.dumps(eval_result), encoding="utf-8")
+    (output_dir / "decision_replay_validation_record.json").write_text(json.dumps(replay), encoding="utf-8")
+    (output_dir / "decision_effectiveness_record.json").write_text(json.dumps(effectiveness), encoding="utf-8")
+    (output_dir / "cde_closeout_gate_record.json").write_text(json.dumps(closeout), encoding="utf-8")
+
+    assert (output_dir / "cde_closeout_gate_record.json").exists()
+    assert closeout["closeout_status"] == "closed"
+    assert closeout["cde_operational"] is True

--- a/tests/test_contract_enforcement.py
+++ b/tests/test_contract_enforcement.py
@@ -668,3 +668,21 @@ def test_standards_manifest_registers_ltv_a_governance_contracts() -> None:
     assert "precedent_selection_record" in artifact_types
     assert "precedent_conflict_record" in artifact_types
     assert "override_governance_record" in artifact_types
+
+
+def test_standards_manifest_registers_cde_closeout_and_sel_enforcement_contracts() -> None:
+    standards = load_standards_contracts()
+    assert standards["cde_closeout_gate_record"]["schema_version"] == "1.0.0"
+    assert standards["cde_closeout_gate_record"]["example_path"] == "contracts/examples/cde_closeout_gate_record.json"
+
+    for artifact_type in (
+        "enforcement_action_record",
+        "enforcement_result_record",
+        "enforcement_eval_result",
+        "enforcement_readiness_record",
+        "enforcement_conflict_record",
+        "enforcement_effectiveness_record",
+        "enforcement_bundle",
+    ):
+        assert standards[artifact_type]["schema_version"] == "1.0.0"
+        assert standards[artifact_type]["example_path"] == f"contracts/examples/{artifact_type}.json"

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -201,9 +201,10 @@ class ContractSchemaTests(unittest.TestCase):
         instance = load_example("system_roadmap")
         validate_artifact(instance, "system_roadmap")
 
-    def test_ril_and_cde_foundation_examples_validate(self) -> None:
+    def test_ril_cde_sel_foundation_examples_validate(self) -> None:
         for name in (
             "ril_closeout_gate_record",
+            "cde_closeout_gate_record",
             "decision_evidence_pack",
             "decision_conflict_record",
             "continuation_decision_record",
@@ -212,6 +213,13 @@ class ContractSchemaTests(unittest.TestCase):
             "decision_bundle",
             "decision_replay_validation_record",
             "decision_effectiveness_record",
+            "enforcement_action_record",
+            "enforcement_result_record",
+            "enforcement_eval_result",
+            "enforcement_readiness_record",
+            "enforcement_conflict_record",
+            "enforcement_effectiveness_record",
+            "enforcement_bundle",
         ):
             instance = load_example(name)
             validate_artifact(instance, name)

--- a/tests/test_sel_enforcement_foundation.py
+++ b/tests/test_sel_enforcement_foundation.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from spectrum_systems.contracts import load_example, validate_artifact
+from spectrum_systems.modules.runtime.sel_enforcement_foundation import (
+    SELEnforcementError,
+    build_enforcement_action_record,
+    build_enforcement_bundle,
+    build_enforcement_conflict_record,
+    build_enforcement_effectiveness_record,
+    build_enforcement_readiness,
+    build_enforcement_result_record,
+    evaluate_enforcement_action,
+    validate_enforcement_replay,
+    verify_sel_boundary_inputs,
+)
+
+
+def _decision_record() -> dict:
+    artifact = load_example("continuation_decision_record")
+    artifact["decision_outcome"] = "continue_repair_bounded"
+    artifact["reason_codes"] = ["bounded_continue_permitted"]
+    artifact["trace_id"] = "trace-sel-001"
+    return artifact
+
+
+def _decision_bundle() -> dict:
+    artifact = load_example("decision_bundle")
+    artifact["trace_id"] = "trace-sel-001"
+    return artifact
+
+
+def _evidence_bundle() -> dict:
+    artifact = load_example("decision_evidence_pack")
+    artifact["trace_id"] = "trace-sel-001"
+    return artifact
+
+
+def test_sel_end_to_end_foundation() -> None:
+    decision = _decision_record()
+    bundle = _decision_bundle()
+    evidence = _evidence_bundle()
+
+    verify_sel_boundary_inputs(decision_record=decision, decision_bundle=bundle, evidence_bundle=evidence)
+    action = build_enforcement_action_record(
+        decision_record=decision,
+        decision_bundle=bundle,
+        evidence_refs=["decision_evidence_pack:cde-ep-0123456789abcdef"],
+    )
+    eval_result = evaluate_enforcement_action(decision_record=decision, action_record=action, evidence_bundle=evidence)
+    readiness = build_enforcement_readiness(decision_record=decision, action_record=action, eval_result=eval_result)
+    conflict = build_enforcement_conflict_record(decision_record=decision, action_record=action, eval_result=eval_result)
+    result = build_enforcement_result_record(
+        decision_record=decision,
+        action_record=action,
+        eval_result=eval_result,
+        readiness_record=readiness,
+        conflict_record=conflict,
+    )
+    bundle_artifact = build_enforcement_bundle(
+        action_record=action,
+        result_record=result,
+        eval_result=eval_result,
+        readiness_record=readiness,
+        conflict_record=conflict,
+    )
+    replay = validate_enforcement_replay(
+        decision_record=decision,
+        action_record=action,
+        first_result=result,
+        replay_result=copy.deepcopy(result),
+        evidence_refs=["decision_evidence_pack:cde-ep-0123456789abcdef"],
+    )
+    effectiveness = build_enforcement_effectiveness_record(
+        decision_record=decision,
+        action_record=action,
+        result_record=result,
+        observed_outcome="improved",
+        observed_outcome_ref="outcome:sel-001",
+    )
+
+    for artifact_type, artifact in (
+        ("enforcement_action_record", action),
+        ("enforcement_eval_result", eval_result),
+        ("enforcement_readiness_record", readiness),
+        ("enforcement_conflict_record", conflict),
+        ("enforcement_result_record", result),
+        ("enforcement_bundle", bundle_artifact),
+        ("enforcement_conflict_record", replay),
+        ("enforcement_effectiveness_record", effectiveness),
+    ):
+        validate_artifact(artifact, artifact_type)
+
+    assert eval_result["result"] == "pass"
+    assert readiness["candidate_ready"] is True
+    assert result["enforcement_status"] == "enforced"
+    assert replay["result"] == "pass"
+
+
+def test_rt1_boundary_integrity_missing_required_fields_fails_closed() -> None:
+    decision = _decision_record()
+    bundle = _decision_bundle()
+    malformed = _evidence_bundle()
+    malformed["artifact_type"] = "ungoverned_input"
+
+    with pytest.raises(SELEnforcementError):
+        verify_sel_boundary_inputs(decision_record=decision, decision_bundle=bundle, evidence_bundle=malformed)
+
+
+def test_rt2_semantic_logic_mismatch_blocks_and_records_conflict() -> None:
+    decision = _decision_record()
+    bundle = _decision_bundle()
+    evidence = _evidence_bundle()
+    action = build_enforcement_action_record(
+        decision_record=decision,
+        decision_bundle=bundle,
+        evidence_refs=["decision_evidence_pack:cde-ep-0123456789abcdef"],
+        requested_action="none",
+    )
+
+    eval_result = evaluate_enforcement_action(decision_record=decision, action_record=action, evidence_bundle=evidence)
+    readiness = build_enforcement_readiness(decision_record=decision, action_record=action, eval_result=eval_result)
+    conflict = build_enforcement_conflict_record(decision_record=decision, action_record=action, eval_result=eval_result)
+    result = build_enforcement_result_record(
+        decision_record=decision,
+        action_record=action,
+        eval_result=eval_result,
+        readiness_record=readiness,
+        conflict_record=conflict,
+    )
+
+    assert "decision_action_mismatch" in eval_result["fail_reasons"]
+    assert readiness["candidate_ready"] is False
+    assert conflict["result"] == "fail"
+    assert result["enforcement_status"] == "blocked"
+
+
+def test_rt3_replay_drift_detected() -> None:
+    decision = _decision_record()
+    bundle = _decision_bundle()
+    evidence = _evidence_bundle()
+    action = build_enforcement_action_record(
+        decision_record=decision,
+        decision_bundle=bundle,
+        evidence_refs=["decision_evidence_pack:cde-ep-0123456789abcdef"],
+    )
+    eval_result = evaluate_enforcement_action(decision_record=decision, action_record=action, evidence_bundle=evidence)
+    readiness = build_enforcement_readiness(decision_record=decision, action_record=action, eval_result=eval_result)
+    conflict = build_enforcement_conflict_record(decision_record=decision, action_record=action, eval_result=eval_result)
+    result = build_enforcement_result_record(
+        decision_record=decision,
+        action_record=action,
+        eval_result=eval_result,
+        readiness_record=readiness,
+        conflict_record=conflict,
+    )
+
+    drifted = copy.deepcopy(result)
+    drifted["enforcement_status"] = "blocked"
+    replay = validate_enforcement_replay(
+        decision_record=decision,
+        action_record=action,
+        first_result=result,
+        replay_result=drifted,
+        evidence_refs=["decision_evidence_pack:cde-ep-0123456789abcdef"],
+    )
+
+    assert replay["result"] == "fail"
+    assert "enforcement_replay_mismatch" in replay["conflict_refs"]
+
+
+def test_rt4_combinatorial_attack_blocks() -> None:
+    decision = _decision_record()
+    bundle = _decision_bundle()
+    evidence = _evidence_bundle()
+    action = build_enforcement_action_record(
+        decision_record=decision,
+        decision_bundle=bundle,
+        evidence_refs=["decision_evidence_pack:cde-ep-0123456789abcdef"],
+        requested_action="quarantine",
+    )
+    action["non_authority_assertions"] = ["sel_enforcement_only"]
+
+    eval_result = evaluate_enforcement_action(decision_record=decision, action_record=action, evidence_bundle=evidence)
+    readiness = build_enforcement_readiness(decision_record=decision, action_record=action, eval_result=eval_result)
+
+    assert eval_result["result"] == "fail"
+    assert "decision_action_mismatch" in eval_result["fail_reasons"]
+    assert "non_decision_assertion_missing" in eval_result["fail_reasons"]
+    assert readiness["candidate_ready"] is False
+
+
+def test_rt5_operational_reality_noop_abuse_detected() -> None:
+    decision = _decision_record()
+    bundle = _decision_bundle()
+    evidence = _evidence_bundle()
+
+    action = build_enforcement_action_record(
+        decision_record=decision,
+        decision_bundle=bundle,
+        evidence_refs=["decision_evidence_pack:cde-ep-0123456789abcdef"],
+        requested_action="none",
+    )
+    eval_result = evaluate_enforcement_action(decision_record=decision, action_record=action, evidence_bundle=evidence)
+    readiness = build_enforcement_readiness(decision_record=decision, action_record=action, eval_result=eval_result)
+
+    assert "no_op_not_ready" in readiness["blocking_reasons"]
+    assert readiness["candidate_ready"] is False


### PR DESCRIPTION
### Motivation
- Provide a minimal, repo-native CDE closeout gate so SEL can depend on deterministic CDE decision artifacts before enforcement occurs.  
- Establish SEL as a strict, fail-closed enforcement boundary with explicit, schema-bound artifacts and deterministic mapping from CDE decisions to bounded enforcement actions.  
- Build an eval/hardening harness (red-team rounds) so every discovered exploit becomes a permanent regression test and hardened logic path.  

### Description
- Added a deterministic SEL enforcement foundation module `spectrum_systems/modules/runtime/sel_enforcement_foundation.py` implementing input fencing, deterministic action mapping, evaluation, readiness, conflict/replay checks, result synthesis, bundle assembly, and effectiveness tracking.  
- Extended CDE with a closeout gate function `build_cde_closeout_gate_record` in `spectrum_systems/modules/runtime/cde_decision_flow.py` to prove decision artifacts are operationally consumable by SEL.  
- Introduced JSON Schema artifacts and golden examples for SEL and CDE: `cde_closeout_gate_record` and SEL artifacts (`enforcement_action_record`, `enforcement_eval_result`, `enforcement_readiness_record`, `enforcement_conflict_record`, `enforcement_result_record`, `enforcement_effectiveness_record`, `enforcement_bundle`), and registered them in `contracts/standards-manifest.json`.  
- Added adversarial regression tests exercising RT1–RT5 (boundary integrity, semantic/logic mismatch, replay/drift, combinatorial attacks, operational no-op abuse) and end-to-end CDE closeout checks under `tests/test_sel_enforcement_foundation.py` and extended `tests/test_cde_decision_flow.py`, plus manifest/registry assertions in contract tests and a BUILD plan in `docs/review-actions/2026-04-12-sel-001-build-plan.md`.  

### Testing
- Ran unit + integration tests: `pytest tests/test_cde_decision_flow.py tests/test_sel_enforcement_foundation.py` and all targeted tests passed (SEL + CDE flows).  
- Ran contract validations: `pytest tests/test_contracts.py tests/test_contract_enforcement.py` and `python scripts/run_contract_enforcement.py`, both passed with no failures.  
- Ran module architecture tests: `pytest tests/test_module_architecture.py`, which passed.  
- Ran contract boundary audit: `.codex/skills/contract-boundary-audit/run.sh`, which completed with non-blocking warnings (no blocking violations).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbe23c5ff08329a94b1393504b7f1c)