### PR TITLE
RDX-001: Implement RDX governance hardening and HNX-10 closeout gate

### DIFF
--- a/contracts/examples/rdx_batch_selection_record.example.json
+++ b/contracts/examples/rdx_batch_selection_record.example.json
@@ -1,0 +1,14 @@
+{
+  "artifact_type": "rdx_batch_selection_record",
+  "record_id": "rbs-001",
+  "roadmap_id": "RM-001",
+  "selected_batch_id": "BATCH-TRUST-01",
+  "selected_umbrella_id": "UMB-TRUST-01",
+  "reason_codes": [
+    "dependency_satisfied",
+    "deterministic_tie_break_applied"
+  ],
+  "trust_gap_tag": "trust-core",
+  "evaluated_at": "2026-04-13T00:00:00Z",
+  "lineage_ref": "lineage:rdx:001"
+}

--- a/contracts/examples/rdx_execution_loop_readiness_handoff_record.example.json
+++ b/contracts/examples/rdx_execution_loop_readiness_handoff_record.example.json
@@ -1,0 +1,14 @@
+{
+  "artifact_type": "rdx_execution_loop_readiness_handoff_record",
+  "record_id": "reh-001",
+  "trace_id": "trace-rdx-001",
+  "selected_batch_id": "BATCH-TRUST-01",
+  "selected_umbrella_id": "UMB-TRUST-01",
+  "lineage_ref": "lineage:rdx:001",
+  "readiness_status": "candidate_only",
+  "non_authority_assertions": [
+    "candidate_only_non_authoritative",
+    "rdx_not_execution_authority"
+  ],
+  "created_at": "2026-04-13T00:00:00Z"
+}

--- a/contracts/examples/rdx_rework_debt_record.example.json
+++ b/contracts/examples/rdx_rework_debt_record.example.json
@@ -1,0 +1,13 @@
+{
+  "artifact_type": "rdx_rework_debt_record",
+  "debt_id": "rrd-001",
+  "trace_id": "trace-rdx-001",
+  "created_at": "2026-04-13T00:00:00Z",
+  "deferred_counts": {
+    "BATCH-TRUST-01": 3
+  },
+  "repeat_rework_batch_ids": [
+    "BATCH-TRUST-01"
+  ],
+  "debt_status": "elevated"
+}

--- a/contracts/examples/rdx_roadmap_governance_bundle.example.json
+++ b/contracts/examples/rdx_roadmap_governance_bundle.example.json
@@ -1,0 +1,20 @@
+{
+  "artifact_type": "rdx_roadmap_governance_bundle",
+  "bundle_id": "rgb-001",
+  "trace_id": "trace-rdx-001",
+  "created_at": "2026-04-13T00:00:00Z",
+  "record_refs": [
+    "rdx_roadmap_selection_record:rrs-001",
+    "rdx_batch_selection_record:rbs-001",
+    "rdx_umbrella_selection_record:rus-001",
+    "rdx_execution_loop_readiness_handoff_record:reh-001",
+    "rdx_selection_eval_result:rse-001",
+    "rdx_selection_readiness_record:rsr-001",
+    "rdx_selection_effectiveness_record:rseff-001",
+    "rdx_rework_debt_record:rrd-001"
+  ],
+  "non_authority_assertions": [
+    "bundle_controls_progression_only",
+    "does_not_replace_cde_closure_authority"
+  ]
+}

--- a/contracts/examples/rdx_roadmap_selection_record.example.json
+++ b/contracts/examples/rdx_roadmap_selection_record.example.json
@@ -1,0 +1,12 @@
+{
+  "artifact_type": "rdx_roadmap_selection_record",
+  "record_id": "rrs-001",
+  "roadmap_id": "RM-001",
+  "selected_umbrella_id": "UMB-TRUST-01",
+  "reason_codes": [
+    "dependency_satisfied",
+    "trust_gap_priority_applied"
+  ],
+  "evaluated_at": "2026-04-13T00:00:00Z",
+  "lineage_ref": "lineage:rdx:001"
+}

--- a/contracts/examples/rdx_selection_conflict_record.example.json
+++ b/contracts/examples/rdx_selection_conflict_record.example.json
@@ -1,0 +1,9 @@
+{
+  "artifact_type": "rdx_selection_conflict_record",
+  "conflict_id": "rconf-001",
+  "trace_id": "trace-rdx-001",
+  "created_at": "2026-04-13T00:00:00Z",
+  "conflict_codes": [
+    "trust_gap_priority_inverted"
+  ]
+}

--- a/contracts/examples/rdx_selection_effectiveness_record.example.json
+++ b/contracts/examples/rdx_selection_effectiveness_record.example.json
@@ -1,0 +1,11 @@
+{
+  "artifact_type": "rdx_selection_effectiveness_record",
+  "effectiveness_id": "rseff-001",
+  "window_id": "WIN-001",
+  "created_at": "2026-04-13T00:00:00Z",
+  "runs_evaluated": 5,
+  "trust_gap_closure_rate": 0.8,
+  "dependency_violation_rate": 0.0,
+  "rework_rate": 0.2,
+  "value_status": "improving"
+}

--- a/contracts/examples/rdx_selection_eval_result.example.json
+++ b/contracts/examples/rdx_selection_eval_result.example.json
@@ -1,0 +1,16 @@
+{
+  "artifact_type": "rdx_selection_eval_result",
+  "eval_id": "rse-001",
+  "selection_ref": "rdx_batch_selection_record:rbs-001",
+  "evaluated_at": "2026-04-13T00:00:00Z",
+  "evaluation_status": "pass",
+  "checks": {
+    "required_evidence_present": true,
+    "dependency_valid": true,
+    "owner_valid": true,
+    "trust_gap_priority_aligned": true,
+    "hierarchy_valid": true
+  },
+  "fail_reasons": [],
+  "trace_id": "trace-rdx-001"
+}

--- a/contracts/examples/rdx_selection_readiness_record.example.json
+++ b/contracts/examples/rdx_selection_readiness_record.example.json
@@ -1,0 +1,12 @@
+{
+  "artifact_type": "rdx_selection_readiness_record",
+  "readiness_id": "rsr-001",
+  "trace_id": "trace-rdx-001",
+  "created_at": "2026-04-13T00:00:00Z",
+  "readiness_status": "candidate_only",
+  "fail_reasons": [],
+  "non_authority_assertions": [
+    "candidate_only_non_authoritative",
+    "rdx_not_closure_authority"
+  ]
+}

--- a/contracts/examples/rdx_umbrella_selection_record.example.json
+++ b/contracts/examples/rdx_umbrella_selection_record.example.json
@@ -1,0 +1,16 @@
+{
+  "artifact_type": "rdx_umbrella_selection_record",
+  "record_id": "rus-001",
+  "roadmap_id": "RM-001",
+  "selected_umbrella_id": "UMB-TRUST-01",
+  "batch_ids": [
+    "BATCH-TRUST-01",
+    "BATCH-TRUST-02"
+  ],
+  "reason_codes": [
+    "umbrella_active",
+    "minimum_cardinality_satisfied"
+  ],
+  "evaluated_at": "2026-04-13T00:00:00Z",
+  "lineage_ref": "lineage:rdx:001"
+}

--- a/contracts/schemas/rdx_batch_selection_record.schema.json
+++ b/contracts/schemas/rdx_batch_selection_record.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/rdx_batch_selection_record.schema.json",
+  "title": "Rdx Batch Selection Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "record_id",
+    "roadmap_id",
+    "selected_batch_id",
+    "selected_umbrella_id",
+    "reason_codes",
+    "trust_gap_tag",
+    "evaluated_at",
+    "lineage_ref"
+  ],
+  "properties": {
+    "artifact_type": {
+      "type": "string",
+      "const": "rdx_batch_selection_record"
+    },
+    "record_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "roadmap_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "selected_batch_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "selected_umbrella_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "reason_codes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string"
+      }
+    },
+    "trust_gap_tag": {
+      "type": "string",
+      "minLength": 1
+    },
+    "evaluated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "lineage_ref": {
+      "type": "string",
+      "minLength": 1
+    }
+  }
+}

--- a/contracts/schemas/rdx_execution_loop_readiness_handoff_record.schema.json
+++ b/contracts/schemas/rdx_execution_loop_readiness_handoff_record.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/rdx_execution_loop_readiness_handoff_record.schema.json",
+  "title": "Rdx Execution Loop Readiness Handoff Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "record_id",
+    "trace_id",
+    "selected_batch_id",
+    "selected_umbrella_id",
+    "lineage_ref",
+    "readiness_status",
+    "non_authority_assertions",
+    "created_at"
+  ],
+  "properties": {
+    "artifact_type": {
+      "type": "string",
+      "const": "rdx_execution_loop_readiness_handoff_record"
+    },
+    "record_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "selected_batch_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "selected_umbrella_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "lineage_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "readiness_status": {
+      "enum": [
+        "candidate_only",
+        "blocked"
+      ]
+    },
+    "non_authority_assertions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string"
+      }
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}

--- a/contracts/schemas/rdx_rework_debt_record.schema.json
+++ b/contracts/schemas/rdx_rework_debt_record.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/rdx_rework_debt_record.schema.json",
+  "title": "Rdx Rework Debt Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "debt_id",
+    "trace_id",
+    "created_at",
+    "deferred_counts",
+    "repeat_rework_batch_ids",
+    "debt_status"
+  ],
+  "properties": {
+    "artifact_type": {
+      "type": "string",
+      "const": "rdx_rework_debt_record"
+    },
+    "debt_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "deferred_counts": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "integer",
+        "minimum": 1
+      }
+    },
+    "repeat_rework_batch_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "debt_status": {
+      "enum": [
+        "normal",
+        "elevated"
+      ]
+    }
+  }
+}

--- a/contracts/schemas/rdx_roadmap_governance_bundle.schema.json
+++ b/contracts/schemas/rdx_roadmap_governance_bundle.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/rdx_roadmap_governance_bundle.schema.json",
+  "title": "Rdx Roadmap Governance Bundle",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "bundle_id",
+    "trace_id",
+    "created_at",
+    "record_refs",
+    "non_authority_assertions"
+  ],
+  "properties": {
+    "artifact_type": {
+      "type": "string",
+      "const": "rdx_roadmap_governance_bundle"
+    },
+    "bundle_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "record_refs": {
+      "type": "array",
+      "minItems": 4,
+      "items": {
+        "type": "string"
+      }
+    },
+    "non_authority_assertions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/contracts/schemas/rdx_roadmap_selection_record.schema.json
+++ b/contracts/schemas/rdx_roadmap_selection_record.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/rdx_roadmap_selection_record.schema.json",
+  "title": "Rdx Roadmap Selection Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "record_id",
+    "roadmap_id",
+    "selected_umbrella_id",
+    "reason_codes",
+    "evaluated_at",
+    "lineage_ref"
+  ],
+  "properties": {
+    "artifact_type": {
+      "type": "string",
+      "const": "rdx_roadmap_selection_record"
+    },
+    "record_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "roadmap_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "selected_umbrella_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "reason_codes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string"
+      }
+    },
+    "evaluated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "lineage_ref": {
+      "type": "string",
+      "minLength": 1
+    }
+  }
+}

--- a/contracts/schemas/rdx_selection_conflict_record.schema.json
+++ b/contracts/schemas/rdx_selection_conflict_record.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/rdx_selection_conflict_record.schema.json",
+  "title": "Rdx Selection Conflict Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "conflict_id",
+    "trace_id",
+    "created_at",
+    "conflict_codes"
+  ],
+  "properties": {
+    "artifact_type": {
+      "type": "string",
+      "const": "rdx_selection_conflict_record"
+    },
+    "conflict_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "conflict_codes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/contracts/schemas/rdx_selection_effectiveness_record.schema.json
+++ b/contracts/schemas/rdx_selection_effectiveness_record.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/rdx_selection_effectiveness_record.schema.json",
+  "title": "Rdx Selection Effectiveness Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "effectiveness_id",
+    "window_id",
+    "created_at",
+    "runs_evaluated",
+    "trust_gap_closure_rate",
+    "dependency_violation_rate",
+    "rework_rate",
+    "value_status"
+  ],
+  "properties": {
+    "artifact_type": {
+      "type": "string",
+      "const": "rdx_selection_effectiveness_record"
+    },
+    "effectiveness_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "window_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "runs_evaluated": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "trust_gap_closure_rate": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "dependency_violation_rate": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "rework_rate": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "value_status": {
+      "enum": [
+        "improving",
+        "degraded",
+        "flat"
+      ]
+    }
+  }
+}

--- a/contracts/schemas/rdx_selection_eval_result.schema.json
+++ b/contracts/schemas/rdx_selection_eval_result.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/rdx_selection_eval_result.schema.json",
+  "title": "Rdx Selection Eval Result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "eval_id",
+    "selection_ref",
+    "evaluated_at",
+    "evaluation_status",
+    "checks",
+    "fail_reasons",
+    "trace_id"
+  ],
+  "properties": {
+    "artifact_type": {
+      "type": "string",
+      "const": "rdx_selection_eval_result"
+    },
+    "eval_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "selection_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "evaluated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "evaluation_status": {
+      "enum": [
+        "pass",
+        "fail"
+      ]
+    },
+    "checks": {
+      "type": "object"
+    },
+    "fail_reasons": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    }
+  }
+}

--- a/contracts/schemas/rdx_selection_readiness_record.schema.json
+++ b/contracts/schemas/rdx_selection_readiness_record.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/rdx_selection_readiness_record.schema.json",
+  "title": "Rdx Selection Readiness Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "readiness_id",
+    "trace_id",
+    "created_at",
+    "readiness_status",
+    "fail_reasons",
+    "non_authority_assertions"
+  ],
+  "properties": {
+    "artifact_type": {
+      "type": "string",
+      "const": "rdx_selection_readiness_record"
+    },
+    "readiness_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "readiness_status": {
+      "enum": [
+        "candidate_only",
+        "blocked"
+      ]
+    },
+    "fail_reasons": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "non_authority_assertions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/contracts/schemas/rdx_umbrella_selection_record.schema.json
+++ b/contracts/schemas/rdx_umbrella_selection_record.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/rdx_umbrella_selection_record.schema.json",
+  "title": "Rdx Umbrella Selection Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "record_id",
+    "roadmap_id",
+    "selected_umbrella_id",
+    "batch_ids",
+    "reason_codes",
+    "evaluated_at",
+    "lineage_ref"
+  ],
+  "properties": {
+    "artifact_type": {
+      "type": "string",
+      "const": "rdx_umbrella_selection_record"
+    },
+    "record_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "roadmap_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "selected_umbrella_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "batch_ids": {
+      "type": "array",
+      "minItems": 2,
+      "items": {
+        "type": "string"
+      }
+    },
+    "reason_codes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string"
+      }
+    },
+    "evaluated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "lineage_ref": {
+      "type": "string",
+      "minLength": 1
+    }
+  }
+}

--- a/contracts/standards-manifest.json
+++ b/contracts/standards-manifest.json
@@ -1,9 +1,9 @@
 {
   "artifact_type": "standards_manifest",
   "artifact_id": "STD-CONTRACTS",
-  "artifact_version": "1.3.121",
+  "artifact_version": "1.3.122",
   "schema_version": "1.3.98",
-  "standards_version": "1.3.121",
+  "standards_version": "1.3.122",
   "record_id": "REC-STD-2026-04-12-TLC-001",
   "run_id": "run-20260412T220000Z-tlc-001",
   "created_at": "2026-04-12T00:00:00Z",
@@ -15,7 +15,7 @@
     "contact": "architecture@spectrum-systems.test"
   },
   "source_repo": "nicklasorte/spectrum-systems",
-  "source_repo_version": "1.3.120",
+  "source_repo_version": "1.3.121",
   "input_artifacts": [
     {
       "artifact_id": "STD-CONTRACTS",
@@ -6277,6 +6277,136 @@
       "last_updated_in": "1.0.82",
       "example_path": "contracts/examples/xrun_signal_quality_result.json",
       "notes": "VAL-06 governed validation artifact proving deterministic XRUN-01 pattern/action/signal quality and fail-closed handling under insufficient/malformed inputs."
+    },
+    {
+      "artifact_type": "rdx_roadmap_selection_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.122",
+      "last_updated_in": "1.3.122",
+      "example_path": "contracts/examples/rdx_roadmap_selection_record.example.json",
+      "notes": "RDX bounded roadmap-governance hardening contract for deterministic selection, eval, replay, readiness, and fail-closed integrity checks."
+    },
+    {
+      "artifact_type": "rdx_batch_selection_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.122",
+      "last_updated_in": "1.3.122",
+      "example_path": "contracts/examples/rdx_batch_selection_record.example.json",
+      "notes": "RDX bounded roadmap-governance hardening contract for deterministic selection, eval, replay, readiness, and fail-closed integrity checks."
+    },
+    {
+      "artifact_type": "rdx_umbrella_selection_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.122",
+      "last_updated_in": "1.3.122",
+      "example_path": "contracts/examples/rdx_umbrella_selection_record.example.json",
+      "notes": "RDX bounded roadmap-governance hardening contract for deterministic selection, eval, replay, readiness, and fail-closed integrity checks."
+    },
+    {
+      "artifact_type": "rdx_execution_loop_readiness_handoff_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.122",
+      "last_updated_in": "1.3.122",
+      "example_path": "contracts/examples/rdx_execution_loop_readiness_handoff_record.example.json",
+      "notes": "RDX bounded roadmap-governance hardening contract for deterministic selection, eval, replay, readiness, and fail-closed integrity checks."
+    },
+    {
+      "artifact_type": "rdx_selection_eval_result",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.122",
+      "last_updated_in": "1.3.122",
+      "example_path": "contracts/examples/rdx_selection_eval_result.example.json",
+      "notes": "RDX bounded roadmap-governance hardening contract for deterministic selection, eval, replay, readiness, and fail-closed integrity checks."
+    },
+    {
+      "artifact_type": "rdx_selection_conflict_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.122",
+      "last_updated_in": "1.3.122",
+      "example_path": "contracts/examples/rdx_selection_conflict_record.example.json",
+      "notes": "RDX bounded roadmap-governance hardening contract for deterministic selection, eval, replay, readiness, and fail-closed integrity checks."
+    },
+    {
+      "artifact_type": "rdx_selection_readiness_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.122",
+      "last_updated_in": "1.3.122",
+      "example_path": "contracts/examples/rdx_selection_readiness_record.example.json",
+      "notes": "RDX bounded roadmap-governance hardening contract for deterministic selection, eval, replay, readiness, and fail-closed integrity checks."
+    },
+    {
+      "artifact_type": "rdx_selection_effectiveness_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.122",
+      "last_updated_in": "1.3.122",
+      "example_path": "contracts/examples/rdx_selection_effectiveness_record.example.json",
+      "notes": "RDX bounded roadmap-governance hardening contract for deterministic selection, eval, replay, readiness, and fail-closed integrity checks."
+    },
+    {
+      "artifact_type": "rdx_rework_debt_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.122",
+      "last_updated_in": "1.3.122",
+      "example_path": "contracts/examples/rdx_rework_debt_record.example.json",
+      "notes": "RDX bounded roadmap-governance hardening contract for deterministic selection, eval, replay, readiness, and fail-closed integrity checks."
+    },
+    {
+      "artifact_type": "rdx_roadmap_governance_bundle",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.122",
+      "last_updated_in": "1.3.122",
+      "example_path": "contracts/examples/rdx_roadmap_governance_bundle.example.json",
+      "notes": "RDX bounded roadmap-governance hardening contract for deterministic selection, eval, replay, readiness, and fail-closed integrity checks."
     }
   ]
 }

--- a/docs/review-actions/PLAN-RDX-001-2026-04-13.md
+++ b/docs/review-actions/PLAN-RDX-001-2026-04-13.md
@@ -1,0 +1,60 @@
+# Plan — RDX-001 — 2026-04-13
+
+## Prompt type
+BUILD
+
+## Roadmap item
+RDX-001 + HNX-10 closeout gate hardening
+
+## Objective
+Implement a bounded, deterministic RDX governance hardening surface with contract-backed artifacts, replay/eval/readiness/effectiveness coverage, and explicit RT1/RT2 fix-loop regression enforcement while verifying HNX closeout gate readiness.
+
+## Declared files
+
+| File | Change type | Reason |
+| --- | --- | --- |
+| docs/review-actions/PLAN-RDX-001-2026-04-13.md | CREATE | Required plan-first artifact for multi-file governed implementation |
+| spectrum_systems/modules/runtime/rdx_hardening.py | CREATE | RDX deterministic governance hardening logic and red-team fix loop |
+| spectrum_systems/modules/runtime/hnx_hardening.py | MODIFY | Add explicit HNX-10 closeout gate verification helper |
+| tests/test_rdx_hardening.py | CREATE | Deterministic tests for RDX-01..RDX-FX2 logic and regressions |
+| tests/test_hnx_hardening.py | MODIFY | Add HNX-10 closeout gate operational test |
+| contracts/schemas/rdx_roadmap_selection_record.schema.json | CREATE | RDX-01 boundary contract |
+| contracts/schemas/rdx_batch_selection_record.schema.json | CREATE | RDX-01 boundary contract |
+| contracts/schemas/rdx_umbrella_selection_record.schema.json | CREATE | RDX-01 boundary contract |
+| contracts/schemas/rdx_execution_loop_readiness_handoff_record.schema.json | CREATE | RDX-01 boundary contract |
+| contracts/schemas/rdx_selection_eval_result.schema.json | CREATE | RDX-04 eval artifact contract |
+| contracts/schemas/rdx_selection_conflict_record.schema.json | CREATE | RDX conflict artifact contract |
+| contracts/schemas/rdx_selection_readiness_record.schema.json | CREATE | RDX-05 readiness contract |
+| contracts/schemas/rdx_selection_effectiveness_record.schema.json | CREATE | RDX-09 effectiveness contract |
+| contracts/schemas/rdx_rework_debt_record.schema.json | CREATE | RDX-08C debt tracker contract |
+| contracts/schemas/rdx_roadmap_governance_bundle.schema.json | CREATE | RDX bundle contract |
+| contracts/examples/rdx_roadmap_selection_record.example.json | CREATE | Canonical governed example |
+| contracts/examples/rdx_batch_selection_record.example.json | CREATE | Canonical governed example |
+| contracts/examples/rdx_umbrella_selection_record.example.json | CREATE | Canonical governed example |
+| contracts/examples/rdx_execution_loop_readiness_handoff_record.example.json | CREATE | Canonical governed example |
+| contracts/examples/rdx_selection_eval_result.example.json | CREATE | Canonical governed example |
+| contracts/examples/rdx_selection_conflict_record.example.json | CREATE | Canonical governed example |
+| contracts/examples/rdx_selection_readiness_record.example.json | CREATE | Canonical governed example |
+| contracts/examples/rdx_selection_effectiveness_record.example.json | CREATE | Canonical governed example |
+| contracts/examples/rdx_rework_debt_record.example.json | CREATE | Canonical governed example |
+| contracts/examples/rdx_roadmap_governance_bundle.example.json | CREATE | Canonical governed example |
+| contracts/standards-manifest.json | MODIFY | Publish schema versions for new RDX contracts |
+| tests/test_contracts.py | MODIFY | Validate new RDX contract examples |
+
+## Contracts touched
+rdx_roadmap_selection_record, rdx_batch_selection_record, rdx_umbrella_selection_record, rdx_execution_loop_readiness_handoff_record, rdx_selection_eval_result, rdx_selection_conflict_record, rdx_selection_readiness_record, rdx_selection_effectiveness_record, rdx_rework_debt_record, rdx_roadmap_governance_bundle, standards_manifest version bump.
+
+## Tests that must pass after execution
+1. `pytest tests/test_rdx_hardening.py -q`
+2. `pytest tests/test_hnx_hardening.py -q`
+3. `pytest tests/test_contracts.py -k "rdx_contract_examples_validate or hnx" -q`
+4. `pytest tests/test_contract_enforcement.py -q`
+5. `python scripts/run_contract_enforcement.py`
+
+## Scope exclusions
+- Do not refactor unrelated runtime systems.
+- Do not alter role ownership definitions in the system registry.
+- Do not change PQX/TLC/CDE authority behavior outside RDX/HNX boundary checks.
+
+## Dependencies
+- Existing HNX hardening and RDX roadmap selection foundation already present in repository.

--- a/spectrum_systems/modules/runtime/hnx_hardening.py
+++ b/spectrum_systems/modules/runtime/hnx_hardening.py
@@ -277,3 +277,16 @@ def build_hnx_conflict_record(*, run_id: str, trace_id: str, conflict_codes: lis
     }
     validate_artifact(artifact, "hnx_harness_conflict_record")
     return artifact
+
+
+def verify_hnx_closeout_gate(*, harness_eval: Mapping[str, Any], readiness: Mapping[str, Any], replay_match: bool, stop_failures: list[str], checkpoint_resume_failures: list[str]) -> dict[str, Any]:
+    """HNX-10 closeout gate proving checkpoint/resume, stop-guard, replay, and continuity are operationally real."""
+    checks = {
+        "checkpoint_resume_integrity": not checkpoint_resume_failures,
+        "stop_condition_integrity": not stop_failures,
+        "harness_replay_valid": replay_match is True,
+        "continuity_semantics_real": harness_eval.get("evaluation_status") == "pass",
+        "hnx_bounded_scope_preserved": "does_not_replace_pqx_execution_authority" in readiness.get("non_authority_assertions", []),
+    }
+    fail_reasons = [name for name, passed in checks.items() if not passed]
+    return {"closeout_status": "closed" if not fail_reasons else "open", "checks": checks, "fail_reasons": fail_reasons}

--- a/spectrum_systems/modules/runtime/rdx_hardening.py
+++ b/spectrum_systems/modules/runtime/rdx_hardening.py
@@ -1,0 +1,449 @@
+"""RDX bounded roadmap-governance hardening with deterministic selection, eval, replay, and red-team fix loops."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import Counter
+from typing import Any, Mapping
+
+from spectrum_systems.contracts import validate_artifact
+
+
+class RDXHardeningError(ValueError):
+    """Raised when RDX hardening checks fail closed."""
+
+
+_FORBIDDEN_ACTION_PREFIXES = (
+    "execute_work",
+    "route_subsystem",
+    "issue_closure",
+    "issue_policy",
+    "reinterpret_review",
+    "generate_repair_plan",
+    "enforce_runtime_action",
+    "adoption_priority",
+)
+
+
+def _hash(payload: Any) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def enforce_rdx_boundary(*, consumed_inputs: list[str], emitted_outputs: list[str], claimed_actions: list[str]) -> list[str]:
+    allowed_inputs = {
+        "roadmap_artifact",
+        "roadmap_signal_bundle",
+        "trust_gap_signals",
+        "dependency_graph",
+        "batch_completion_evidence",
+        "umbrella_completion_evidence",
+        "execution_loop_readiness_inputs",
+    }
+    allowed_outputs = {
+        "rdx_roadmap_selection_record",
+        "rdx_batch_selection_record",
+        "rdx_umbrella_selection_record",
+        "rdx_execution_loop_readiness_handoff_record",
+        "rdx_selection_eval_result",
+        "rdx_selection_conflict_record",
+        "rdx_selection_readiness_record",
+        "rdx_selection_effectiveness_record",
+        "rdx_rework_debt_record",
+        "rdx_roadmap_governance_bundle",
+    }
+    failures: list[str] = []
+    for name in consumed_inputs:
+        if name not in allowed_inputs:
+            failures.append(f"invalid_upstream_input:{name}")
+    for name in emitted_outputs:
+        if name not in allowed_outputs:
+            failures.append(f"invalid_downstream_output:{name}")
+    for action in claimed_actions:
+        if action.startswith(_FORBIDDEN_ACTION_PREFIXES):
+            failures.append(f"forbidden_owner_overlap:{action}")
+    return sorted(set(failures))
+
+
+def select_next_governed_batch(*, roadmap: Mapping[str, Any], trust_gap_priority: list[str], now: str) -> dict[str, Any]:
+    batches = roadmap.get("batches")
+    if not isinstance(batches, list) or not batches:
+        raise RDXHardeningError("roadmap_batches_required")
+
+    status_by_id = {str(b.get("batch_id")): str(b.get("status")) for b in batches if isinstance(b, Mapping)}
+    eligible: list[dict[str, Any]] = []
+    reasons: list[str] = []
+
+    for batch in batches:
+        if not isinstance(batch, Mapping):
+            continue
+        batch_id = str(batch.get("batch_id") or "")
+        if not batch_id or str(batch.get("status")) != "not_started":
+            continue
+        deps = batch.get("depends_on", [])
+        if not isinstance(deps, list):
+            raise RDXHardeningError(f"depends_on_list_required:{batch_id}")
+        unmet = [dep for dep in deps if status_by_id.get(str(dep)) != "completed"]
+        if unmet:
+            reasons.append(f"dependency_unmet:{batch_id}:{','.join(sorted(str(d) for d in unmet))}")
+            continue
+        trust_tag = str(batch.get("trust_gap_tag") or "")
+        priority_rank = trust_gap_priority.index(trust_tag) if trust_tag in trust_gap_priority else len(trust_gap_priority) + 99
+        eligible.append(
+            {
+                "batch_id": batch_id,
+                "umbrella_id": str(batch.get("umbrella_id") or "UNKNOWN"),
+                "priority_rank": priority_rank,
+                "base_priority": int(batch.get("priority") or 9999),
+                "trust_gap_tag": trust_tag,
+            }
+        )
+
+    if not eligible:
+        raise RDXHardeningError("no_eligible_batch")
+
+    selected = sorted(eligible, key=lambda row: (row["priority_rank"], row["base_priority"], row["batch_id"]))[0]
+    record = {
+        "artifact_type": "rdx_batch_selection_record",
+        "record_id": f"rbs-{_hash([roadmap.get('roadmap_id'), selected['batch_id'], now])[:16]}",
+        "roadmap_id": str(roadmap.get("roadmap_id") or "unknown"),
+        "selected_batch_id": selected["batch_id"],
+        "selected_umbrella_id": selected["umbrella_id"],
+        "reason_codes": ["dependency_satisfied", "trust_gap_priority_applied", "deterministic_tie_break_applied"],
+        "trust_gap_tag": selected["trust_gap_tag"],
+        "evaluated_at": now,
+        "lineage_ref": str(roadmap.get("lineage_ref") or "lineage:unknown"),
+    }
+    validate_artifact(record, "rdx_batch_selection_record")
+    return record
+
+
+def build_roadmap_selection_record(*, roadmap: Mapping[str, Any], selected_umbrella_id: str, reason_codes: list[str], evaluated_at: str) -> dict[str, Any]:
+    record = {
+        "artifact_type": "rdx_roadmap_selection_record",
+        "record_id": f"rrs-{_hash([roadmap.get('roadmap_id'), selected_umbrella_id, evaluated_at])[:16]}",
+        "roadmap_id": str(roadmap.get("roadmap_id") or "unknown"),
+        "selected_umbrella_id": selected_umbrella_id,
+        "reason_codes": sorted(set(reason_codes)),
+        "evaluated_at": evaluated_at,
+        "lineage_ref": str(roadmap.get("lineage_ref") or "lineage:unknown"),
+    }
+    validate_artifact(record, "rdx_roadmap_selection_record")
+    return record
+
+
+def build_umbrella_selection_record(*, roadmap: Mapping[str, Any], selected_umbrella_id: str, evaluated_at: str) -> dict[str, Any]:
+    umbrellas = [u for u in roadmap.get("umbrellas", []) if isinstance(u, Mapping)]
+    row = next((u for u in umbrellas if str(u.get("umbrella_id")) == selected_umbrella_id), None)
+    if not row:
+        raise RDXHardeningError("selected_umbrella_not_found")
+    batch_ids = row.get("batch_ids", [])
+    if not isinstance(batch_ids, list) or len(batch_ids) < 2:
+        raise RDXHardeningError("selected_umbrella_invalid_cardinality")
+    record = {
+        "artifact_type": "rdx_umbrella_selection_record",
+        "record_id": f"rus-{_hash([roadmap.get('roadmap_id'), selected_umbrella_id, evaluated_at])[:16]}",
+        "roadmap_id": str(roadmap.get("roadmap_id") or "unknown"),
+        "selected_umbrella_id": selected_umbrella_id,
+        "batch_ids": [str(v) for v in batch_ids],
+        "reason_codes": ["umbrella_active", "minimum_cardinality_satisfied"],
+        "evaluated_at": evaluated_at,
+        "lineage_ref": str(roadmap.get("lineage_ref") or "lineage:unknown"),
+    }
+    validate_artifact(record, "rdx_umbrella_selection_record")
+    return record
+
+
+def build_execution_loop_readiness_handoff(*, trace_id: str, selected_batch_id: str, selected_umbrella_id: str, lineage_ref: str, readiness_status: str, created_at: str) -> dict[str, Any]:
+    record = {
+        "artifact_type": "rdx_execution_loop_readiness_handoff_record",
+        "record_id": f"reh-{_hash([trace_id, selected_batch_id, created_at])[:16]}",
+        "trace_id": trace_id,
+        "selected_batch_id": selected_batch_id,
+        "selected_umbrella_id": selected_umbrella_id,
+        "lineage_ref": lineage_ref,
+        "readiness_status": readiness_status,
+        "non_authority_assertions": ["candidate_only_non_authoritative", "rdx_not_execution_authority"],
+        "created_at": created_at,
+    }
+    validate_artifact(record, "rdx_execution_loop_readiness_handoff_record")
+    return record
+
+
+def evaluate_selection(*, roadmap: Mapping[str, Any], selection_record: Mapping[str, Any], owner: str, trust_gap_priority: list[str], evaluated_at: str) -> dict[str, Any]:
+    checks = {
+        "required_evidence_present": bool(roadmap.get("dependency_graph_ref")) and bool(roadmap.get("trust_signal_ref")),
+        "dependency_valid": True,
+        "owner_valid": owner == "RDX",
+        "trust_gap_priority_aligned": True,
+        "hierarchy_valid": True,
+    }
+    fail_reasons: list[str] = []
+    selected = str(selection_record.get("selected_batch_id") or "")
+    batches = [b for b in roadmap.get("batches", []) if isinstance(b, Mapping)]
+    by_id = {str(b.get("batch_id")): b for b in batches}
+    batch = by_id.get(selected)
+    if not batch:
+        checks["dependency_valid"] = False
+        checks["hierarchy_valid"] = False
+        fail_reasons.append("selected_batch_missing")
+    else:
+        deps = batch.get("depends_on", [])
+        if not isinstance(deps, list):
+            checks["dependency_valid"] = False
+            fail_reasons.append("selected_batch_depends_on_invalid")
+        else:
+            unmet = [d for d in deps if str(by_id.get(str(d), {}).get("status")) != "completed"]
+            if unmet:
+                checks["dependency_valid"] = False
+                fail_reasons.append("selected_batch_dependency_unmet")
+
+        selected_tag = str(batch.get("trust_gap_tag") or "")
+        unresolved_tags = sorted(
+            {
+                str(row.get("trust_gap_tag"))
+                for row in batches
+                if str(row.get("status")) == "not_started" and isinstance(row.get("trust_gap_tag"), str)
+            }
+        )
+        expected_top = next((tag for tag in trust_gap_priority if tag in unresolved_tags), None)
+        if expected_top and selected_tag != expected_top:
+            checks["trust_gap_priority_aligned"] = False
+            fail_reasons.append("trust_gap_priority_inverted")
+
+    umbrellas = roadmap.get("umbrellas", [])
+    if not isinstance(umbrellas, list):
+        checks["hierarchy_valid"] = False
+        fail_reasons.append("umbrellas_missing")
+    else:
+        for umb in umbrellas:
+            if not isinstance(umb, Mapping):
+                checks["hierarchy_valid"] = False
+                fail_reasons.append("umbrella_row_invalid")
+                continue
+            batch_ids = umb.get("batch_ids", [])
+            if not isinstance(batch_ids, list) or len(batch_ids) < 2:
+                checks["hierarchy_valid"] = False
+                fail_reasons.append("invalid_single_batch_umbrella")
+            if isinstance(batch_ids, list) and len(batch_ids) == 1 and str(batch_ids[0]) == str(umb.get("umbrella_id")):
+                checks["hierarchy_valid"] = False
+                fail_reasons.append("pass_through_wrapper_detected")
+
+    for batch_row in batches:
+        slice_ids = batch_row.get("slice_ids", [])
+        if isinstance(slice_ids, list) and len(slice_ids) < 2:
+            checks["hierarchy_valid"] = False
+            fail_reasons.append("invalid_single_slice_batch")
+
+    eval_result = {
+        "artifact_type": "rdx_selection_eval_result",
+        "eval_id": f"rse-{_hash([selection_record.get('record_id'), checks, evaluated_at])[:16]}",
+        "selection_ref": f"rdx_batch_selection_record:{selection_record.get('record_id')}",
+        "evaluated_at": evaluated_at,
+        "evaluation_status": "pass" if not fail_reasons else "fail",
+        "checks": checks,
+        "fail_reasons": sorted(set(fail_reasons)),
+        "trace_id": str(roadmap.get("trace_id") or "trace:unknown"),
+    }
+    validate_artifact(eval_result, "rdx_selection_eval_result")
+    return eval_result
+
+
+def validate_selection_replay(*, prior_input: Mapping[str, Any], replay_input: Mapping[str, Any], prior_selection: Mapping[str, Any], replay_selection: Mapping[str, Any], prior_eval: Mapping[str, Any], replay_eval: Mapping[str, Any]) -> tuple[bool, list[str]]:
+    failures: list[str] = []
+    if _hash(prior_input) != _hash(replay_input):
+        failures.append("replay_input_drift")
+    if prior_selection.get("selected_batch_id") != replay_selection.get("selected_batch_id"):
+        failures.append("replay_selected_batch_mismatch")
+    if prior_selection.get("reason_codes") != replay_selection.get("reason_codes"):
+        failures.append("replay_reason_code_mismatch")
+    if prior_eval.get("fail_reasons") != replay_eval.get("fail_reasons"):
+        failures.append("replay_eval_mismatch")
+    if not prior_input.get("dependency_graph_ref") or not replay_input.get("dependency_graph_ref"):
+        failures.append("replay_evidence_incomplete")
+    return (not failures, sorted(set(failures)))
+
+
+def validate_progression_vs_closure(*, progression_refs: list[str], closure_refs: list[str], non_authority_assertions: list[str]) -> list[str]:
+    failures: list[str] = []
+    if any(ref.startswith("closure_decision_artifact:") for ref in progression_refs):
+        failures.append("progression_contains_closure_artifact")
+    if any(ref.startswith("promotion_readiness_decision:") for ref in progression_refs):
+        failures.append("progression_contains_promotion_artifact")
+    if any(ref.startswith("rdx_") for ref in closure_refs):
+        failures.append("closure_flow_consumes_rdx_progression_artifact")
+    if "rdx_not_closure_authority" not in non_authority_assertions:
+        failures.append("missing_non_authority_assertion")
+    return sorted(set(failures))
+
+
+def detect_pass_through_wrappers(*, roadmap: Mapping[str, Any]) -> list[str]:
+    fails: list[str] = []
+    for batch in roadmap.get("batches", []):
+        if isinstance(batch, Mapping):
+            batch_id = str(batch.get("batch_id") or "")
+            slice_ids = batch.get("slice_ids", [])
+            if isinstance(slice_ids, list) and len(slice_ids) == 1:
+                only = str(slice_ids[0])
+                if only == batch_id or only.startswith("BATCH-"):
+                    fails.append(f"batch_pass_through_wrapper:{batch_id}")
+    for umb in roadmap.get("umbrellas", []):
+        if isinstance(umb, Mapping):
+            umbrella_id = str(umb.get("umbrella_id") or "")
+            batch_ids = umb.get("batch_ids", [])
+            if isinstance(batch_ids, list) and len(batch_ids) == 1:
+                only = str(batch_ids[0])
+                if only == umbrella_id or only.startswith("UMB-"):
+                    fails.append(f"umbrella_pass_through_wrapper:{umbrella_id}")
+    return sorted(set(fails))
+
+
+def build_rework_debt_record(*, selection_history: list[Mapping[str, Any]], created_at: str, trace_id: str) -> dict[str, Any]:
+    counter: Counter[str] = Counter()
+    for row in selection_history:
+        for batch_id in row.get("deferred_batch_ids", []):
+            counter[str(batch_id)] += 1
+    repeated = sorted([batch for batch, count in counter.items() if count >= 3])
+    artifact = {
+        "artifact_type": "rdx_rework_debt_record",
+        "debt_id": f"rrd-{_hash([trace_id, sorted(counter.items())])[:16]}",
+        "trace_id": trace_id,
+        "created_at": created_at,
+        "deferred_counts": {k: int(v) for k, v in sorted(counter.items())},
+        "repeat_rework_batch_ids": repeated,
+        "debt_status": "elevated" if repeated else "normal",
+    }
+    validate_artifact(artifact, "rdx_rework_debt_record")
+    return artifact
+
+
+def validate_selection_to_tlc_integrity(*, handoff_record: Mapping[str, Any], tlc_input: Mapping[str, Any]) -> list[str]:
+    failures: list[str] = []
+    if handoff_record.get("selected_batch_id") != tlc_input.get("selected_batch_id"):
+        failures.append("selected_batch_drift")
+    if handoff_record.get("selected_umbrella_id") != tlc_input.get("selected_umbrella_id"):
+        failures.append("selected_umbrella_drift")
+    if handoff_record.get("lineage_ref") != tlc_input.get("lineage_ref"):
+        failures.append("lineage_drift")
+    if tlc_input.get("execution_authority"):
+        failures.append("handoff_smuggles_execution_authority")
+    return sorted(set(failures))
+
+
+def detect_progression_artifact_misuse(*, consumer_artifacts: list[Mapping[str, Any]]) -> list[str]:
+    failures: list[str] = []
+    for artifact in consumer_artifacts:
+        source = str(artifact.get("source_ref") or "")
+        use = str(artifact.get("used_for") or "")
+        if source.startswith("rdx_") and use in {"closure_evidence", "promotion_evidence"}:
+            failures.append(f"progression_artifact_misused:{artifact.get('artifact_id', 'unknown')}")
+    return sorted(set(failures))
+
+
+def build_selection_readiness(*, eval_result: Mapping[str, Any], dependency_failures: list[str], created_at: str, trace_id: str) -> dict[str, Any]:
+    fail_reasons = sorted(set([*eval_result.get("fail_reasons", []), *dependency_failures]))
+    record = {
+        "artifact_type": "rdx_selection_readiness_record",
+        "readiness_id": f"rsr-{_hash([trace_id, fail_reasons])[:16]}",
+        "trace_id": trace_id,
+        "created_at": created_at,
+        "readiness_status": "candidate_only" if not fail_reasons else "blocked",
+        "fail_reasons": fail_reasons,
+        "non_authority_assertions": [
+            "candidate_only_non_authoritative",
+            "rdx_not_closure_authority",
+            "rdx_not_policy_authority",
+            "rdx_not_execution_authority",
+        ],
+    }
+    validate_artifact(record, "rdx_selection_readiness_record")
+    return record
+
+
+def build_selection_effectiveness(*, outcomes: list[Mapping[str, Any]], window_id: str, created_at: str) -> dict[str, Any]:
+    if not outcomes:
+        raise RDXHardeningError("selection_effectiveness_requires_outcomes")
+    total = len(outcomes)
+    trust_gap_closed = sum(1 for row in outcomes if row.get("trust_gap_closed") is True)
+    dependency_violations = sum(1 for row in outcomes if row.get("dependency_violation") is True)
+    rework = sum(1 for row in outcomes if row.get("rework") is True)
+    status = "improving" if trust_gap_closed / total >= 0.6 and dependency_violations == 0 and rework / total <= 0.3 else "degraded"
+    artifact = {
+        "artifact_type": "rdx_selection_effectiveness_record",
+        "effectiveness_id": f"rseff-{_hash([window_id, total, trust_gap_closed, dependency_violations, rework])[:16]}",
+        "window_id": window_id,
+        "created_at": created_at,
+        "runs_evaluated": total,
+        "trust_gap_closure_rate": trust_gap_closed / total,
+        "dependency_violation_rate": dependency_violations / total,
+        "rework_rate": rework / total,
+        "value_status": status,
+    }
+    validate_artifact(artifact, "rdx_selection_effectiveness_record")
+    return artifact
+
+
+def build_governance_bundle(*, roadmap_selection: Mapping[str, Any], batch_selection: Mapping[str, Any], umbrella_selection: Mapping[str, Any], handoff: Mapping[str, Any], eval_result: Mapping[str, Any], readiness: Mapping[str, Any], effectiveness: Mapping[str, Any], rework_debt: Mapping[str, Any], created_at: str, trace_id: str) -> dict[str, Any]:
+    bundle = {
+        "artifact_type": "rdx_roadmap_governance_bundle",
+        "bundle_id": f"rgb-{_hash([trace_id, roadmap_selection.get('record_id'), batch_selection.get('record_id')])[:16]}",
+        "trace_id": trace_id,
+        "created_at": created_at,
+        "record_refs": [
+            f"rdx_roadmap_selection_record:{roadmap_selection.get('record_id')}",
+            f"rdx_batch_selection_record:{batch_selection.get('record_id')}",
+            f"rdx_umbrella_selection_record:{umbrella_selection.get('record_id')}",
+            f"rdx_execution_loop_readiness_handoff_record:{handoff.get('record_id')}",
+            f"rdx_selection_eval_result:{eval_result.get('eval_id')}",
+            f"rdx_selection_readiness_record:{readiness.get('readiness_id')}",
+            f"rdx_selection_effectiveness_record:{effectiveness.get('effectiveness_id')}",
+            f"rdx_rework_debt_record:{rework_debt.get('debt_id')}",
+        ],
+        "non_authority_assertions": [
+            "bundle_controls_progression_only",
+            "does_not_replace_cde_closure_authority",
+            "does_not_replace_tpa_policy_authority",
+        ],
+    }
+    validate_artifact(bundle, "rdx_roadmap_governance_bundle")
+    return bundle
+
+
+def run_rdx_boundary_redteam(*, fixtures: list[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    return [dict(row) for row in fixtures if row.get("should_fail_closed") and row.get("observed") != "blocked"]
+
+
+def run_rdx_semantic_redteam(*, fixtures: list[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    for row in fixtures:
+        if row.get("semantic_risk") is True and row.get("observed") != "blocked":
+            findings.append(dict(row))
+    return findings
+
+
+def build_selection_conflict_record(*, trace_id: str, created_at: str, conflict_codes: list[str]) -> dict[str, Any]:
+    record = {
+        "artifact_type": "rdx_selection_conflict_record",
+        "conflict_id": f"rconf-{_hash([trace_id, sorted(set(conflict_codes))])[:16]}",
+        "trace_id": trace_id,
+        "created_at": created_at,
+        "conflict_codes": sorted(set(conflict_codes)),
+    }
+    validate_artifact(record, "rdx_selection_conflict_record")
+    return record
+
+
+def verify_hnx_closeout_dependency_gate(*, hnx_closeout_status: str, replay_match: bool, stop_guard_ok: bool, checkpoint_resume_ok: bool) -> dict[str, Any]:
+    checks = {
+        "hnx_closeout_closed": hnx_closeout_status == "closed",
+        "replay_valid": replay_match,
+        "stop_condition_integrity": stop_guard_ok,
+        "checkpoint_resume_integrity": checkpoint_resume_ok,
+    }
+    fail_reasons = [name for name, ok in checks.items() if not ok]
+    return {
+        "closeout_status": "closed" if not fail_reasons else "open",
+        "checks": checks,
+        "fail_reasons": fail_reasons,
+    }

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -261,6 +261,22 @@ class ContractSchemaTests(unittest.TestCase):
             instance = load_example(name)
             validate_artifact(instance, name)
 
+    def test_rdx_hardening_contract_examples_validate(self) -> None:
+        for name in (
+            "rdx_roadmap_selection_record",
+            "rdx_batch_selection_record",
+            "rdx_umbrella_selection_record",
+            "rdx_execution_loop_readiness_handoff_record",
+            "rdx_selection_eval_result",
+            "rdx_selection_conflict_record",
+            "rdx_selection_readiness_record",
+            "rdx_selection_effectiveness_record",
+            "rdx_rework_debt_record",
+            "rdx_roadmap_governance_bundle",
+        ):
+            instance = load_example(name)
+            validate_artifact(instance, name)
+
 
     def test_system_roadmap_batches_have_required_governed_fields(self) -> None:
         instance = load_example("system_roadmap")

--- a/tests/test_hnx_hardening.py
+++ b/tests/test_hnx_hardening.py
@@ -20,6 +20,7 @@ from spectrum_systems.modules.runtime.hnx_hardening import (
     validate_checkpoint_resume_integrity,
     validate_harness_replay,
     validate_stop_conditions,
+    verify_hnx_closeout_gate,
 )
 
 
@@ -203,3 +204,31 @@ def test_harness_effectiveness_requires_outcomes() -> None:
         ],
     )
     assert artifact["runs_evaluated"] == 2
+
+
+def test_hnx_10_closeout_gate_is_operationally_real() -> None:
+    fx = _fixtures()
+    eval_result = evaluate_harness_contracts(
+        stage_contract=fx["stage_contract"],
+        checkpoint_record=fx["checkpoint"],
+        resume_record=fx["resume"],
+        continuity_state=fx["continuity"],
+        stop_condition_record=fx["stop"],
+        expected_lineage_chain=["AEX", "TLC", "TPA", "PQX"],
+        evaluated_at="2026-04-13T00:00:00Z",
+    )
+    readiness = build_harness_readiness(
+        run_id="run-closeout",
+        trace_id="trace-hnx-closeout",
+        eval_result=eval_result,
+        continuity_failures=[],
+        created_at="2026-04-13T00:00:00Z",
+    )
+    closeout = verify_hnx_closeout_gate(
+        harness_eval=eval_result,
+        readiness=readiness,
+        replay_match=True,
+        stop_failures=[],
+        checkpoint_resume_failures=[],
+    )
+    assert closeout["closeout_status"] == "closed"

--- a/tests/test_rdx_hardening.py
+++ b/tests/test_rdx_hardening.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from spectrum_systems.contracts import load_example, validate_artifact
+from spectrum_systems.modules.runtime.rdx_hardening import (
+    RDXHardeningError,
+    build_execution_loop_readiness_handoff,
+    build_governance_bundle,
+    build_roadmap_selection_record,
+    build_rework_debt_record,
+    build_selection_conflict_record,
+    build_selection_effectiveness,
+    build_selection_readiness,
+    build_umbrella_selection_record,
+    detect_pass_through_wrappers,
+    detect_progression_artifact_misuse,
+    enforce_rdx_boundary,
+    evaluate_selection,
+    run_rdx_boundary_redteam,
+    run_rdx_semantic_redteam,
+    select_next_governed_batch,
+    validate_progression_vs_closure,
+    validate_selection_replay,
+    validate_selection_to_tlc_integrity,
+    verify_hnx_closeout_dependency_gate,
+)
+
+
+def _roadmap() -> dict:
+    return {
+        "roadmap_id": "RM-001",
+        "trace_id": "trace-rdx-001",
+        "lineage_ref": "lineage:rdx:001",
+        "dependency_graph_ref": "dep:1",
+        "trust_signal_ref": "trust:1",
+        "batches": [
+            {
+                "batch_id": "BATCH-TRUST-01",
+                "umbrella_id": "UMB-TRUST-01",
+                "status": "not_started",
+                "depends_on": ["BATCH-BASE-01"],
+                "priority": 20,
+                "trust_gap_tag": "trust-core",
+                "slice_ids": ["S1", "S2"],
+            },
+            {
+                "batch_id": "BATCH-CAP-01",
+                "umbrella_id": "UMB-CAP-01",
+                "status": "not_started",
+                "depends_on": ["BATCH-BASE-01"],
+                "priority": 1,
+                "trust_gap_tag": "capability",
+                "slice_ids": ["S3", "S4"],
+            },
+            {
+                "batch_id": "BATCH-BASE-01",
+                "umbrella_id": "UMB-BASE-01",
+                "status": "completed",
+                "depends_on": [],
+                "priority": 0,
+                "trust_gap_tag": "foundation",
+                "slice_ids": ["S0A", "S0B"],
+            },
+        ],
+        "umbrellas": [
+            {"umbrella_id": "UMB-TRUST-01", "batch_ids": ["BATCH-TRUST-01", "BATCH-CAP-01"]},
+            {"umbrella_id": "UMB-BASE-01", "batch_ids": ["BATCH-BASE-01", "BATCH-TRUST-01"]},
+        ],
+    }
+
+
+def test_rdx_contract_examples_validate() -> None:
+    for name in (
+        "rdx_roadmap_selection_record",
+        "rdx_batch_selection_record",
+        "rdx_umbrella_selection_record",
+        "rdx_execution_loop_readiness_handoff_record",
+        "rdx_selection_eval_result",
+        "rdx_selection_conflict_record",
+        "rdx_selection_readiness_record",
+        "rdx_selection_effectiveness_record",
+        "rdx_rework_debt_record",
+        "rdx_roadmap_governance_bundle",
+    ):
+        validate_artifact(load_example(name), name)
+
+
+def test_rdx_01_02_03_boundary_fencing_and_deterministic_selection() -> None:
+    failures = enforce_rdx_boundary(
+        consumed_inputs=["roadmap_artifact", "trust_gap_signals", "pqx_execution_record"],
+        emitted_outputs=["rdx_batch_selection_record", "closure_decision_artifact"],
+        claimed_actions=["execute_work_slice:B1"],
+    )
+    assert "invalid_upstream_input:pqx_execution_record" in failures
+    assert "invalid_downstream_output:closure_decision_artifact" in failures
+    assert "forbidden_owner_overlap:execute_work_slice:B1" in failures
+
+    selection_a = select_next_governed_batch(roadmap=_roadmap(), trust_gap_priority=["trust-core", "capability"], now="2026-04-13T00:00:00Z")
+    selection_b = select_next_governed_batch(roadmap=_roadmap(), trust_gap_priority=["trust-core", "capability"], now="2026-04-13T00:00:00Z")
+    assert selection_a == selection_b
+    assert selection_a["selected_batch_id"] == "BATCH-TRUST-01"
+
+
+def test_rdx_04_06_07_08_and_08a_08b_checks() -> None:
+    roadmap = _roadmap()
+    selection = select_next_governed_batch(roadmap=roadmap, trust_gap_priority=["trust-core", "capability"], now="2026-04-13T00:00:00Z")
+    eval_result = evaluate_selection(
+        roadmap=roadmap,
+        selection_record=selection,
+        owner="RDX",
+        trust_gap_priority=["trust-core", "capability"],
+        evaluated_at="2026-04-13T00:00:00Z",
+    )
+    assert eval_result["evaluation_status"] == "pass"
+
+    replay_ok, replay_fails = validate_selection_replay(
+        prior_input=roadmap,
+        replay_input=copy.deepcopy(roadmap),
+        prior_selection=selection,
+        replay_selection=copy.deepcopy(selection),
+        prior_eval=eval_result,
+        replay_eval=copy.deepcopy(eval_result),
+    )
+    assert replay_ok is True
+    assert replay_fails == []
+
+    progression_fails = validate_progression_vs_closure(
+        progression_refs=["batch_progression:B1"],
+        closure_refs=["closure_decision_artifact:CDE-1"],
+        non_authority_assertions=["rdx_not_closure_authority"],
+    )
+    assert progression_fails == []
+
+    wrapper_roadmap = _roadmap()
+    wrapper_roadmap["batches"][0]["slice_ids"] = ["BATCH-TRUST-01"]
+    assert "batch_pass_through_wrapper:BATCH-TRUST-01" in detect_pass_through_wrappers(roadmap=wrapper_roadmap)
+
+
+def test_rdx_08c_08d_08e_05_09_artifacts_and_fail_closed() -> None:
+    debt = build_rework_debt_record(
+        selection_history=[
+            {"deferred_batch_ids": ["BATCH-TRUST-01"]},
+            {"deferred_batch_ids": ["BATCH-TRUST-01"]},
+            {"deferred_batch_ids": ["BATCH-TRUST-01", "BATCH-CAP-01"]},
+        ],
+        created_at="2026-04-13T00:00:00Z",
+        trace_id="trace-rdx-001",
+    )
+    assert debt["debt_status"] == "elevated"
+
+    tlc_fails = validate_selection_to_tlc_integrity(
+        handoff_record={"selected_batch_id": "BATCH-TRUST-01", "selected_umbrella_id": "UMB-TRUST-01", "lineage_ref": "lineage:rdx:001"},
+        tlc_input={"selected_batch_id": "BATCH-TRUST-01", "selected_umbrella_id": "UMB-TRUST-01", "lineage_ref": "lineage:rdx:001"},
+    )
+    assert tlc_fails == []
+
+    misuse = detect_progression_artifact_misuse(
+        consumer_artifacts=[
+            {"artifact_id": "x", "source_ref": "rdx_selection_readiness_record:1", "used_for": "closure_evidence"}
+        ]
+    )
+    assert misuse == ["progression_artifact_misused:x"]
+
+    readiness = build_selection_readiness(
+        eval_result={"fail_reasons": []}, dependency_failures=[], created_at="2026-04-13T00:00:00Z", trace_id="trace-rdx-001"
+    )
+    assert readiness["readiness_status"] == "candidate_only"
+
+    effectiveness = build_selection_effectiveness(
+        outcomes=[
+            {"trust_gap_closed": True, "dependency_violation": False, "rework": False},
+            {"trust_gap_closed": True, "dependency_violation": False, "rework": False},
+            {"trust_gap_closed": True, "dependency_violation": False, "rework": False},
+            {"trust_gap_closed": False, "dependency_violation": False, "rework": True},
+        ],
+        window_id="WIN-001",
+        created_at="2026-04-13T00:00:00Z",
+    )
+    assert effectiveness["value_status"] == "improving"
+
+    with pytest.raises(RDXHardeningError, match="selection_effectiveness_requires_outcomes"):
+        build_selection_effectiveness(outcomes=[], window_id="W", created_at="2026-04-13T00:00:00Z")
+
+
+def test_rdx_rt1_fx1_rt2_fx2_exploits_become_regressions_and_bundle() -> None:
+    rt1_findings = run_rdx_boundary_redteam(
+        fixtures=[
+            {"fixture_id": "RT1-OWNER-LEAK", "should_fail_closed": True, "observed": "accepted"},
+            {"fixture_id": "RT1-SCHEMA-MALFORM", "should_fail_closed": True, "observed": "blocked"},
+        ]
+    )
+    assert [row["fixture_id"] for row in rt1_findings] == ["RT1-OWNER-LEAK"]
+
+    rt2_findings = run_rdx_semantic_redteam(
+        fixtures=[
+            {"fixture_id": "RT2-TRUST-GAP-INVERSION", "semantic_risk": True, "observed": "accepted"},
+            {"fixture_id": "RT2-DEPENDENCY-INVERSION", "semantic_risk": True, "observed": "blocked"},
+        ]
+    )
+    assert [row["fixture_id"] for row in rt2_findings] == ["RT2-TRUST-GAP-INVERSION"]
+
+    conflict = build_selection_conflict_record(
+        trace_id="trace-rdx-001",
+        created_at="2026-04-13T00:00:00Z",
+        conflict_codes=["RT1-OWNER-LEAK", "RT2-TRUST-GAP-INVERSION"],
+    )
+    assert len(conflict["conflict_codes"]) == 2
+
+    roadmap = _roadmap()
+    roadmap_record = build_roadmap_selection_record(
+        roadmap=roadmap,
+        selected_umbrella_id="UMB-TRUST-01",
+        reason_codes=["dependency_satisfied", "trust_gap_priority_applied"],
+        evaluated_at="2026-04-13T00:00:00Z",
+    )
+    batch_record = select_next_governed_batch(roadmap=roadmap, trust_gap_priority=["trust-core", "capability"], now="2026-04-13T00:00:00Z")
+    umbrella_record = build_umbrella_selection_record(roadmap=roadmap, selected_umbrella_id="UMB-TRUST-01", evaluated_at="2026-04-13T00:00:00Z")
+    handoff = build_execution_loop_readiness_handoff(
+        trace_id="trace-rdx-001",
+        selected_batch_id=batch_record["selected_batch_id"],
+        selected_umbrella_id=roadmap_record["selected_umbrella_id"],
+        lineage_ref="lineage:rdx:001",
+        readiness_status="candidate_only",
+        created_at="2026-04-13T00:00:00Z",
+    )
+    eval_result = {"eval_id": "rse-1"}
+    readiness = {"readiness_id": "rsr-1"}
+    effectiveness = {"effectiveness_id": "rseff-1"}
+    debt = {"debt_id": "rrd-1"}
+    bundle = build_governance_bundle(
+        roadmap_selection=roadmap_record,
+        batch_selection=batch_record,
+        umbrella_selection=umbrella_record,
+        handoff=handoff,
+        eval_result=eval_result,
+        readiness=readiness,
+        effectiveness=effectiveness,
+        rework_debt=debt,
+        created_at="2026-04-13T00:00:00Z",
+        trace_id="trace-rdx-001",
+    )
+    assert bundle["artifact_type"] == "rdx_roadmap_governance_bundle"
+
+
+def test_hnx_gate_dependency_for_rdx_is_checked() -> None:
+    closeout = verify_hnx_closeout_dependency_gate(
+        hnx_closeout_status="closed",
+        replay_match=True,
+        stop_guard_ok=True,
+        checkpoint_resume_ok=True,
+    )
+    assert closeout["closeout_status"] == "closed"


### PR DESCRIPTION
### Motivation
- Provide a repo-native, fail-closed RDX roadmap-governance foundation so roadmap selection is deterministic, replayable, and bounded by owner boundaries. 
- Ensure HNX closeout semantics (checkpoint/resume, stop-guard, replay, continuity) are operationally real before RDX depends on HNX outputs. 
- Encode every red-team finding as permanent evals, regression tests, and hardened logic so discovered exploits are prevented from recurring.

### Description
- Add a new runtime module `spectrum_systems/modules/runtime/rdx_hardening.py` implementing boundary fencing, deterministic batch/umbrella selection, selection evaluation, replay validation, progression-vs-closure checks, trust-gap priority handling, pass-through wrapper detection, rework-debt tracking, TLC handoff integrity checks, readiness/effectiveness artifact builders, and RT1/RT2 red-team runners. 
- Add HNX closeout verifier `verify_hnx_closeout_gate` in `spectrum_systems/modules/runtime/hnx_hardening.py` to assert checkpoint/resume integrity, stop-condition integrity, replay validity, and bounded HNX scope. 
- Publish 10 new RDX contracts (schemas + examples) and update `contracts/standards-manifest.json` for: `rdx_roadmap_selection_record`, `rdx_batch_selection_record`, `rdx_umbrella_selection_record`, `rdx_execution_loop_readiness_handoff_record`, `rdx_selection_eval_result`, `rdx_selection_conflict_record`, `rdx_selection_readiness_record`, `rdx_selection_effectiveness_record`, `rdx_rework_debt_record`, and `rdx_roadmap_governance_bundle`. 
- Add tests and plan artifacts: new `tests/test_rdx_hardening.py`, updated `tests/test_hnx_hardening.py` and `tests/test_contracts.py`, and `docs/review-actions/PLAN-RDX-001-2026-04-13.md` describing the multi-file change.

### Testing
- Ran unit tests for the new and modified surfaces with `pytest tests/test_rdx_hardening.py -q` and `pytest tests/test_hnx_hardening.py -q`, both suites passed (all new tests green). 
- Validated contract examples with `pytest tests/test_contracts.py -k "rdx_hardening_contract_examples_validate or test_hnx_continuity_contract_examples_validate" -q` and `pytest tests/test_contract_enforcement.py -q`, both succeeded. 
- Executed contract enforcement script `python scripts/run_contract_enforcement.py` which completed with zero failures, and ran `.codex/skills/contract-boundary-audit/run.sh` which returned non-blocking warnings but no blocking errors. 
- All added unit tests and contract validations are passing and red-team fixtures are exercised as regression checks in `tests/test_rdx_hardening.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc4dc9ed808329b4dcc67acbcb2377)