### PR TITLE
Fix dashboard publication snapshot freshness timestamp wiring

### DIFF
--- a/scripts/refresh_dashboard.sh
+++ b/scripts/refresh_dashboard.sh
@@ -39,9 +39,7 @@ if [[ ! -f "${SNAPSHOT_ARTIFACT}" ]]; then
   exit 1
 fi
 
-REFRESHED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-
-python3 - <<'PY' "${REPO_ROOT}" "${DASHBOARD_PUBLIC_DIR}" "${REFRESHED_AT}"
+python3 - <<'PY' "${REPO_ROOT}" "${DASHBOARD_PUBLIC_DIR}"
 from __future__ import annotations
 
 import hashlib
@@ -53,7 +51,6 @@ from pathlib import Path
 
 repo_root = Path(sys.argv[1])
 public_root = Path(sys.argv[2])
-refreshed_at = sys.argv[3]
 
 required_sources = {
     "repo_snapshot.json": repo_root / "artifacts" / "dashboard" / "repo_snapshot.json",
@@ -95,9 +92,24 @@ if missing:
         print(f"- {row}", file=sys.stderr)
     raise SystemExit(1)
 
+snapshot_payload = json.loads(required_sources["repo_snapshot.json"].read_text(encoding="utf-8"))
+snapshot_generated_at = str(snapshot_payload.get("generated_at", "")).strip()
+if not snapshot_generated_at:
+    print("ERROR: repo_snapshot.json.generated_at is required", file=sys.stderr)
+    raise SystemExit(1)
+
+try:
+    datetime.strptime(snapshot_generated_at, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+except ValueError as exc:
+    print(
+        "ERROR: repo_snapshot.json.generated_at must be ISO UTC (YYYY-MM-DDTHH:MM:SSZ)",
+        file=sys.stderr,
+    )
+    raise SystemExit(1) from exc
+
 snapshot_size_bytes = required_sources["repo_snapshot.json"].stat().st_size
 meta_payload = {
-    "last_refreshed_time": refreshed_at,
+    "last_refreshed_time": snapshot_generated_at,
     "snapshot_size": f"{snapshot_size_bytes} bytes",
     "data_source_state": "live",
     "snapshot_source_path": "artifacts/dashboard/repo_snapshot.json",
@@ -105,13 +117,13 @@ meta_payload = {
 }
 
 freshness_payload = json.loads(required_sources["dashboard_freshness_status.json"].read_text(encoding="utf-8"))
-refreshed_dt = datetime.strptime(refreshed_at, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+refreshed_dt = datetime.strptime(snapshot_generated_at, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
 age_hours = (datetime.now(timezone.utc) - refreshed_dt).total_seconds() / 3600
 freshness_payload.update(
     {
-        "generated_at": refreshed_at,
+        "generated_at": snapshot_generated_at,
         "status": "fresh" if age_hours <= 6 else "stale",
-        "snapshot_last_refreshed_time": refreshed_at,
+        "snapshot_last_refreshed_time": snapshot_generated_at,
         "snapshot_age_hours": round(age_hours, 3),
         "publication_state": "live",
     }
@@ -142,7 +154,7 @@ for name in sorted(required_sources):
 
 audit_payload = {
     "artifact_type": "dashboard_publication_sync_audit",
-    "published_at": refreshed_at,
+    "published_at": snapshot_generated_at,
     "publication_state": "live",
     "required_artifact_count": len(required_sources) + 2,
     "records": copied_rows,
@@ -152,7 +164,7 @@ audit_payload = {
 publication_manifest = {
     "artifact_type": "dashboard_publication_manifest",
     "manifest_version": "1.0.0",
-    "published_at": refreshed_at,
+    "published_at": snapshot_generated_at,
     "publication_mode": "atomic",
     "publication_state": "live",
     "publication_contract": "canonical_live_artifact_projection",
@@ -195,6 +207,22 @@ print(f"Refresh complete: {public_root / 'repo_snapshot.json'}")
 print(f"Metadata written: {public_root / 'repo_snapshot_meta.json'}")
 print(f"Publication audit: {public_root / 'dashboard_publication_sync_audit.json'}")
 PY
+
+REFRESHED_AT="$(python3 - <<'PY' "${SNAPSHOT_ARTIFACT}"
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+snapshot_path = Path(sys.argv[1])
+payload = json.loads(snapshot_path.read_text(encoding="utf-8"))
+value = str(payload.get("generated_at", "")).strip()
+if not value:
+    raise SystemExit("ERROR: repo_snapshot.json.generated_at missing after refresh")
+print(value)
+PY
+)"
 
 python3 "${VALIDATOR_SCRIPT}"
 

--- a/tests/test_refresh_dashboard_publication.py
+++ b/tests/test_refresh_dashboard_publication.py
@@ -6,6 +6,7 @@ import json
 import shutil
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -68,3 +69,23 @@ def test_failed_run_does_not_auto_refresh() -> None:
     assert result.returncode != 0
     assert not TRIGGER_PATH.exists()
     assert not INVOKE_PATH.exists()
+
+
+def test_refresh_uses_repo_snapshot_generated_at_for_freshness_contract() -> None:
+    _run(["bash", str(REFRESH_SCRIPT)])
+    first_snapshot = json.loads((PUBLIC_ROOT / "repo_snapshot.json").read_text(encoding="utf-8"))
+    first_meta = json.loads((PUBLIC_ROOT / "repo_snapshot_meta.json").read_text(encoding="utf-8"))
+    first_freshness = json.loads((PUBLIC_ROOT / "dashboard_freshness_status.json").read_text(encoding="utf-8"))
+
+    assert first_snapshot["generated_at"] == first_meta["last_refreshed_time"]
+    assert first_snapshot["generated_at"] == first_freshness["snapshot_last_refreshed_time"]
+
+    time.sleep(1.1)
+    _run(["bash", str(REFRESH_SCRIPT)])
+    second_snapshot = json.loads((PUBLIC_ROOT / "repo_snapshot.json").read_text(encoding="utf-8"))
+    second_meta = json.loads((PUBLIC_ROOT / "repo_snapshot_meta.json").read_text(encoding="utf-8"))
+    second_freshness = json.loads((PUBLIC_ROOT / "dashboard_freshness_status.json").read_text(encoding="utf-8"))
+
+    assert second_snapshot["generated_at"] == second_meta["last_refreshed_time"]
+    assert second_snapshot["generated_at"] == second_freshness["snapshot_last_refreshed_time"]
+    assert second_snapshot["generated_at"] != first_snapshot["generated_at"]


### PR DESCRIPTION
### Motivation
- The publication freshness gate must be anchored to the snapshot artifact timestamp so dashboard freshness checks are consistent and deterministic. 
- Root cause: the refresh pipeline used an independent shell `REFRESHED_AT` which could desynchronize `repo_snapshot_meta`/`dashboard_freshness_status` from the actual `repo_snapshot.json.generated_at`. 
- The change preserves dashboard logic and instead ensures the publication pipeline sources its freshness contract from the canonical snapshot `generated_at` field.

### Description
- Read and validate `generated_at` from `artifacts/dashboard/repo_snapshot.json` as a required ISO-8601 UTC string (`YYYY-MM-DDTHH:MM:SSZ`) and fail-closed on missing or malformed values. 
- Use the snapshot-derived timestamp for `repo_snapshot_meta.last_refreshed_time`, `dashboard_freshness_status.generated_at`, `dashboard_freshness_status.snapshot_last_refreshed_time`, audit `published_at`, and manifest `published_at`, replacing the prior independent timestamp. 
- Ensure the refresh pipeline rewrites the snapshot-derived metadata on every run and aborts on contract violations. 
- Files changed: `scripts/refresh_dashboard.sh` (freshness wiring and validation) and `tests/test_refresh_dashboard_publication.py` (regression test `test_refresh_uses_repo_snapshot_generated_at_for_freshness_contract`).

### Testing
- Ran `pytest -q tests/test_refresh_dashboard_publication.py` which exercised the refresh pipeline and the new regression (`test_refresh_uses_repo_snapshot_generated_at_for_freshness_contract`) and returned `4 passed`. 
- Ran `python3 scripts/validate_dashboard_public_artifacts.py` which returned `dashboard-public-artifacts: pass` confirming publication artifacts and manifest integrity. 
- Executed `bash scripts/refresh_dashboard.sh` and confirmed the snapshot timestamp advanced and metadata aligned, for example `before=2026-04-12T18:26:46Z` and `after=2026-04-12T18:27:00Z` with `repo_snapshot_meta.last_refreshed_time` and `dashboard_freshness_status.snapshot_last_refreshed_time` both matching the snapshot `generated_at`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbe369a93083298f761ff6135f8e5f)