### PR TITLE
PRG-001: Implement PRG governance hardening + RDX closeout and red-team fix loops

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -380,3 +380,5 @@ Closed plans are not deleted — they remain as execution history.
 | docs/review-actions/PLAN-DASHBOARD-UI-FIX-TRUTH-BOUNDARY-02-2026-04-12.md | DASHBOARD-UI-FIX-TRUTH-BOUNDARY-02 — UI truth-boundary surgical hardening | Active |
 
 | docs/review-actions/PLAN-DASHBOARD-NEXT-PHASE-SERIAL-04-2026-04-12.md | DASHBOARD-NEXT-PHASE-SERIAL-04 — Governed operator coordination surface | Active |
+
+| docs/review-actions/PLAN-PRG-001-2026-04-13.md | PRG-001 — RDX closeout + PRG bounded governance foundation + red-team fix loops | Active |

--- a/contracts/examples/adaptive_readiness_record.json
+++ b/contracts/examples/adaptive_readiness_record.json
@@ -1,0 +1,12 @@
+{
+  "artifact_type": "adaptive_readiness_record",
+  "readiness_id": "arr-001",
+  "readiness_state": "candidate_only",
+  "non_authority_assertions": [
+    "recommendation_only"
+  ],
+  "fail_reasons": [],
+  "created_at": "2026-04-13T00:00:00Z",
+  "trace_id": "trace-prg-001",
+  "lineage_ref": "lineage:prg:001"
+}

--- a/contracts/examples/evaluation_pattern_report.json
+++ b/contracts/examples/evaluation_pattern_report.json
@@ -1,0 +1,28 @@
+{
+  "artifact_type": "evaluation_pattern_report",
+  "report_id": "epr-001",
+  "program_id": "PRG-ROADMAP-EXECUTION",
+  "generated_at": "2026-04-13T00:00:00Z",
+  "created_at": "2026-04-13T00:00:00Z",
+  "trace_id": "trace-prg-001",
+  "lineage_ref": "lineage:prg:001",
+  "patterns": [
+    {
+      "pattern_code": "missing_eval_coverage",
+      "occurrences": 2,
+      "evidence_refs": [
+        "signal:missing_eval"
+      ]
+    }
+  ],
+  "causal_claims": [
+    {
+      "claim_id": "claim-1",
+      "claim": "coverage gaps increase governance risk",
+      "evidence_refs": [
+        "signal:missing_eval"
+      ],
+      "supported": true
+    }
+  ]
+}

--- a/contracts/examples/policy_change_candidate.json
+++ b/contracts/examples/policy_change_candidate.json
@@ -1,0 +1,12 @@
+{
+  "artifact_type": "policy_change_candidate",
+  "candidate_id": "pcc-001",
+  "policy_area": "tpa_scope",
+  "reason_codes": [
+    "recurring_conflict"
+  ],
+  "authority_scope": "recommendation_only",
+  "created_at": "2026-04-13T00:00:00Z",
+  "trace_id": "trace-prg-001",
+  "lineage_ref": "lineage:prg:001"
+}

--- a/contracts/examples/prg_governance_bundle.json
+++ b/contracts/examples/prg_governance_bundle.json
@@ -1,0 +1,15 @@
+{
+  "artifact_type": "prg_governance_bundle",
+  "bundle_id": "pgb-001",
+  "artifact_refs": [
+    "evaluation_pattern_report:epr-001",
+    "prioritized_adoption_candidate_set:pacs-001",
+    "prg_governance_eval_result:pge-001"
+  ],
+  "non_authority_assertions": [
+    "recommendation_only"
+  ],
+  "created_at": "2026-04-13T00:00:00Z",
+  "trace_id": "trace-prg-001",
+  "lineage_ref": "lineage:prg:001"
+}

--- a/contracts/examples/prg_governance_conflict_record.json
+++ b/contracts/examples/prg_governance_conflict_record.json
@@ -1,0 +1,11 @@
+{
+  "artifact_type": "prg_governance_conflict_record",
+  "conflict_id": "pgc-001",
+  "conflict_codes": [
+    "recommendation_authority_leakage"
+  ],
+  "severity": "high",
+  "created_at": "2026-04-13T00:00:00Z",
+  "trace_id": "trace-prg-001",
+  "lineage_ref": "lineage:prg:001"
+}

--- a/contracts/examples/prg_governance_effectiveness_record.json
+++ b/contracts/examples/prg_governance_effectiveness_record.json
@@ -1,0 +1,13 @@
+{
+  "artifact_type": "prg_governance_effectiveness_record",
+  "effectiveness_id": "pgeff-001",
+  "window_size": 3,
+  "trust_improvement_rate": 0.6667,
+  "drift_reduction_rate": 0.6667,
+  "alignment_improvement_rate": 1.0,
+  "effectiveness_score": 0.7778,
+  "value_status": "improving",
+  "created_at": "2026-04-13T00:00:00Z",
+  "trace_id": "trace-prg-001",
+  "lineage_ref": "lineage:prg:001"
+}

--- a/contracts/examples/prg_governance_eval_result.json
+++ b/contracts/examples/prg_governance_eval_result.json
@@ -1,0 +1,13 @@
+{
+  "artifact_type": "prg_governance_eval_result",
+  "eval_id": "pge-001",
+  "evaluation_status": "pass",
+  "checks": {
+    "evidence_sufficient": true,
+    "non_authority_correct": true
+  },
+  "fail_reasons": [],
+  "created_at": "2026-04-13T00:00:00Z",
+  "trace_id": "trace-prg-001",
+  "lineage_ref": "lineage:prg:001"
+}

--- a/contracts/examples/prg_governance_readiness_record.json
+++ b/contracts/examples/prg_governance_readiness_record.json
@@ -1,0 +1,12 @@
+{
+  "artifact_type": "prg_governance_readiness_record",
+  "readiness_id": "pgr-001",
+  "readiness_status": "candidate_only",
+  "non_authority_assertions": [
+    "prg_not_policy_authority"
+  ],
+  "fail_reasons": [],
+  "created_at": "2026-04-13T00:00:00Z",
+  "trace_id": "trace-prg-001",
+  "lineage_ref": "lineage:prg:001"
+}

--- a/contracts/examples/prg_recommendation_rework_debt_record.json
+++ b/contracts/examples/prg_recommendation_rework_debt_record.json
@@ -1,0 +1,15 @@
+{
+  "artifact_type": "prg_recommendation_rework_debt_record",
+  "debt_id": "prd-001",
+  "rework_items": [
+    {
+      "recommendation_key": "contract-tighten",
+      "recurrence_count": 3,
+      "status": "open"
+    }
+  ],
+  "debt_status": "elevated",
+  "created_at": "2026-04-13T00:00:00Z",
+  "trace_id": "trace-prg-001",
+  "lineage_ref": "lineage:prg:001"
+}

--- a/contracts/examples/prioritized_adoption_candidate_set.json
+++ b/contracts/examples/prioritized_adoption_candidate_set.json
@@ -1,0 +1,27 @@
+{
+  "artifact_type": "prioritized_adoption_candidate_set",
+  "candidate_set_id": "pacs-001",
+  "program_id": "PRG-ROADMAP-EXECUTION",
+  "generated_at": "2026-04-13T00:00:00Z",
+  "created_at": "2026-04-13T00:00:00Z",
+  "trace_id": "trace-prg-001",
+  "lineage_ref": "lineage:prg:001",
+  "non_authority_assertions": [
+    "recommendation_only"
+  ],
+  "candidates": [
+    {
+      "candidate_id": "cand-1",
+      "target_type": "slice_contract",
+      "target_ref": "slice:S1",
+      "priority": 90,
+      "reason_codes": [
+        "pattern_recurrence"
+      ],
+      "authority_scope": "recommendation_only",
+      "evidence_refs": [
+        "evaluation_pattern_report:epr-001"
+      ]
+    }
+  ]
+}

--- a/contracts/examples/program_alignment_assessment.json
+++ b/contracts/examples/program_alignment_assessment.json
@@ -1,0 +1,14 @@
+{
+  "artifact_type": "program_alignment_assessment",
+  "assessment_id": "paa-001",
+  "program_id": "PRG-ROADMAP-EXECUTION",
+  "alignment_status": "aligned",
+  "strategy_integrity": "trust_gap_first",
+  "reason_codes": [
+    "incomplete_trust_layers_prioritized"
+  ],
+  "fail_reasons": [],
+  "created_at": "2026-04-13T00:00:00Z",
+  "trace_id": "trace-prg-001",
+  "lineage_ref": "lineage:prg:001"
+}

--- a/contracts/examples/slice_contract_update_candidate.json
+++ b/contracts/examples/slice_contract_update_candidate.json
@@ -1,0 +1,10 @@
+{
+  "artifact_type": "slice_contract_update_candidate",
+  "candidate_id": "scc-001",
+  "target_contract": "roadmap_step_contract",
+  "change_summary": "tighten non-authority assertions",
+  "authority_scope": "recommendation_only",
+  "created_at": "2026-04-13T00:00:00Z",
+  "trace_id": "trace-prg-001",
+  "lineage_ref": "lineage:prg:001"
+}

--- a/contracts/schemas/adaptive_readiness_record.schema.json
+++ b/contracts/schemas/adaptive_readiness_record.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/adaptive_readiness_record.schema.json",
+  "title": "adaptive_readiness_record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "readiness_id",
+    "created_at",
+    "trace_id",
+    "lineage_ref",
+    "readiness_state",
+    "non_authority_assertions",
+    "fail_reasons"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "adaptive_readiness_record"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "lineage_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "readiness_id": {
+      "type": "string"
+    },
+    "readiness_state": {
+      "type": "string",
+      "enum": [
+        "candidate_only",
+        "blocked"
+      ]
+    },
+    "non_authority_assertions": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "fail_reasons": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/contracts/schemas/evaluation_pattern_report.schema.json
+++ b/contracts/schemas/evaluation_pattern_report.schema.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/evaluation_pattern_report.schema.json",
+  "title": "evaluation_pattern_report",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "report_id",
+    "program_id",
+    "generated_at",
+    "trace_id",
+    "lineage_ref",
+    "patterns",
+    "causal_claims"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "evaluation_pattern_report"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "lineage_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "report_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "program_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "patterns": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "pattern_code",
+          "occurrences",
+          "evidence_refs"
+        ],
+        "properties": {
+          "pattern_code": {
+            "type": "string"
+          },
+          "occurrences": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "evidence_refs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1
+          }
+        }
+      }
+    },
+    "causal_claims": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "claim_id",
+          "claim",
+          "evidence_refs",
+          "supported"
+        ],
+        "properties": {
+          "claim_id": {
+            "type": "string"
+          },
+          "claim": {
+            "type": "string"
+          },
+          "evidence_refs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1
+          },
+          "supported": {
+            "type": "boolean"
+          }
+        }
+      }
+    }
+  }
+}

--- a/contracts/schemas/policy_change_candidate.schema.json
+++ b/contracts/schemas/policy_change_candidate.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/policy_change_candidate.schema.json",
+  "title": "policy_change_candidate",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "candidate_id",
+    "created_at",
+    "trace_id",
+    "lineage_ref",
+    "policy_area",
+    "reason_codes",
+    "authority_scope"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "policy_change_candidate"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "lineage_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "candidate_id": {
+      "type": "string"
+    },
+    "policy_area": {
+      "type": "string"
+    },
+    "reason_codes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "authority_scope": {
+      "type": "string",
+      "const": "recommendation_only"
+    }
+  }
+}

--- a/contracts/schemas/prg_governance_bundle.schema.json
+++ b/contracts/schemas/prg_governance_bundle.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/prg_governance_bundle.schema.json",
+  "title": "prg_governance_bundle",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "bundle_id",
+    "created_at",
+    "trace_id",
+    "lineage_ref",
+    "artifact_refs",
+    "non_authority_assertions"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "prg_governance_bundle"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "lineage_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "bundle_id": {
+      "type": "string"
+    },
+    "artifact_refs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 3
+    },
+    "non_authority_assertions": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    }
+  }
+}

--- a/contracts/schemas/prg_governance_conflict_record.schema.json
+++ b/contracts/schemas/prg_governance_conflict_record.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/prg_governance_conflict_record.schema.json",
+  "title": "prg_governance_conflict_record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "conflict_id",
+    "created_at",
+    "trace_id",
+    "lineage_ref",
+    "conflict_codes",
+    "severity"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "prg_governance_conflict_record"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "lineage_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "conflict_id": {
+      "type": "string"
+    },
+    "conflict_codes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "severity": {
+      "type": "string",
+      "enum": [
+        "none",
+        "low",
+        "medium",
+        "high"
+      ]
+    }
+  }
+}

--- a/contracts/schemas/prg_governance_effectiveness_record.schema.json
+++ b/contracts/schemas/prg_governance_effectiveness_record.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/prg_governance_effectiveness_record.schema.json",
+  "title": "prg_governance_effectiveness_record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "effectiveness_id",
+    "created_at",
+    "trace_id",
+    "lineage_ref",
+    "window_size",
+    "trust_improvement_rate",
+    "drift_reduction_rate",
+    "alignment_improvement_rate",
+    "effectiveness_score",
+    "value_status"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "prg_governance_effectiveness_record"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "lineage_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "effectiveness_id": {
+      "type": "string"
+    },
+    "window_size": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "trust_improvement_rate": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "drift_reduction_rate": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "alignment_improvement_rate": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "effectiveness_score": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "value_status": {
+      "type": "string",
+      "enum": [
+        "improving",
+        "stagnating"
+      ]
+    }
+  }
+}

--- a/contracts/schemas/prg_governance_eval_result.schema.json
+++ b/contracts/schemas/prg_governance_eval_result.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/prg_governance_eval_result.schema.json",
+  "title": "prg_governance_eval_result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "eval_id",
+    "created_at",
+    "trace_id",
+    "lineage_ref",
+    "evaluation_status",
+    "checks",
+    "fail_reasons"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "prg_governance_eval_result"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "lineage_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "eval_id": {
+      "type": "string"
+    },
+    "evaluation_status": {
+      "type": "string",
+      "enum": [
+        "pass",
+        "fail"
+      ]
+    },
+    "checks": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "minProperties": 1
+    },
+    "fail_reasons": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/contracts/schemas/prg_governance_readiness_record.schema.json
+++ b/contracts/schemas/prg_governance_readiness_record.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/prg_governance_readiness_record.schema.json",
+  "title": "prg_governance_readiness_record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "readiness_id",
+    "created_at",
+    "trace_id",
+    "lineage_ref",
+    "readiness_status",
+    "non_authority_assertions",
+    "fail_reasons"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "prg_governance_readiness_record"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "lineage_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "readiness_id": {
+      "type": "string"
+    },
+    "readiness_status": {
+      "type": "string",
+      "enum": [
+        "candidate_only",
+        "blocked"
+      ]
+    },
+    "non_authority_assertions": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "fail_reasons": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/contracts/schemas/prg_recommendation_rework_debt_record.schema.json
+++ b/contracts/schemas/prg_recommendation_rework_debt_record.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/prg_recommendation_rework_debt_record.schema.json",
+  "title": "prg_recommendation_rework_debt_record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "debt_id",
+    "created_at",
+    "trace_id",
+    "lineage_ref",
+    "rework_items",
+    "debt_status"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "prg_recommendation_rework_debt_record"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "lineage_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "debt_id": {
+      "type": "string"
+    },
+    "rework_items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "recommendation_key",
+          "recurrence_count",
+          "status"
+        ],
+        "properties": {
+          "recommendation_key": {
+            "type": "string"
+          },
+          "recurrence_count": {
+            "type": "integer",
+            "minimum": 2
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "open",
+              "resolved"
+            ]
+          }
+        }
+      }
+    },
+    "debt_status": {
+      "type": "string",
+      "enum": [
+        "stable",
+        "elevated"
+      ]
+    }
+  }
+}

--- a/contracts/schemas/prioritized_adoption_candidate_set.schema.json
+++ b/contracts/schemas/prioritized_adoption_candidate_set.schema.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/prioritized_adoption_candidate_set.schema.json",
+  "title": "prioritized_adoption_candidate_set",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "candidate_set_id",
+    "program_id",
+    "generated_at",
+    "trace_id",
+    "lineage_ref",
+    "non_authority_assertions",
+    "candidates"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "prioritized_adoption_candidate_set"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "lineage_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "candidate_set_id": {
+      "type": "string"
+    },
+    "program_id": {
+      "type": "string"
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "non_authority_assertions": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "candidates": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "candidate_id",
+          "target_type",
+          "target_ref",
+          "priority",
+          "reason_codes",
+          "authority_scope",
+          "evidence_refs"
+        ],
+        "properties": {
+          "candidate_id": {
+            "type": "string"
+          },
+          "target_type": {
+            "type": "string"
+          },
+          "target_ref": {
+            "type": "string"
+          },
+          "priority": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100
+          },
+          "reason_codes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1
+          },
+          "authority_scope": {
+            "type": "string",
+            "const": "recommendation_only"
+          },
+          "evidence_refs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/contracts/schemas/program_alignment_assessment.schema.json
+++ b/contracts/schemas/program_alignment_assessment.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/program_alignment_assessment.schema.json",
+  "title": "program_alignment_assessment",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "assessment_id",
+    "program_id",
+    "alignment_status",
+    "strategy_integrity",
+    "created_at",
+    "trace_id",
+    "lineage_ref",
+    "reason_codes",
+    "fail_reasons"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "program_alignment_assessment"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "lineage_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "assessment_id": {
+      "type": "string"
+    },
+    "program_id": {
+      "type": "string"
+    },
+    "alignment_status": {
+      "type": "string",
+      "enum": [
+        "aligned",
+        "misaligned"
+      ]
+    },
+    "strategy_integrity": {
+      "type": "string",
+      "enum": [
+        "trust_gap_first",
+        "breadth_first_inversion"
+      ]
+    },
+    "reason_codes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "fail_reasons": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/contracts/schemas/slice_contract_update_candidate.schema.json
+++ b/contracts/schemas/slice_contract_update_candidate.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/slice_contract_update_candidate.schema.json",
+  "title": "slice_contract_update_candidate",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "candidate_id",
+    "created_at",
+    "trace_id",
+    "lineage_ref",
+    "target_contract",
+    "change_summary",
+    "authority_scope"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "slice_contract_update_candidate"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "lineage_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "candidate_id": {
+      "type": "string"
+    },
+    "target_contract": {
+      "type": "string"
+    },
+    "change_summary": {
+      "type": "string"
+    },
+    "authority_scope": {
+      "type": "string",
+      "const": "recommendation_only"
+    }
+  }
+}

--- a/contracts/standards-manifest.json
+++ b/contracts/standards-manifest.json
@@ -1,9 +1,9 @@
 {
   "artifact_type": "standards_manifest",
   "artifact_id": "STD-CONTRACTS",
-  "artifact_version": "1.3.122",
-  "schema_version": "1.3.98",
-  "standards_version": "1.3.122",
+  "artifact_version": "1.3.123",
+  "schema_version": "1.3.99",
+  "standards_version": "1.3.123",
   "record_id": "REC-STD-2026-04-12-TLC-001",
   "run_id": "run-20260412T220000Z-tlc-001",
   "created_at": "2026-04-12T00:00:00Z",
@@ -15,7 +15,7 @@
     "contact": "architecture@spectrum-systems.test"
   },
   "source_repo": "nicklasorte/spectrum-systems",
-  "source_repo_version": "1.3.121",
+  "source_repo_version": "1.3.122",
   "input_artifacts": [
     {
       "artifact_id": "STD-CONTRACTS",
@@ -65,6 +65,19 @@
       "last_updated_in": "1.3.37",
       "example_path": "contracts/examples/adaptive_execution_trend_report.json",
       "notes": "BATCH-X1 deterministic guardrail and trend report for bounded adaptive execution operator tuning decisions."
+    },
+    {
+      "artifact_type": "adaptive_readiness_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.123",
+      "last_updated_in": "1.3.123",
+      "example_path": "contracts/examples/adaptive_readiness_record.json",
+      "notes": "PRG-001 bounded governance hardening artifact with non-authoritative recommendation semantics."
     },
     {
       "artifact_type": "admission_authenticity_record",
@@ -1828,6 +1841,19 @@
       "notes": "Aggregated monitoring artifact supporting both regression-window and run-bundle control-loop summary shapes."
     },
     {
+      "artifact_type": "evaluation_pattern_report",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.123",
+      "last_updated_in": "1.3.123",
+      "example_path": "contracts/examples/evaluation_pattern_report.json",
+      "notes": "PRG-001 bounded governance hardening artifact with non-authoritative recommendation semantics."
+    },
+    {
       "artifact_type": "evaluation_release_record",
       "artifact_class": "coordination",
       "schema_version": "1.1.0",
@@ -3346,6 +3372,19 @@
       "notes": "BATCH-LTV-D governed policy extraction/activation/conflict artifact for deterministic policy rollout control."
     },
     {
+      "artifact_type": "policy_change_candidate",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.123",
+      "last_updated_in": "1.3.123",
+      "example_path": "contracts/examples/policy_change_candidate.json",
+      "notes": "PRG-001 bounded governance hardening artifact with non-authoritative recommendation semantics."
+    },
+    {
       "artifact_type": "policy_conflict_record",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -3851,6 +3890,110 @@
       "last_updated_in": "1.3.62",
       "example_path": "contracts/examples/precedent_selection_record.json",
       "notes": "LT-02 deterministic precedent retrieval and selection decision record with explicit rejected candidates."
+    },
+    {
+      "artifact_type": "prg_governance_bundle",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.123",
+      "last_updated_in": "1.3.123",
+      "example_path": "contracts/examples/prg_governance_bundle.json",
+      "notes": "PRG-001 bounded governance hardening artifact with non-authoritative recommendation semantics."
+    },
+    {
+      "artifact_type": "prg_governance_conflict_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.123",
+      "last_updated_in": "1.3.123",
+      "example_path": "contracts/examples/prg_governance_conflict_record.json",
+      "notes": "PRG-001 bounded governance hardening artifact with non-authoritative recommendation semantics."
+    },
+    {
+      "artifact_type": "prg_governance_effectiveness_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.123",
+      "last_updated_in": "1.3.123",
+      "example_path": "contracts/examples/prg_governance_effectiveness_record.json",
+      "notes": "PRG-001 bounded governance hardening artifact with non-authoritative recommendation semantics."
+    },
+    {
+      "artifact_type": "prg_governance_eval_result",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.123",
+      "last_updated_in": "1.3.123",
+      "example_path": "contracts/examples/prg_governance_eval_result.json",
+      "notes": "PRG-001 bounded governance hardening artifact with non-authoritative recommendation semantics."
+    },
+    {
+      "artifact_type": "prg_governance_readiness_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.123",
+      "last_updated_in": "1.3.123",
+      "example_path": "contracts/examples/prg_governance_readiness_record.json",
+      "notes": "PRG-001 bounded governance hardening artifact with non-authoritative recommendation semantics."
+    },
+    {
+      "artifact_type": "prg_recommendation_rework_debt_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.123",
+      "last_updated_in": "1.3.123",
+      "example_path": "contracts/examples/prg_recommendation_rework_debt_record.json",
+      "notes": "PRG-001 bounded governance hardening artifact with non-authoritative recommendation semantics."
+    },
+    {
+      "artifact_type": "prioritized_adoption_candidate_set",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.123",
+      "last_updated_in": "1.3.123",
+      "example_path": "contracts/examples/prioritized_adoption_candidate_set.json",
+      "notes": "PRG-001 bounded governance hardening artifact with non-authoritative recommendation semantics."
+    },
+    {
+      "artifact_type": "program_alignment_assessment",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.123",
+      "last_updated_in": "1.3.123",
+      "example_path": "contracts/examples/program_alignment_assessment.json",
+      "notes": "PRG-001 bounded governance hardening artifact with non-authoritative recommendation semantics."
     },
     {
       "artifact_type": "program_artifact",
@@ -4676,6 +4819,136 @@
       "last_updated_in": "1.3.112",
       "example_path": "contracts/examples/rax_upstream_input_envelope.example.json",
       "notes": "RAX-INTERFACE-24-01 strict compact upstream roadmap envelope consumed by RAX for deterministic contract expansion."
+    },
+    {
+      "artifact_type": "rdx_batch_selection_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.122",
+      "last_updated_in": "1.3.122",
+      "example_path": "contracts/examples/rdx_batch_selection_record.example.json",
+      "notes": "RDX bounded roadmap-governance hardening contract for deterministic selection, eval, replay, readiness, and fail-closed integrity checks."
+    },
+    {
+      "artifact_type": "rdx_execution_loop_readiness_handoff_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.122",
+      "last_updated_in": "1.3.122",
+      "example_path": "contracts/examples/rdx_execution_loop_readiness_handoff_record.example.json",
+      "notes": "RDX bounded roadmap-governance hardening contract for deterministic selection, eval, replay, readiness, and fail-closed integrity checks."
+    },
+    {
+      "artifact_type": "rdx_rework_debt_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.122",
+      "last_updated_in": "1.3.122",
+      "example_path": "contracts/examples/rdx_rework_debt_record.example.json",
+      "notes": "RDX bounded roadmap-governance hardening contract for deterministic selection, eval, replay, readiness, and fail-closed integrity checks."
+    },
+    {
+      "artifact_type": "rdx_roadmap_governance_bundle",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.122",
+      "last_updated_in": "1.3.122",
+      "example_path": "contracts/examples/rdx_roadmap_governance_bundle.example.json",
+      "notes": "RDX bounded roadmap-governance hardening contract for deterministic selection, eval, replay, readiness, and fail-closed integrity checks."
+    },
+    {
+      "artifact_type": "rdx_roadmap_selection_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.122",
+      "last_updated_in": "1.3.122",
+      "example_path": "contracts/examples/rdx_roadmap_selection_record.example.json",
+      "notes": "RDX bounded roadmap-governance hardening contract for deterministic selection, eval, replay, readiness, and fail-closed integrity checks."
+    },
+    {
+      "artifact_type": "rdx_selection_conflict_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.122",
+      "last_updated_in": "1.3.122",
+      "example_path": "contracts/examples/rdx_selection_conflict_record.example.json",
+      "notes": "RDX bounded roadmap-governance hardening contract for deterministic selection, eval, replay, readiness, and fail-closed integrity checks."
+    },
+    {
+      "artifact_type": "rdx_selection_effectiveness_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.122",
+      "last_updated_in": "1.3.122",
+      "example_path": "contracts/examples/rdx_selection_effectiveness_record.example.json",
+      "notes": "RDX bounded roadmap-governance hardening contract for deterministic selection, eval, replay, readiness, and fail-closed integrity checks."
+    },
+    {
+      "artifact_type": "rdx_selection_eval_result",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.122",
+      "last_updated_in": "1.3.122",
+      "example_path": "contracts/examples/rdx_selection_eval_result.example.json",
+      "notes": "RDX bounded roadmap-governance hardening contract for deterministic selection, eval, replay, readiness, and fail-closed integrity checks."
+    },
+    {
+      "artifact_type": "rdx_selection_readiness_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.122",
+      "last_updated_in": "1.3.122",
+      "example_path": "contracts/examples/rdx_selection_readiness_record.example.json",
+      "notes": "RDX bounded roadmap-governance hardening contract for deterministic selection, eval, replay, readiness, and fail-closed integrity checks."
+    },
+    {
+      "artifact_type": "rdx_umbrella_selection_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.122",
+      "last_updated_in": "1.3.122",
+      "example_path": "contracts/examples/rdx_umbrella_selection_record.example.json",
+      "notes": "RDX bounded roadmap-governance hardening contract for deterministic selection, eval, replay, readiness, and fail-closed integrity checks."
     },
     {
       "artifact_type": "readiness_review_dashboard_artifact",
@@ -5644,6 +5917,19 @@
       "notes": "SRE-08 governed deterministic SLO definition artifact for bounded observability metric objectives and breach severities."
     },
     {
+      "artifact_type": "slice_contract_update_candidate",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.123",
+      "last_updated_in": "1.3.123",
+      "example_path": "contracts/examples/slice_contract_update_candidate.json",
+      "notes": "PRG-001 bounded governance hardening artifact with non-authoritative recommendation semantics."
+    },
+    {
       "artifact_type": "slide_deck",
       "artifact_class": "work",
       "schema_version": "1.0.0",
@@ -6277,136 +6563,6 @@
       "last_updated_in": "1.0.82",
       "example_path": "contracts/examples/xrun_signal_quality_result.json",
       "notes": "VAL-06 governed validation artifact proving deterministic XRUN-01 pattern/action/signal quality and fail-closed handling under insufficient/malformed inputs."
-    },
-    {
-      "artifact_type": "rdx_roadmap_selection_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "stable",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.122",
-      "last_updated_in": "1.3.122",
-      "example_path": "contracts/examples/rdx_roadmap_selection_record.example.json",
-      "notes": "RDX bounded roadmap-governance hardening contract for deterministic selection, eval, replay, readiness, and fail-closed integrity checks."
-    },
-    {
-      "artifact_type": "rdx_batch_selection_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "stable",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.122",
-      "last_updated_in": "1.3.122",
-      "example_path": "contracts/examples/rdx_batch_selection_record.example.json",
-      "notes": "RDX bounded roadmap-governance hardening contract for deterministic selection, eval, replay, readiness, and fail-closed integrity checks."
-    },
-    {
-      "artifact_type": "rdx_umbrella_selection_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "stable",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.122",
-      "last_updated_in": "1.3.122",
-      "example_path": "contracts/examples/rdx_umbrella_selection_record.example.json",
-      "notes": "RDX bounded roadmap-governance hardening contract for deterministic selection, eval, replay, readiness, and fail-closed integrity checks."
-    },
-    {
-      "artifact_type": "rdx_execution_loop_readiness_handoff_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "stable",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.122",
-      "last_updated_in": "1.3.122",
-      "example_path": "contracts/examples/rdx_execution_loop_readiness_handoff_record.example.json",
-      "notes": "RDX bounded roadmap-governance hardening contract for deterministic selection, eval, replay, readiness, and fail-closed integrity checks."
-    },
-    {
-      "artifact_type": "rdx_selection_eval_result",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "stable",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.122",
-      "last_updated_in": "1.3.122",
-      "example_path": "contracts/examples/rdx_selection_eval_result.example.json",
-      "notes": "RDX bounded roadmap-governance hardening contract for deterministic selection, eval, replay, readiness, and fail-closed integrity checks."
-    },
-    {
-      "artifact_type": "rdx_selection_conflict_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "stable",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.122",
-      "last_updated_in": "1.3.122",
-      "example_path": "contracts/examples/rdx_selection_conflict_record.example.json",
-      "notes": "RDX bounded roadmap-governance hardening contract for deterministic selection, eval, replay, readiness, and fail-closed integrity checks."
-    },
-    {
-      "artifact_type": "rdx_selection_readiness_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "stable",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.122",
-      "last_updated_in": "1.3.122",
-      "example_path": "contracts/examples/rdx_selection_readiness_record.example.json",
-      "notes": "RDX bounded roadmap-governance hardening contract for deterministic selection, eval, replay, readiness, and fail-closed integrity checks."
-    },
-    {
-      "artifact_type": "rdx_selection_effectiveness_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "stable",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.122",
-      "last_updated_in": "1.3.122",
-      "example_path": "contracts/examples/rdx_selection_effectiveness_record.example.json",
-      "notes": "RDX bounded roadmap-governance hardening contract for deterministic selection, eval, replay, readiness, and fail-closed integrity checks."
-    },
-    {
-      "artifact_type": "rdx_rework_debt_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "stable",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.122",
-      "last_updated_in": "1.3.122",
-      "example_path": "contracts/examples/rdx_rework_debt_record.example.json",
-      "notes": "RDX bounded roadmap-governance hardening contract for deterministic selection, eval, replay, readiness, and fail-closed integrity checks."
-    },
-    {
-      "artifact_type": "rdx_roadmap_governance_bundle",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "stable",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.122",
-      "last_updated_in": "1.3.122",
-      "example_path": "contracts/examples/rdx_roadmap_governance_bundle.example.json",
-      "notes": "RDX bounded roadmap-governance hardening contract for deterministic selection, eval, replay, readiness, and fail-closed integrity checks."
     }
   ]
 }

--- a/docs/governance-reports/contract-enforcement-report.md
+++ b/docs/governance-reports/contract-enforcement-report.md
@@ -1,6 +1,6 @@
 # Cross-Repo Contract Enforcement Report
 
-Generated: 2026-04-12T22:51:05Z
+Generated: 2026-04-13T10:44:35Z
 Source: `contracts/standards-manifest.json`
 
 ## Summary

--- a/docs/review-actions/PLAN-PRG-001-2026-04-13.md
+++ b/docs/review-actions/PLAN-PRG-001-2026-04-13.md
@@ -1,0 +1,32 @@
+# Plan — PRG-001 — 2026-04-13
+
+## Prompt type
+BUILD
+
+## Roadmap item
+PRG-001 — Implement RDX closeout and PRG bounded program-governance foundation with built-in red-team review/fix loops
+
+## Objective
+Deliver repo-native implementation for RDX closeout gating and PRG governance hardening (contracts, deterministic engine, boundary fences, eval/readiness/replay/integrity checks, effectiveness tracking, RT1/RT2 exploit conversion to permanent guards) with fail-closed tests.
+
+## Declared files
+
+| File | Change type | Reason |
+| --- | --- | --- |
+| `spectrum_systems/modules/runtime/prg_hardening.py` | CREATE | Deterministic PRG engine, boundary/integrity checks, eval/readiness/replay/effectiveness logic, red-team rounds, and hardening hooks. |
+| `tests/test_prg_hardening.py` | CREATE | End-to-end roadmap-slice tests including RT1/RT2 exploit regression conversion. |
+| `contracts/schemas/*.schema.json` (PRG artifacts) | CREATE | Contract-first schema surface for PRG governance artifacts and candidate/readiness/eval bundles. |
+| `contracts/examples/*.json` (PRG artifacts) | CREATE | Valid canonical examples for all new PRG contracts. |
+| `contracts/standards-manifest.json` | MODIFY | Register new PRG contracts and version bump. |
+| `tests/test_contracts.py` | MODIFY | Add contract example validation coverage for new PRG artifacts. |
+| `PLANS.md` | MODIFY | Register this plan entry per plan-first operating rule. |
+
+## Tests that must pass after execution
+1. `pytest tests/test_prg_hardening.py tests/test_rdx_hardening.py`
+2. `pytest tests/test_contracts.py tests/test_contract_enforcement.py`
+3. `python scripts/run_contract_enforcement.py`
+
+## Scope exclusions
+- No ownership redefinition outside canonical system registry.
+- No execution-authority expansion for PRG.
+- No unrelated refactors outside RDX/PRG hardening seams.

--- a/governance/reports/contract-dependency-graph.json
+++ b/governance/reports/contract-dependency-graph.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0.0",
-  "generated_at": "2026-04-12T22:51:05Z",
+  "generated_at": "2026-04-13T10:44:35Z",
   "source_manifest": "contracts/standards-manifest.json",
   "repos": [
     {

--- a/spectrum_systems/modules/runtime/prg_hardening.py
+++ b/spectrum_systems/modules/runtime/prg_hardening.py
@@ -1,0 +1,334 @@
+"""PRG bounded program-governance hardening with deterministic recommendation/eval/replay loops."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import Counter
+from typing import Any, Mapping
+
+from spectrum_systems.contracts import validate_artifact
+
+
+class PRGHardeningError(ValueError):
+    """Raised when PRG governance checks fail closed."""
+
+
+_FORBIDDEN_ACTION_PREFIXES = (
+    "execute_work",
+    "admission_gate",
+    "enforce_runtime_block",
+    "issue_closure",
+    "issue_policy",
+    "interpret_review_packet",
+)
+
+
+ALLOWED_UPSTREAM_INPUTS = {
+    "roadmap_signal_bundle",
+    "roadmap_review_view_artifact",
+    "batch_delivery_report",
+    "evaluation_pattern_signal",
+    "trust_posture_snapshot",
+    "program_alignment_input",
+}
+
+ALLOWED_DOWNSTREAM_OUTPUTS = {
+    "evaluation_pattern_report",
+    "policy_change_candidate",
+    "slice_contract_update_candidate",
+    "program_alignment_assessment",
+    "prioritized_adoption_candidate_set",
+    "adaptive_readiness_record",
+    "program_roadmap_alignment_result",
+    "prg_governance_eval_result",
+    "prg_governance_readiness_record",
+    "prg_governance_conflict_record",
+    "prg_governance_effectiveness_record",
+    "prg_recommendation_rework_debt_record",
+    "prg_governance_bundle",
+}
+
+
+def _hash(payload: Any) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def enforce_prg_boundary(*, consumed_inputs: list[str], emitted_outputs: list[str], claimed_actions: list[str]) -> list[str]:
+    failures: list[str] = []
+    for name in consumed_inputs:
+        if name not in ALLOWED_UPSTREAM_INPUTS:
+            failures.append(f"invalid_upstream_input:{name}")
+    for name in emitted_outputs:
+        if name not in ALLOWED_DOWNSTREAM_OUTPUTS:
+            failures.append(f"invalid_downstream_output:{name}")
+    for action in claimed_actions:
+        if action.startswith(_FORBIDDEN_ACTION_PREFIXES):
+            failures.append(f"forbidden_owner_overlap:{action}")
+    return sorted(set(failures))
+
+
+def run_governance_recommendation_engine(*, program_brief: Mapping[str, Any], roadmap_signal_bundle: Mapping[str, Any], evaluation_patterns: list[Mapping[str, Any]], created_at: str, trace_id: str) -> dict[str, Any]:
+    unresolved = sorted({str(v) for v in roadmap_signal_bundle.get("missing_eval_coverage", []) if str(v)})
+    hotspots = sorted({str(v) for v in roadmap_signal_bundle.get("override_hotspots", []) if str(v)})
+    if not unresolved and not hotspots:
+        raise PRGHardeningError("governance_inputs_insufficient")
+
+    counts = Counter(str(row.get("pattern_code") or "unknown") for row in evaluation_patterns if isinstance(row, Mapping))
+    pattern_rows = [
+        {"pattern_code": code, "occurrences": count, "evidence_refs": [f"eval_pattern:{code}"]}
+        for code, count in sorted(counts.items())
+    ]
+    pattern_report = {
+        "artifact_type": "evaluation_pattern_report",
+        "report_id": f"epr-{_hash([trace_id, created_at, pattern_rows])[:16]}",
+        "program_id": str(program_brief.get("program_id") or "PRG-UNKNOWN"),
+        "generated_at": created_at,
+        "trace_id": trace_id,
+        "lineage_ref": str(program_brief.get("lineage_ref") or "lineage:unknown"),
+        "patterns": pattern_rows,
+        "causal_claims": [
+            {
+                "claim_id": "claim-1",
+                "claim": "recurring coverage gaps increase governance risk",
+                "evidence_refs": sorted({*hotspots, *unresolved})[:4],
+                "supported": True,
+            }
+        ],
+    }
+    validate_artifact(pattern_report, "evaluation_pattern_report")
+
+    adoption_candidates = []
+    for code, count in sorted(counts.items()):
+        adoption_candidates.append(
+            {
+                "candidate_id": f"cand-{code}",
+                "target_type": "slice_contract",
+                "target_ref": f"slice:{code}",
+                "priority": min(100, 50 + (count * 10)),
+                "reason_codes": ["pattern_recurrence", "trust_gap_first"],
+                "authority_scope": "recommendation_only",
+                "evidence_refs": [f"evaluation_pattern_report:{pattern_report['report_id']}"],
+            }
+        )
+    candidate_set = {
+        "artifact_type": "prioritized_adoption_candidate_set",
+        "candidate_set_id": f"pacs-{_hash([trace_id, adoption_candidates])[:16]}",
+        "program_id": pattern_report["program_id"],
+        "generated_at": created_at,
+        "trace_id": trace_id,
+        "lineage_ref": pattern_report["lineage_ref"],
+        "non_authority_assertions": ["recommendation_only", "not_policy_authority", "not_closure_authority"],
+        "candidates": sorted(adoption_candidates, key=lambda row: (-int(row["priority"]), str(row["candidate_id"]))),
+    }
+    validate_artifact(candidate_set, "prioritized_adoption_candidate_set")
+
+    alignment = {
+        "artifact_type": "program_alignment_assessment",
+        "assessment_id": f"paa-{_hash([trace_id, unresolved, hotspots])[:16]}",
+        "program_id": pattern_report["program_id"],
+        "alignment_status": "misaligned" if hotspots else "aligned",
+        "strategy_integrity": "trust_gap_first",
+        "created_at": created_at,
+        "trace_id": trace_id,
+        "lineage_ref": pattern_report["lineage_ref"],
+        "reason_codes": ["incomplete_trust_layers_prioritized"] if unresolved else ["no_open_trust_gaps"],
+        "fail_reasons": ["override_hotspot_detected"] if hotspots else [],
+    }
+    validate_artifact(alignment, "program_alignment_assessment")
+
+    return {
+        "pattern_report": pattern_report,
+        "candidate_set": candidate_set,
+        "alignment_assessment": alignment,
+    }
+
+
+def run_governance_eval(*, pattern_report: Mapping[str, Any], candidate_set: Mapping[str, Any], alignment_assessment: Mapping[str, Any], evidence_refs: list[str], created_at: str, trace_id: str) -> dict[str, Any]:
+    checks = {
+        "evidence_sufficient": len([r for r in evidence_refs if str(r).strip()]) >= 2,
+        "recommendation_bounded": all(str(c.get("authority_scope")) == "recommendation_only" for c in candidate_set.get("candidates", [])),
+        "strategy_alignment": str(alignment_assessment.get("strategy_integrity")) == "trust_gap_first",
+        "non_authority_correct": bool(candidate_set.get("non_authority_assertions")),
+        "artifact_completeness": bool(pattern_report.get("patterns")) and isinstance(candidate_set.get("candidates"), list),
+    }
+    fail_reasons = [k for k, ok in checks.items() if not ok]
+    result = {
+        "artifact_type": "prg_governance_eval_result",
+        "eval_id": f"pge-{_hash([trace_id, checks, created_at])[:16]}",
+        "created_at": created_at,
+        "trace_id": trace_id,
+        "lineage_ref": str(pattern_report.get("lineage_ref") or "lineage:unknown"),
+        "evaluation_status": "pass" if not fail_reasons else "fail",
+        "checks": checks,
+        "fail_reasons": sorted(fail_reasons),
+    }
+    validate_artifact(result, "prg_governance_eval_result")
+    return result
+
+
+def build_governance_readiness(*, eval_result: Mapping[str, Any], evidence_complete: bool, created_at: str, trace_id: str) -> dict[str, Any]:
+    fail_reasons = []
+    if eval_result.get("evaluation_status") != "pass":
+        fail_reasons.append("governance_eval_failed")
+    if not evidence_complete:
+        fail_reasons.append("governance_evidence_incomplete")
+    readiness = {
+        "artifact_type": "prg_governance_readiness_record",
+        "readiness_id": f"pgr-{_hash([trace_id, eval_result.get('eval_id'), fail_reasons])[:16]}",
+        "created_at": created_at,
+        "trace_id": trace_id,
+        "lineage_ref": str(eval_result.get("lineage_ref") or "lineage:unknown"),
+        "readiness_status": "candidate_only" if not fail_reasons else "blocked",
+        "non_authority_assertions": [
+            "prg_not_policy_authority",
+            "prg_not_closure_authority",
+            "prg_not_execution_authority",
+            "prg_not_runtime_enforcement",
+        ],
+        "fail_reasons": sorted(fail_reasons),
+    }
+    validate_artifact(readiness, "prg_governance_readiness_record")
+    return readiness
+
+
+def validate_recommendation_replay(*, prior_inputs: Mapping[str, Any], replay_inputs: Mapping[str, Any], prior_outputs: Mapping[str, Any], replay_outputs: Mapping[str, Any]) -> tuple[bool, list[str]]:
+    failures: list[str] = []
+    if _hash(prior_inputs) != _hash(replay_inputs):
+        failures.append("replay_input_drift")
+    if _hash(prior_outputs) != _hash(replay_outputs):
+        failures.append("replay_output_drift")
+    return not failures, failures
+
+
+def check_recommendation_authority_boundary(*, recommendation_artifacts: list[Mapping[str, Any]]) -> list[str]:
+    fails: list[str] = []
+    for row in recommendation_artifacts:
+        purpose = str(row.get("used_for") or "")
+        art_id = str(row.get("artifact_id") or "unknown")
+        if purpose in {"policy_decision", "closure_decision", "roadmap_progression_authority"}:
+            fails.append(f"recommendation_authority_leakage:{art_id}")
+    return sorted(set(fails))
+
+
+def check_adoption_candidate_integrity(*, candidate_set: Mapping[str, Any]) -> list[str]:
+    fails: list[str] = []
+    for row in candidate_set.get("candidates", []):
+        if str(row.get("authority_scope")) != "recommendation_only":
+            fails.append(f"candidate_authority_scope_invalid:{row.get('candidate_id')}")
+    return sorted(set(fails))
+
+
+def check_trust_posture_snapshot_integrity(*, trust_posture_snapshot: Mapping[str, Any]) -> list[str]:
+    refs = trust_posture_snapshot.get("evidence_refs", [])
+    if not isinstance(refs, list) or not refs:
+        return ["trust_posture_evidence_missing"]
+    if any(str(ref).startswith("narrative:") for ref in refs):
+        return ["trust_posture_narrative_inference_blocked"]
+    return []
+
+
+def build_recommendation_rework_debt(*, recommendation_history: list[Mapping[str, Any]], created_at: str, trace_id: str) -> dict[str, Any]:
+    counter = Counter(str(r.get("recommendation_key") or "unknown") for r in recommendation_history)
+    repeated = {k: c for k, c in counter.items() if c >= 2}
+    record = {
+        "artifact_type": "prg_recommendation_rework_debt_record",
+        "debt_id": f"prd-{_hash([trace_id, repeated, created_at])[:16]}",
+        "created_at": created_at,
+        "trace_id": trace_id,
+        "lineage_ref": "lineage:prg:rework",
+        "rework_items": [
+            {"recommendation_key": key, "recurrence_count": count, "status": "open"}
+            for key, count in sorted(repeated.items())
+        ],
+        "debt_status": "elevated" if repeated else "stable",
+    }
+    validate_artifact(record, "prg_recommendation_rework_debt_record")
+    return record
+
+
+def check_governance_to_rdx_integrity(*, prg_handoff: Mapping[str, Any], rdx_input: Mapping[str, Any]) -> list[str]:
+    fails = []
+    if str(prg_handoff.get("authority_scope")) != "recommendation_only":
+        fails.append("handoff_scope_invalid")
+    if str(rdx_input.get("authority_scope")) != "recommendation_input":
+        fails.append("rdx_input_scope_invalid")
+    return sorted(set(fails))
+
+
+def check_pattern_report_integrity(*, report: Mapping[str, Any]) -> list[str]:
+    fails: list[str] = []
+    for claim in report.get("causal_claims", []):
+        if not claim.get("evidence_refs"):
+            fails.append(f"unsupported_causal_claim:{claim.get('claim_id')}")
+    return sorted(set(fails))
+
+
+def run_prg_boundary_redteam(*, fixtures: list[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    findings = []
+    for row in fixtures:
+        if row.get("should_fail_closed") and row.get("observed") != "blocked":
+            findings.append({"fixture_id": str(row.get("fixture_id")), "severity": "high", "class": "boundary_fail_open"})
+    return sorted(findings, key=lambda r: r["fixture_id"])
+
+
+def run_prg_semantic_redteam(*, fixtures: list[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    findings = []
+    for row in fixtures:
+        if row.get("semantic_risk") and row.get("observed") != "blocked":
+            findings.append({"fixture_id": str(row.get("fixture_id")), "severity": "high", "class": "semantic_fail_open"})
+    return sorted(findings, key=lambda r: r["fixture_id"])
+
+
+def build_governance_effectiveness(*, outcomes: list[Mapping[str, Any]], created_at: str, trace_id: str) -> dict[str, Any]:
+    if not outcomes:
+        raise PRGHardeningError("effectiveness_outcomes_required")
+    improved = sum(1 for row in outcomes if row.get("trust_improved") is True)
+    drift_reduced = sum(1 for row in outcomes if row.get("drift_reduced") is True)
+    alignment_improved = sum(1 for row in outcomes if row.get("alignment_improved") is True)
+    total = len(outcomes)
+    score = round((improved + drift_reduced + alignment_improved) / (total * 3), 4)
+    record = {
+        "artifact_type": "prg_governance_effectiveness_record",
+        "effectiveness_id": f"pgeff-{_hash([trace_id, score, created_at])[:16]}",
+        "created_at": created_at,
+        "trace_id": trace_id,
+        "lineage_ref": "lineage:prg:effectiveness",
+        "window_size": total,
+        "trust_improvement_rate": round(improved / total, 4),
+        "drift_reduction_rate": round(drift_reduced / total, 4),
+        "alignment_improvement_rate": round(alignment_improved / total, 4),
+        "effectiveness_score": score,
+        "value_status": "improving" if score >= 0.66 else "stagnating",
+    }
+    validate_artifact(record, "prg_governance_effectiveness_record")
+    return record
+
+
+def build_governance_conflict_record(*, conflict_codes: list[str], created_at: str, trace_id: str) -> dict[str, Any]:
+    record = {
+        "artifact_type": "prg_governance_conflict_record",
+        "conflict_id": f"pgc-{_hash([trace_id, conflict_codes, created_at])[:16]}",
+        "created_at": created_at,
+        "trace_id": trace_id,
+        "lineage_ref": "lineage:prg:conflicts",
+        "conflict_codes": sorted({str(c) for c in conflict_codes if str(c)}),
+        "severity": "high" if conflict_codes else "none",
+    }
+    validate_artifact(record, "prg_governance_conflict_record")
+    return record
+
+
+def build_governance_bundle(*, artifact_refs: list[str], created_at: str, trace_id: str) -> dict[str, Any]:
+    bundle = {
+        "artifact_type": "prg_governance_bundle",
+        "bundle_id": f"pgb-{_hash([trace_id, artifact_refs, created_at])[:16]}",
+        "created_at": created_at,
+        "trace_id": trace_id,
+        "lineage_ref": "lineage:prg:bundle",
+        "artifact_refs": sorted({str(ref) for ref in artifact_refs if str(ref)}),
+        "non_authority_assertions": ["recommendation_only", "candidate_only_readiness"],
+    }
+    validate_artifact(bundle, "prg_governance_bundle")
+    return bundle

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -237,6 +237,26 @@ class ContractSchemaTests(unittest.TestCase):
             validate_artifact(instance, name)
 
 
+
+
+    def test_prg_governance_contract_examples_validate(self) -> None:
+        for name in (
+            "evaluation_pattern_report",
+            "policy_change_candidate",
+            "slice_contract_update_candidate",
+            "program_alignment_assessment",
+            "prioritized_adoption_candidate_set",
+            "adaptive_readiness_record",
+            "prg_governance_eval_result",
+            "prg_governance_readiness_record",
+            "prg_governance_conflict_record",
+            "prg_governance_bundle",
+            "prg_governance_effectiveness_record",
+            "prg_recommendation_rework_debt_record",
+        ):
+            instance = load_example(name)
+            validate_artifact(instance, name)
+
     def test_rqx_redteam_contract_examples_validate(self) -> None:
         for name in (
             "redteam_review_request",

--- a/tests/test_prg_hardening.py
+++ b/tests/test_prg_hardening.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from spectrum_systems.contracts import load_example, validate_artifact
+from spectrum_systems.modules.runtime.prg_hardening import (
+    PRGHardeningError,
+    build_governance_bundle,
+    build_governance_conflict_record,
+    build_governance_effectiveness,
+    build_governance_readiness,
+    build_recommendation_rework_debt,
+    check_adoption_candidate_integrity,
+    check_governance_to_rdx_integrity,
+    check_pattern_report_integrity,
+    check_recommendation_authority_boundary,
+    check_trust_posture_snapshot_integrity,
+    enforce_prg_boundary,
+    run_governance_eval,
+    run_governance_recommendation_engine,
+    run_prg_boundary_redteam,
+    run_prg_semantic_redteam,
+    validate_recommendation_replay,
+)
+
+
+def _program_brief() -> dict:
+    return {
+        "program_id": "PRG-ROADMAP-EXECUTION",
+        "lineage_ref": "lineage:prg:001",
+    }
+
+
+def _signal_bundle() -> dict:
+    return {
+        "missing_eval_coverage": ["S1", "S2"],
+        "override_hotspots": [],
+    }
+
+
+def test_prg_contract_examples_validate() -> None:
+    for name in (
+        "evaluation_pattern_report",
+        "policy_change_candidate",
+        "slice_contract_update_candidate",
+        "program_alignment_assessment",
+        "prioritized_adoption_candidate_set",
+        "adaptive_readiness_record",
+        "prg_governance_eval_result",
+        "prg_governance_readiness_record",
+        "prg_governance_conflict_record",
+        "prg_governance_bundle",
+        "prg_governance_effectiveness_record",
+        "prg_recommendation_rework_debt_record",
+    ):
+        validate_artifact(load_example(name), name)
+
+
+def test_prg_01_02_03_04_06_07_engine_eval_alignment_replay() -> None:
+    failures = enforce_prg_boundary(
+        consumed_inputs=["roadmap_signal_bundle", "runtime_execution_state"],
+        emitted_outputs=["prioritized_adoption_candidate_set", "closure_decision_artifact"],
+        claimed_actions=["execute_work:batch-1"],
+    )
+    assert "invalid_upstream_input:runtime_execution_state" in failures
+    assert "invalid_downstream_output:closure_decision_artifact" in failures
+    assert "forbidden_owner_overlap:execute_work:batch-1" in failures
+
+    outputs = run_governance_recommendation_engine(
+        program_brief=_program_brief(),
+        roadmap_signal_bundle=_signal_bundle(),
+        evaluation_patterns=[{"pattern_code": "missing_eval_coverage"}, {"pattern_code": "missing_eval_coverage"}],
+        created_at="2026-04-13T00:00:00Z",
+        trace_id="trace-prg-001",
+    )
+    eval_result = run_governance_eval(
+        pattern_report=outputs["pattern_report"],
+        candidate_set=outputs["candidate_set"],
+        alignment_assessment=outputs["alignment_assessment"],
+        evidence_refs=["ev:1", "ev:2"],
+        created_at="2026-04-13T00:00:00Z",
+        trace_id="trace-prg-001",
+    )
+    assert eval_result["evaluation_status"] == "pass"
+
+    replay_ok, replay_fails = validate_recommendation_replay(
+        prior_inputs={"program_brief": _program_brief(), "signal": _signal_bundle()},
+        replay_inputs={"program_brief": _program_brief(), "signal": _signal_bundle()},
+        prior_outputs=outputs,
+        replay_outputs=copy.deepcopy(outputs),
+    )
+    assert replay_ok is True
+    assert replay_fails == []
+
+
+def test_prg_05_08_08a_08b_08c_08d_08e_09_and_redteam_fix_loops() -> None:
+    outputs = run_governance_recommendation_engine(
+        program_brief=_program_brief(),
+        roadmap_signal_bundle=_signal_bundle(),
+        evaluation_patterns=[{"pattern_code": "P1"}, {"pattern_code": "P1"}, {"pattern_code": "P2"}],
+        created_at="2026-04-13T00:00:00Z",
+        trace_id="trace-prg-001",
+    )
+    eval_result = run_governance_eval(
+        pattern_report=outputs["pattern_report"],
+        candidate_set=outputs["candidate_set"],
+        alignment_assessment=outputs["alignment_assessment"],
+        evidence_refs=["ev:1", "ev:2", "ev:3"],
+        created_at="2026-04-13T00:00:00Z",
+        trace_id="trace-prg-001",
+    )
+    readiness = build_governance_readiness(
+        eval_result=eval_result,
+        evidence_complete=True,
+        created_at="2026-04-13T00:00:00Z",
+        trace_id="trace-prg-001",
+    )
+    assert readiness["readiness_status"] == "candidate_only"
+
+    assert check_recommendation_authority_boundary(recommendation_artifacts=[{"artifact_id": "a1", "used_for": "policy_decision"}]) == [
+        "recommendation_authority_leakage:a1"
+    ]
+    assert check_adoption_candidate_integrity(candidate_set=outputs["candidate_set"]) == []
+    assert check_trust_posture_snapshot_integrity(trust_posture_snapshot={"evidence_refs": ["signal:s1"]}) == []
+
+    debt = build_recommendation_rework_debt(
+        recommendation_history=[
+            {"recommendation_key": "k1"},
+            {"recommendation_key": "k1"},
+            {"recommendation_key": "k2"},
+        ],
+        created_at="2026-04-13T00:00:00Z",
+        trace_id="trace-prg-001",
+    )
+    assert debt["debt_status"] == "elevated"
+
+    assert check_governance_to_rdx_integrity(
+        prg_handoff={"authority_scope": "recommendation_only"},
+        rdx_input={"authority_scope": "recommendation_input"},
+    ) == []
+    assert check_pattern_report_integrity(report=outputs["pattern_report"]) == []
+
+    rt1 = run_prg_boundary_redteam(
+        fixtures=[
+            {"fixture_id": "RT1-AUTH-LEAK", "should_fail_closed": True, "observed": "accepted"},
+            {"fixture_id": "RT1-BLOCKED", "should_fail_closed": True, "observed": "blocked"},
+        ]
+    )
+    rt2 = run_prg_semantic_redteam(
+        fixtures=[
+            {"fixture_id": "RT2-PRIORITY-INVERSION", "semantic_risk": True, "observed": "accepted"},
+            {"fixture_id": "RT2-BLOCKED", "semantic_risk": True, "observed": "blocked"},
+        ]
+    )
+    assert [row["fixture_id"] for row in rt1] == ["RT1-AUTH-LEAK"]
+    assert [row["fixture_id"] for row in rt2] == ["RT2-PRIORITY-INVERSION"]
+
+    conflict = build_governance_conflict_record(
+        conflict_codes=["RT1-AUTH-LEAK", "RT2-PRIORITY-INVERSION"],
+        created_at="2026-04-13T00:00:00Z",
+        trace_id="trace-prg-001",
+    )
+    assert conflict["severity"] == "high"
+
+    effectiveness = build_governance_effectiveness(
+        outcomes=[
+            {"trust_improved": True, "drift_reduced": True, "alignment_improved": True},
+            {"trust_improved": True, "drift_reduced": False, "alignment_improved": True},
+            {"trust_improved": False, "drift_reduced": True, "alignment_improved": True},
+        ],
+        created_at="2026-04-13T00:00:00Z",
+        trace_id="trace-prg-001",
+    )
+    assert effectiveness["value_status"] == "improving"
+
+    bundle = build_governance_bundle(
+        artifact_refs=[
+            f"evaluation_pattern_report:{outputs['pattern_report']['report_id']}",
+            f"prioritized_adoption_candidate_set:{outputs['candidate_set']['candidate_set_id']}",
+            f"prg_governance_eval_result:{eval_result['eval_id']}",
+        ],
+        created_at="2026-04-13T00:00:00Z",
+        trace_id="trace-prg-001",
+    )
+    assert bundle["artifact_type"] == "prg_governance_bundle"
+
+    with pytest.raises(PRGHardeningError, match="effectiveness_outcomes_required"):
+        build_governance_effectiveness(outcomes=[], created_at="2026-04-13T00:00:00Z", trace_id="trace-prg-001")
+
+    with pytest.raises(PRGHardeningError, match="governance_inputs_insufficient"):
+        run_governance_recommendation_engine(
+            program_brief=_program_brief(),
+            roadmap_signal_bundle={"missing_eval_coverage": [], "override_hotspots": []},
+            evaluation_patterns=[],
+            created_at="2026-04-13T00:00:00Z",
+            trace_id="trace-prg-001",
+        )


### PR DESCRIPTION
### Motivation
- Provide a repo-native, deterministic, fail-closed PRG (program-governance) foundation that is recommendation-only and safe to depend on RDX outputs. 
- Ensure RDX closeout gates are operationally real before PRG consumes roadmap signals to avoid progression-vs-closure leakage. 
- Prevent authority leakage and semantic/prioritization regressions by building red-team rounds whose findings become permanent evals, tests, and hardened logic. 
- Establish contract-first artifacts for PRG outputs (schemas + examples) so governance artifacts are schema-validated, trace-linked, and fail-closed when required evidence is missing. 

### Description
- Added a deterministic PRG runtime module `spectrum_systems/modules/runtime/prg_hardening.py` implementing boundary fencing, a recommendation engine, governance eval/readiness, replay validation, authority-boundary checks, trust-posture integrity checks, rework-debt tracking, effectiveness calculations, RT1/RT2 red-team runners, conflict bundling, and bundle builders. Key functions include `enforce_prg_boundary`, `run_governance_recommendation_engine`, `run_governance_eval`, `build_governance_readiness`, `validate_recommendation_replay`, `check_recommendation_authority_boundary`, `build_recommendation_rework_debt`, `run_prg_boundary_redteam`, and `run_prg_semantic_redteam`. 
- Added contract-first schema and example coverage for PRG artifact families under `contracts/schemas/` and `contracts/examples/` (notable artifacts: `evaluation_pattern_report`, `prioritized_adoption_candidate_set`, `program_alignment_assessment`, `prg_governance_eval_result`, `prg_governance_readiness_record`, `prg_governance_conflict_record`, `prg_governance_bundle`, `prg_governance_effectiveness_record`, `prg_recommendation_rework_debt_record`, plus related candidate/patch artifacts). 
- Updated `contracts/standards-manifest.json` to register the new PRG artifacts (version bump) and added canonical example payloads. 
- Added `tests/test_prg_hardening.py` for end-to-end PRG slices covering PRG-01..PRG-09, PRG-08A..08E, PRG-RT1/FX1 and PRG-RT2/FX2 behaviors, and integrated replay/eval/readiness assertions. 
- Extended `tests/test_contracts.py` to include PRG contract example validation. 
- Added a plan-first artifact `docs/review-actions/PLAN-PRG-001-2026-04-13.md` and registered it in `PLANS.md`. 

### Testing
- Ran PRG and RDX unit tests with `pytest tests/test_prg_hardening.py tests/test_rdx_hardening.py` which completed successfully (`9 passed`). 
- Ran contract validation and enforcement tests with `pytest tests/test_contracts.py tests/test_contract_enforcement.py` which completed successfully (`125 passed`). 
- Ran module-architecture checks with `pytest tests/test_module_architecture.py` which passed (`47 passed`). 
- Executed cross-repo contract enforcement with `python scripts/run_contract_enforcement.py` which produced a report and returned no failures (`failures=0 warnings=0`). 
- Executed contract-boundary audit `.codex/skills/contract-boundary-audit/run.sh` which completed with non-blocking warnings and no blocking errors. 
- All added/modified contract examples validate against their schemas using `spectrum_systems.contracts.validate_artifact` as exercised by the test suite (tests above).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcc7ddb3948329827727cad5744b51)