### PR TITLE
Implement PRG-10 closeout gate and MAP projection hardening foundation

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -89,6 +89,7 @@ List any prior roadmap items that must be complete before this plan can execute.
 
 ## Active plans
 
+| docs/review-actions/PLAN-MAP-001-PRG10-2026-04-13.md | MAP-001 — PRG-10 closeout + MAP bounded mediation/projection hardening with RT/FX loops | Active |
 | docs/review-actions/PLAN-BATCH-RIL-001-2026-04-12.md | BATCH-RIL-001 — FRE closeout + RIL bounded interpretation foundation/hardening | Active |
 | docs/review-actions/PLAN-REAL-WORLD-EXECUTION-CYCLE-01-2026-04-10.md | REAL-WORLD-EXECUTION-CYCLE-01 — Governed execution on real task input | Active |
 | docs/review-actions/PLAN-BATCH-RDX-EXEC-02-UMBRELLA-03-2026-04-10.md | BATCH-RDX-EXEC-02-UMBRELLA-03 — Serial umbrella governed execution + mandatory red-team review | Active |

--- a/contracts/examples/map_projection_bundle.json
+++ b/contracts/examples/map_projection_bundle.json
@@ -1,0 +1,15 @@
+{
+  "artifact_type": "map_projection_bundle",
+  "bundle_id": "mpb-a1b2c3d4e5f67890",
+  "created_at": "2026-04-13T00:00:00Z",
+  "trace_id": "trace-map-001",
+  "projection_ref": "map_projection_record:mpr-a1b2c3d4e5f67890",
+  "eval_ref": "map_projection_eval_result:mpe-a1b2c3d4e5f67890",
+  "readiness_ref": "map_projection_readiness_record:mprr-a1b2c3d4e5f67890",
+  "conflict_ref": "map_projection_conflict_record:mpc-a1b2c3d4e5f67890",
+  "debt_ref": "map_projection_debt_record:mpd-a1b2c3d4e5f67890",
+  "effectiveness_ref": "map_projection_effectiveness_record:mpeff-a1b2c3d4e5f67890",
+  "non_authority_assertions": [
+    "map_not_policy_authority"
+  ]
+}

--- a/contracts/examples/map_projection_conflict_record.json
+++ b/contracts/examples/map_projection_conflict_record.json
@@ -1,0 +1,11 @@
+{
+  "artifact_type": "map_projection_conflict_record",
+  "conflict_id": "mpc-a1b2c3d4e5f67890",
+  "created_at": "2026-04-13T00:00:00Z",
+  "trace_id": "trace-map-001",
+  "projection_eval_ref": "map_projection_eval_result:mpe-a1b2c3d4e5f67890",
+  "conflict_codes": [
+    "RT1-BOUNDARY-AUTH-LOOKING"
+  ],
+  "severity": "high"
+}

--- a/contracts/examples/map_projection_debt_record.json
+++ b/contracts/examples/map_projection_debt_record.json
@@ -1,0 +1,14 @@
+{
+  "artifact_type": "map_projection_debt_record",
+  "debt_id": "mpd-a1b2c3d4e5f67890",
+  "created_at": "2026-04-13T00:00:00Z",
+  "trace_id": "trace-map-001",
+  "debt_items": [
+    {
+      "incident_code": "field_loss",
+      "recurrence_count": 3,
+      "status": "open"
+    }
+  ],
+  "debt_status": "elevated"
+}

--- a/contracts/examples/map_projection_effectiveness_record.json
+++ b/contracts/examples/map_projection_effectiveness_record.json
@@ -1,0 +1,12 @@
+{
+  "artifact_type": "map_projection_effectiveness_record",
+  "effectiveness_id": "mpeff-a1b2c3d4e5f67890",
+  "created_at": "2026-04-13T00:00:00Z",
+  "trace_id": "trace-map-001",
+  "window_size": 5,
+  "usability_improvement_rate": 0.8,
+  "semantic_distortion_rate": 0.2,
+  "authority_confusion_rate": 0.0,
+  "effectiveness_score": 0.6,
+  "value_status": "improving"
+}

--- a/contracts/examples/map_projection_eval_result.json
+++ b/contracts/examples/map_projection_eval_result.json
@@ -1,0 +1,21 @@
+{
+  "artifact_type": "map_projection_eval_result",
+  "eval_id": "mpe-a1b2c3d4e5f67890",
+  "created_at": "2026-04-13T00:00:00Z",
+  "trace_id": "trace-map-001",
+  "projection_id": "mpr-a1b2c3d4e5f67890",
+  "evaluation_status": "pass",
+  "checks": {
+    "completeness": true,
+    "provenance_retention": true,
+    "contradiction_visibility": true,
+    "required_field_preservation": true,
+    "formatting_correctness": true,
+    "field_loss_detector": true,
+    "status_washing_detector": true,
+    "ril_to_map_integrity": true,
+    "projection_to_governance_integrity": true
+  },
+  "missing_required_fields": [],
+  "fail_reasons": []
+}

--- a/contracts/examples/map_projection_readiness_record.json
+++ b/contracts/examples/map_projection_readiness_record.json
@@ -1,0 +1,13 @@
+{
+  "artifact_type": "map_projection_readiness_record",
+  "readiness_id": "mprr-a1b2c3d4e5f67890",
+  "created_at": "2026-04-13T00:00:00Z",
+  "trace_id": "trace-map-001",
+  "projection_eval_ref": "map_projection_eval_result:mpe-a1b2c3d4e5f67890",
+  "readiness_status": "candidate_only",
+  "non_authority_assertions": [
+    "candidate_only",
+    "does_not_replace_cde"
+  ],
+  "fail_reasons": []
+}

--- a/contracts/examples/map_projection_record.json
+++ b/contracts/examples/map_projection_record.json
@@ -1,0 +1,33 @@
+{
+  "artifact_type": "map_projection_record",
+  "projection_id": "mpr-a1b2c3d4e5f67890",
+  "created_at": "2026-04-13T00:00:00Z",
+  "trace_id": "trace-map-001",
+  "lineage_ref": "rip-4f2a6e1c8d9b7a30",
+  "source_artifact_ref": "review_projection_bundle_artifact:rpb-1a2b3c4d5e6f7890",
+  "source_artifact_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "projection_scope": "mediation_projection_only",
+  "non_authority_assertions": [
+    "map_not_interpretation_authority",
+    "map_not_policy_authority"
+  ],
+  "status_markers": {
+    "blocker_present": true,
+    "escalation_present": true,
+    "highest_priority": "P0"
+  },
+  "contradiction_markers": [
+    "rii-1234567890abcdef"
+  ],
+  "projected_payload": {
+    "roadmap_projection_ref": "rrp-1234567890abcdef",
+    "control_loop_projection_ref": "cri-abcdef1234567890",
+    "readiness_projection_ref": "rdp-1111222233334444",
+    "roadmap_item_count": 2,
+    "control_queue_count": 2,
+    "readiness_item_count": 1,
+    "evidence_trace_refs": [
+      "docs/reviews/RVW-MAP.md"
+    ]
+  }
+}

--- a/contracts/schemas/map_projection_bundle.schema.json
+++ b/contracts/schemas/map_projection_bundle.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/map_projection_bundle.schema.json",
+  "title": "MAP Projection Bundle",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "bundle_id",
+    "created_at",
+    "trace_id",
+    "projection_ref",
+    "eval_ref",
+    "readiness_ref",
+    "conflict_ref",
+    "debt_ref",
+    "effectiveness_ref",
+    "non_authority_assertions"
+  ],
+  "properties": {
+    "artifact_type": {
+      "type": "string",
+      "const": "map_projection_bundle"
+    },
+    "bundle_id": {
+      "type": "string",
+      "pattern": "^mpb-[a-f0-9]{16}$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "projection_ref": {
+      "type": "string",
+      "pattern": "^map_projection_record:mpr-[a-f0-9]{16}$"
+    },
+    "eval_ref": {
+      "type": "string",
+      "pattern": "^map_projection_eval_result:mpe-[a-f0-9]{16}$"
+    },
+    "readiness_ref": {
+      "type": "string",
+      "pattern": "^map_projection_readiness_record:mprr-[a-f0-9]{16}$"
+    },
+    "conflict_ref": {
+      "type": "string",
+      "pattern": "^map_projection_conflict_record:mpc-[a-f0-9]{16}$"
+    },
+    "debt_ref": {
+      "type": "string",
+      "pattern": "^map_projection_debt_record:mpd-[a-f0-9]{16}$"
+    },
+    "effectiveness_ref": {
+      "type": "string",
+      "pattern": "^map_projection_effectiveness_record:mpeff-[a-f0-9]{16}$"
+    },
+    "non_authority_assertions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/contracts/schemas/map_projection_conflict_record.schema.json
+++ b/contracts/schemas/map_projection_conflict_record.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/map_projection_conflict_record.schema.json",
+  "title": "MAP Projection Conflict Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "conflict_id",
+    "created_at",
+    "trace_id",
+    "projection_eval_ref",
+    "conflict_codes",
+    "severity"
+  ],
+  "properties": {
+    "artifact_type": {
+      "type": "string",
+      "const": "map_projection_conflict_record"
+    },
+    "conflict_id": {
+      "type": "string",
+      "pattern": "^mpc-[a-f0-9]{16}$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "projection_eval_ref": {
+      "type": "string",
+      "pattern": "^map_projection_eval_result:mpe-[a-f0-9]{16}$"
+    },
+    "conflict_codes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "severity": {
+      "type": "string",
+      "enum": [
+        "none",
+        "high"
+      ]
+    }
+  }
+}

--- a/contracts/schemas/map_projection_debt_record.schema.json
+++ b/contracts/schemas/map_projection_debt_record.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/map_projection_debt_record.schema.json",
+  "title": "MAP Projection Debt Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "debt_id",
+    "created_at",
+    "trace_id",
+    "debt_items",
+    "debt_status"
+  ],
+  "properties": {
+    "artifact_type": {
+      "type": "string",
+      "const": "map_projection_debt_record"
+    },
+    "debt_id": {
+      "type": "string",
+      "pattern": "^mpd-[a-f0-9]{16}$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "debt_items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "incident_code",
+          "recurrence_count",
+          "status"
+        ],
+        "properties": {
+          "incident_code": {
+            "type": "string",
+            "minLength": 1
+          },
+          "recurrence_count": {
+            "type": "integer",
+            "minimum": 2
+          },
+          "status": {
+            "type": "string",
+            "const": "open"
+          }
+        }
+      }
+    },
+    "debt_status": {
+      "type": "string",
+      "enum": [
+        "stable",
+        "elevated"
+      ]
+    }
+  }
+}

--- a/contracts/schemas/map_projection_effectiveness_record.schema.json
+++ b/contracts/schemas/map_projection_effectiveness_record.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/map_projection_effectiveness_record.schema.json",
+  "title": "MAP Projection Effectiveness Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "effectiveness_id",
+    "created_at",
+    "trace_id",
+    "window_size",
+    "usability_improvement_rate",
+    "semantic_distortion_rate",
+    "authority_confusion_rate",
+    "effectiveness_score",
+    "value_status"
+  ],
+  "properties": {
+    "artifact_type": {
+      "type": "string",
+      "const": "map_projection_effectiveness_record"
+    },
+    "effectiveness_id": {
+      "type": "string",
+      "pattern": "^mpeff-[a-f0-9]{16}$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "window_size": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "usability_improvement_rate": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "semantic_distortion_rate": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "authority_confusion_rate": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "effectiveness_score": {
+      "type": "number",
+      "minimum": -1,
+      "maximum": 1
+    },
+    "value_status": {
+      "type": "string",
+      "enum": [
+        "improving",
+        "degrading"
+      ]
+    }
+  }
+}

--- a/contracts/schemas/map_projection_eval_result.schema.json
+++ b/contracts/schemas/map_projection_eval_result.schema.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/map_projection_eval_result.schema.json",
+  "title": "MAP Projection Eval Result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "eval_id",
+    "created_at",
+    "trace_id",
+    "projection_id",
+    "evaluation_status",
+    "checks",
+    "missing_required_fields",
+    "fail_reasons"
+  ],
+  "properties": {
+    "artifact_type": {
+      "type": "string",
+      "const": "map_projection_eval_result"
+    },
+    "eval_id": {
+      "type": "string",
+      "pattern": "^mpe-[a-f0-9]{16}$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "projection_id": {
+      "type": "string",
+      "pattern": "^mpr-[a-f0-9]{16}$"
+    },
+    "evaluation_status": {
+      "type": "string",
+      "enum": [
+        "pass",
+        "fail"
+      ]
+    },
+    "checks": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "completeness",
+        "provenance_retention",
+        "contradiction_visibility",
+        "required_field_preservation",
+        "formatting_correctness",
+        "field_loss_detector",
+        "status_washing_detector",
+        "ril_to_map_integrity",
+        "projection_to_governance_integrity"
+      ],
+      "properties": {
+        "completeness": {
+          "type": "boolean"
+        },
+        "provenance_retention": {
+          "type": "boolean"
+        },
+        "contradiction_visibility": {
+          "type": "boolean"
+        },
+        "required_field_preservation": {
+          "type": "boolean"
+        },
+        "formatting_correctness": {
+          "type": "boolean"
+        },
+        "field_loss_detector": {
+          "type": "boolean"
+        },
+        "status_washing_detector": {
+          "type": "boolean"
+        },
+        "ril_to_map_integrity": {
+          "type": "boolean"
+        },
+        "projection_to_governance_integrity": {
+          "type": "boolean"
+        }
+      }
+    },
+    "missing_required_fields": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "fail_reasons": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/contracts/schemas/map_projection_readiness_record.schema.json
+++ b/contracts/schemas/map_projection_readiness_record.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/map_projection_readiness_record.schema.json",
+  "title": "MAP Projection Readiness Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "readiness_id",
+    "created_at",
+    "trace_id",
+    "projection_eval_ref",
+    "readiness_status",
+    "non_authority_assertions",
+    "fail_reasons"
+  ],
+  "properties": {
+    "artifact_type": {
+      "type": "string",
+      "const": "map_projection_readiness_record"
+    },
+    "readiness_id": {
+      "type": "string",
+      "pattern": "^mprr-[a-f0-9]{16}$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "projection_eval_ref": {
+      "type": "string",
+      "pattern": "^map_projection_eval_result:mpe-[a-f0-9]{16}$"
+    },
+    "readiness_status": {
+      "type": "string",
+      "enum": [
+        "candidate_only",
+        "blocked"
+      ]
+    },
+    "non_authority_assertions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "fail_reasons": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/contracts/schemas/map_projection_record.schema.json
+++ b/contracts/schemas/map_projection_record.schema.json
@@ -1,0 +1,143 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/map_projection_record.schema.json",
+  "title": "MAP Projection Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "projection_id",
+    "created_at",
+    "trace_id",
+    "lineage_ref",
+    "source_artifact_ref",
+    "source_artifact_hash",
+    "projection_scope",
+    "non_authority_assertions",
+    "status_markers",
+    "contradiction_markers",
+    "projected_payload"
+  ],
+  "properties": {
+    "artifact_type": {
+      "type": "string",
+      "const": "map_projection_record"
+    },
+    "projection_id": {
+      "type": "string",
+      "pattern": "^mpr-[a-f0-9]{16}$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "lineage_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source_artifact_ref": {
+      "type": "string",
+      "pattern": "^review_projection_bundle_artifact:rpb-[a-f0-9]{16}$"
+    },
+    "source_artifact_hash": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "projection_scope": {
+      "type": "string",
+      "const": "mediation_projection_only"
+    },
+    "non_authority_assertions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "status_markers": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "blocker_present",
+        "escalation_present",
+        "highest_priority"
+      ],
+      "properties": {
+        "blocker_present": {
+          "type": "boolean"
+        },
+        "escalation_present": {
+          "type": "boolean"
+        },
+        "highest_priority": {
+          "type": "string",
+          "enum": [
+            "P0",
+            "P1",
+            "P2",
+            "monitor"
+          ]
+        }
+      }
+    },
+    "contradiction_markers": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^rii-[a-f0-9]{16}$"
+      }
+    },
+    "projected_payload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "roadmap_projection_ref",
+        "control_loop_projection_ref",
+        "readiness_projection_ref",
+        "roadmap_item_count",
+        "control_queue_count",
+        "readiness_item_count",
+        "evidence_trace_refs"
+      ],
+      "properties": {
+        "roadmap_projection_ref": {
+          "type": "string",
+          "pattern": "^rrp-[a-f0-9]{16}$"
+        },
+        "control_loop_projection_ref": {
+          "type": "string",
+          "pattern": "^cri-[a-f0-9]{16}$"
+        },
+        "readiness_projection_ref": {
+          "type": "string",
+          "pattern": "^rdp-[a-f0-9]{16}$"
+        },
+        "roadmap_item_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "control_queue_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "readiness_item_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "evidence_trace_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/contracts/standards-manifest.json
+++ b/contracts/standards-manifest.json
@@ -1,12 +1,12 @@
 {
   "artifact_type": "standards_manifest",
   "artifact_id": "STD-CONTRACTS",
-  "artifact_version": "1.3.123",
+  "artifact_version": "1.3.124",
   "schema_version": "1.3.99",
-  "standards_version": "1.3.123",
-  "record_id": "REC-STD-2026-04-12-TLC-001",
-  "run_id": "run-20260412T220000Z-tlc-001",
-  "created_at": "2026-04-12T00:00:00Z",
+  "standards_version": "1.3.124",
+  "record_id": "REC-STD-2026-04-13-MAP-001",
+  "run_id": "run-20260413T000000Z-map-001",
+  "created_at": "2026-04-13T00:00:00Z",
   "created_by": {
     "name": "Spectrum Systems Architecture Team",
     "role": "standards-publication",
@@ -15,7 +15,7 @@
     "contact": "architecture@spectrum-systems.test"
   },
   "source_repo": "nicklasorte/spectrum-systems",
-  "source_repo_version": "1.3.122",
+  "source_repo_version": "1.3.123",
   "input_artifacts": [
     {
       "artifact_id": "STD-CONTRACTS",
@@ -2890,6 +2890,97 @@
       "last_updated_in": "1.3.71",
       "example_path": "contracts/examples/judgment_remediation_readiness_status.json",
       "notes": "Deterministic remediation readiness status including TPA bypass drift observability fields and blocking reason wiring."
+    },
+    {
+      "artifact_type": "map_projection_bundle",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.124",
+      "last_updated_in": "1.3.124",
+      "example_path": "contracts/examples/map_projection_bundle.json",
+      "notes": "MAP-001 bounded mediation/projection hardening contract with deterministic fail-closed behavior."
+    },
+    {
+      "artifact_type": "map_projection_conflict_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.124",
+      "last_updated_in": "1.3.124",
+      "example_path": "contracts/examples/map_projection_conflict_record.json",
+      "notes": "MAP-001 bounded mediation/projection hardening contract with deterministic fail-closed behavior."
+    },
+    {
+      "artifact_type": "map_projection_debt_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.124",
+      "last_updated_in": "1.3.124",
+      "example_path": "contracts/examples/map_projection_debt_record.json",
+      "notes": "MAP-001 bounded mediation/projection hardening contract with deterministic fail-closed behavior."
+    },
+    {
+      "artifact_type": "map_projection_effectiveness_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.124",
+      "last_updated_in": "1.3.124",
+      "example_path": "contracts/examples/map_projection_effectiveness_record.json",
+      "notes": "MAP-001 bounded mediation/projection hardening contract with deterministic fail-closed behavior."
+    },
+    {
+      "artifact_type": "map_projection_eval_result",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.124",
+      "last_updated_in": "1.3.124",
+      "example_path": "contracts/examples/map_projection_eval_result.json",
+      "notes": "MAP-001 bounded mediation/projection hardening contract with deterministic fail-closed behavior."
+    },
+    {
+      "artifact_type": "map_projection_readiness_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.124",
+      "last_updated_in": "1.3.124",
+      "example_path": "contracts/examples/map_projection_readiness_record.json",
+      "notes": "MAP-001 bounded mediation/projection hardening contract with deterministic fail-closed behavior."
+    },
+    {
+      "artifact_type": "map_projection_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.124",
+      "last_updated_in": "1.3.124",
+      "example_path": "contracts/examples/map_projection_record.json",
+      "notes": "MAP-001 bounded mediation/projection hardening contract with deterministic fail-closed behavior."
     },
     {
       "artifact_type": "meeting_agenda_contract",

--- a/docs/review-actions/PLAN-MAP-001-PRG10-2026-04-13.md
+++ b/docs/review-actions/PLAN-MAP-001-PRG10-2026-04-13.md
@@ -1,0 +1,53 @@
+# Plan — MAP-001 + PRG-10 — 2026-04-13
+
+## Prompt type
+BUILD
+
+## Roadmap item
+MAP-001 batch (PRG-10, MAP-01..MAP-FX2)
+
+## Objective
+Implement a bounded MAP mediation/projection hardening subsystem (contracts + runtime + tests) and PRG closeout gate checks with deterministic fail-closed validation and red-team regression coverage.
+
+## Declared files
+
+| File | Change type | Reason |
+| --- | --- | --- |
+| docs/review-actions/PLAN-MAP-001-PRG10-2026-04-13.md | CREATE | Required plan-first artifact before multi-file build. |
+| PLANS.md | MODIFY | Register active plan entry. |
+| contracts/schemas/map_projection_record.schema.json | CREATE | MAP deterministic projection output contract. |
+| contracts/schemas/map_projection_eval_result.schema.json | CREATE | MAP eval harness result contract. |
+| contracts/schemas/map_projection_readiness_record.schema.json | CREATE | Candidate-only readiness contract. |
+| contracts/schemas/map_projection_conflict_record.schema.json | CREATE | MAP conflict and detector findings contract. |
+| contracts/schemas/map_projection_bundle.schema.json | CREATE | Bounded MAP output bundle contract. |
+| contracts/schemas/map_projection_effectiveness_record.schema.json | CREATE | MAP effectiveness tracking contract. |
+| contracts/schemas/map_projection_debt_record.schema.json | CREATE | MAP projection debt tracking contract. |
+| contracts/examples/map_projection_record.json | CREATE | Golden example for MAP projection output. |
+| contracts/examples/map_projection_eval_result.json | CREATE | Golden example for MAP eval result. |
+| contracts/examples/map_projection_readiness_record.json | CREATE | Golden example for MAP readiness record. |
+| contracts/examples/map_projection_conflict_record.json | CREATE | Golden example for MAP conflict record. |
+| contracts/examples/map_projection_bundle.json | CREATE | Golden example for MAP bundle. |
+| contracts/examples/map_projection_effectiveness_record.json | CREATE | Golden example for MAP effectiveness. |
+| contracts/examples/map_projection_debt_record.json | CREATE | Golden example for MAP debt tracking. |
+| contracts/standards-manifest.json | MODIFY | Publish and version new MAP contracts. |
+| spectrum_systems/modules/runtime/prg_hardening.py | MODIFY | Add PRG-10 closeout gate checks and outputs. |
+| spectrum_systems/modules/runtime/map_projection_hardening.py | CREATE | MAP projection engine, eval harness, replay, integrity checks, debt/effectiveness, RT/FX loops. |
+| tests/test_prg_hardening.py | MODIFY | Add PRG-10 closeout assertions and regression coverage. |
+| tests/test_map_projection_hardening.py | CREATE | MAP step-by-step tests + red-team exploit regression conversion. |
+| tests/test_contracts.py | MODIFY | Add MAP contract example validation coverage. |
+
+## Contracts touched
+New MAP contracts listed above + standards-manifest version bump.
+
+## Tests that must pass after execution
+1. `pytest tests/test_map_projection_hardening.py tests/test_prg_hardening.py`
+2. `pytest tests/test_contracts.py tests/test_contract_enforcement.py`
+3. `python scripts/run_contract_enforcement.py`
+
+## Scope exclusions
+- Do not change RIL semantic interpretation ownership.
+- Do not modify CDE/TPA/RDX authority semantics.
+- Do not introduce networked/runtime side effects.
+
+## Dependencies
+- Existing `review_projection_bundle_artifact` and PRG hardening contracts must remain compatible.

--- a/spectrum_systems/modules/runtime/map_projection_hardening.py
+++ b/spectrum_systems/modules/runtime/map_projection_hardening.py
@@ -1,0 +1,313 @@
+"""MAP bounded mediation/projection hardening (MAP-01..MAP-FX2)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import Counter
+from typing import Any, Mapping
+
+from spectrum_systems.contracts import validate_artifact
+
+
+class MAPProjectionError(ValueError):
+    """Raised when MAP projection processing must fail closed."""
+
+
+_ALLOWED_UPSTREAM = {
+    "review_projection_bundle_artifact",
+    "roadmap_review_projection_artifact",
+    "readiness_review_projection_artifact",
+}
+
+_FORBIDDEN_ACTION_PREFIXES = (
+    "interpret_review",
+    "issue_policy",
+    "issue_closure",
+    "execute_work",
+    "enforce_runtime_action",
+    "prioritize_program_governance",
+)
+
+
+_REQUIRED_SOURCE_PATHS = (
+    "roadmap_projection",
+    "control_loop_projection",
+    "readiness_projection",
+)
+
+
+def _hash(payload: Any) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _read_path(payload: Mapping[str, Any], dotted: str) -> Any:
+    node: Any = payload
+    for part in dotted.split("."):
+        if not isinstance(node, Mapping) or part not in node:
+            return None
+        node = node[part]
+    return node
+
+
+def enforce_map_boundary(*, upstream_artifact_type: str, claimed_actions: list[str], emitted_artifact_types: list[str]) -> list[str]:
+    fails: list[str] = []
+    if upstream_artifact_type not in _ALLOWED_UPSTREAM:
+        fails.append(f"invalid_upstream_artifact:{upstream_artifact_type}")
+    for action in claimed_actions:
+        if action.startswith(_FORBIDDEN_ACTION_PREFIXES):
+            fails.append(f"forbidden_owner_overlap:{action}")
+    for artifact_type in emitted_artifact_types:
+        if artifact_type not in {
+            "map_projection_record",
+            "map_projection_eval_result",
+            "map_projection_readiness_record",
+            "map_projection_conflict_record",
+            "map_projection_bundle",
+            "map_projection_effectiveness_record",
+            "map_projection_debt_record",
+        }:
+            fails.append(f"invalid_downstream_artifact:{artifact_type}")
+    return sorted(set(fails))
+
+
+def build_map_projection_record(*, review_projection_bundle_artifact: Mapping[str, Any], created_at: str, trace_id: str) -> dict[str, Any]:
+    if str(review_projection_bundle_artifact.get("artifact_type")) != "review_projection_bundle_artifact":
+        raise MAPProjectionError("map_requires_review_projection_bundle_artifact")
+
+    missing_paths = [path for path in _REQUIRED_SOURCE_PATHS if _read_path(review_projection_bundle_artifact, path) is None]
+    if missing_paths:
+        raise MAPProjectionError(f"required_projection_sections_missing:{','.join(missing_paths)}")
+
+    record = {
+        "artifact_type": "map_projection_record",
+        "projection_id": f"mpr-{_hash([trace_id, created_at, review_projection_bundle_artifact.get('review_projection_bundle_id')])[:16]}",
+        "created_at": created_at,
+        "trace_id": trace_id,
+        "lineage_ref": str(review_projection_bundle_artifact.get("source_review_integration_packet_ref") or "lineage:unknown"),
+        "source_artifact_ref": f"review_projection_bundle_artifact:{review_projection_bundle_artifact.get('review_projection_bundle_id')}",
+        "source_artifact_hash": _hash(review_projection_bundle_artifact),
+        "projection_scope": "mediation_projection_only",
+        "non_authority_assertions": [
+            "map_not_interpretation_authority",
+            "map_not_policy_authority",
+            "map_not_closure_authority",
+            "map_not_execution_authority",
+        ],
+        "status_markers": {
+            "blocker_present": bool(review_projection_bundle_artifact.get("blocker_present")),
+            "escalation_present": bool(review_projection_bundle_artifact.get("escalation_present")),
+            "highest_priority": str(review_projection_bundle_artifact.get("roadmap_projection", {}).get("highest_priority") or "monitor"),
+        },
+        "contradiction_markers": sorted(
+            {
+                str(item.get("source_input_id"))
+                for item in review_projection_bundle_artifact.get("control_loop_projection", {}).get("control_queue_items", [])
+                if item.get("priority") == "P0" and item.get("severity") == "medium"
+            }
+        ),
+        "projected_payload": {
+            "roadmap_projection_ref": review_projection_bundle_artifact.get("roadmap_projection_ref"),
+            "control_loop_projection_ref": review_projection_bundle_artifact.get("control_loop_projection_ref"),
+            "readiness_projection_ref": review_projection_bundle_artifact.get("readiness_projection_ref"),
+            "roadmap_item_count": int(review_projection_bundle_artifact.get("roadmap_projection", {}).get("item_count", 0)),
+            "control_queue_count": int(review_projection_bundle_artifact.get("control_loop_projection", {}).get("item_count", 0)),
+            "readiness_item_count": int(review_projection_bundle_artifact.get("readiness_projection", {}).get("item_count", 0)),
+            "evidence_trace_refs": sorted(
+                {
+                    str(trace.get("source_path"))
+                    for section in (
+                        review_projection_bundle_artifact.get("roadmap_projection", {}).get("projected_roadmap_items", []),
+                        review_projection_bundle_artifact.get("control_loop_projection", {}).get("control_queue_items", []),
+                        review_projection_bundle_artifact.get("readiness_projection", {}).get("readiness_items", []),
+                    )
+                    for item in section
+                    for trace in item.get("trace_refs", [])
+                    if trace.get("source_path")
+                }
+            ),
+        },
+    }
+    validate_artifact(record, "map_projection_record")
+    return record
+
+
+def evaluate_map_projection(*, source_bundle: Mapping[str, Any], projection_record: Mapping[str, Any], expected_required_paths: list[str] | None = None, created_at: str, trace_id: str) -> dict[str, Any]:
+    expected_paths = expected_required_paths or list(_REQUIRED_SOURCE_PATHS)
+    missing_required_fields = [path for path in expected_paths if _read_path(source_bundle, path) is None]
+
+    source_refs = {
+        "roadmap": source_bundle.get("roadmap_projection_ref"),
+        "control": source_bundle.get("control_loop_projection_ref"),
+        "readiness": source_bundle.get("readiness_projection_ref"),
+    }
+    projection_payload = projection_record.get("projected_payload", {})
+    projected_refs = {
+        "roadmap": projection_payload.get("roadmap_projection_ref"),
+        "control": projection_payload.get("control_loop_projection_ref"),
+        "readiness": projection_payload.get("readiness_projection_ref"),
+    }
+
+    checks = {
+        "completeness": not missing_required_fields,
+        "provenance_retention": bool(projection_record.get("source_artifact_hash")) and bool(projection_payload.get("evidence_trace_refs")),
+        "contradiction_visibility": bool(projection_record.get("contradiction_markers") or projection_record.get("status_markers", {}).get("blocker_present")),
+        "required_field_preservation": source_refs == projected_refs,
+        "formatting_correctness": str(projection_record.get("projection_scope")) == "mediation_projection_only",
+        "field_loss_detector": not missing_required_fields,
+        "status_washing_detector": projection_record.get("status_markers") == {
+            "blocker_present": bool(source_bundle.get("blocker_present")),
+            "escalation_present": bool(source_bundle.get("escalation_present")),
+            "highest_priority": str(source_bundle.get("roadmap_projection", {}).get("highest_priority") or "monitor"),
+        },
+        "ril_to_map_integrity": str(source_bundle.get("source_review_integration_packet_ref")) in str(projection_record.get("lineage_ref")),
+        "projection_to_governance_integrity": "map_not_policy_authority" in projection_record.get("non_authority_assertions", []),
+    }
+
+    fail_reasons = [k for k, ok in checks.items() if not ok]
+    if missing_required_fields:
+        fail_reasons.append("missing_required_source_fields")
+
+    result = {
+        "artifact_type": "map_projection_eval_result",
+        "eval_id": f"mpe-{_hash([trace_id, projection_record.get('projection_id'), checks, created_at])[:16]}",
+        "created_at": created_at,
+        "trace_id": trace_id,
+        "projection_id": str(projection_record.get("projection_id")),
+        "evaluation_status": "pass" if not fail_reasons else "fail",
+        "checks": checks,
+        "missing_required_fields": sorted(set(missing_required_fields)),
+        "fail_reasons": sorted(set(fail_reasons)),
+    }
+    validate_artifact(result, "map_projection_eval_result")
+    return result
+
+
+def validate_map_projection_replay(*, prior_input: Mapping[str, Any], replay_input: Mapping[str, Any], prior_projection: Mapping[str, Any], replay_projection: Mapping[str, Any]) -> tuple[bool, list[str]]:
+    fails: list[str] = []
+    if _hash(prior_input) != _hash(replay_input):
+        fails.append("projection_replay_input_drift")
+    if _hash(prior_projection) != _hash(replay_projection):
+        fails.append("projection_replay_output_drift")
+    return not fails, fails
+
+
+def build_map_projection_readiness(*, eval_result: Mapping[str, Any], evidence_refs: list[str], created_at: str, trace_id: str) -> dict[str, Any]:
+    fail_reasons: list[str] = []
+    if str(eval_result.get("evaluation_status")) != "pass":
+        fail_reasons.append("projection_eval_failed")
+    if len([x for x in evidence_refs if str(x).strip()]) < 2:
+        fail_reasons.append("projection_evidence_incomplete")
+
+    readiness = {
+        "artifact_type": "map_projection_readiness_record",
+        "readiness_id": f"mprr-{_hash([trace_id, eval_result.get('eval_id'), fail_reasons, created_at])[:16]}",
+        "created_at": created_at,
+        "trace_id": trace_id,
+        "projection_eval_ref": f"map_projection_eval_result:{eval_result.get('eval_id')}",
+        "readiness_status": "candidate_only" if not fail_reasons else "blocked",
+        "non_authority_assertions": [
+            "candidate_only",
+            "does_not_replace_cde",
+            "does_not_replace_tpa",
+            "does_not_replace_prg",
+            "does_not_replace_rdx",
+        ],
+        "fail_reasons": sorted(set(fail_reasons)),
+    }
+    validate_artifact(readiness, "map_projection_readiness_record")
+    return readiness
+
+
+def build_map_projection_conflict_record(*, eval_result: Mapping[str, Any], redteam_findings: list[Mapping[str, Any]], created_at: str, trace_id: str) -> dict[str, Any]:
+    conflict_codes = sorted({*eval_result.get("fail_reasons", []), *(str(r.get("fixture_id")) for r in redteam_findings)})
+    record = {
+        "artifact_type": "map_projection_conflict_record",
+        "conflict_id": f"mpc-{_hash([trace_id, conflict_codes, created_at])[:16]}",
+        "created_at": created_at,
+        "trace_id": trace_id,
+        "projection_eval_ref": f"map_projection_eval_result:{eval_result.get('eval_id')}",
+        "conflict_codes": conflict_codes,
+        "severity": "high" if conflict_codes else "none",
+    }
+    validate_artifact(record, "map_projection_conflict_record")
+    return record
+
+
+def build_map_projection_debt_record(*, incidents: list[Mapping[str, Any]], created_at: str, trace_id: str) -> dict[str, Any]:
+    counts = Counter(str(row.get("incident_code") or "unknown") for row in incidents)
+    repeated = {k: v for k, v in counts.items() if v >= 2}
+    record = {
+        "artifact_type": "map_projection_debt_record",
+        "debt_id": f"mpd-{_hash([trace_id, repeated, created_at])[:16]}",
+        "created_at": created_at,
+        "trace_id": trace_id,
+        "debt_items": [
+            {"incident_code": code, "recurrence_count": count, "status": "open"}
+            for code, count in sorted(repeated.items())
+        ],
+        "debt_status": "elevated" if repeated else "stable",
+    }
+    validate_artifact(record, "map_projection_debt_record")
+    return record
+
+
+def build_map_projection_effectiveness(*, outcomes: list[Mapping[str, Any]], created_at: str, trace_id: str) -> dict[str, Any]:
+    if not outcomes:
+        raise MAPProjectionError("projection_effectiveness_outcomes_required")
+
+    usable = sum(1 for row in outcomes if row.get("usability_improved") is True)
+    distortion = sum(1 for row in outcomes if row.get("semantic_distortion_detected") is True)
+    confusion = sum(1 for row in outcomes if row.get("authority_confusion_detected") is True)
+    total = len(outcomes)
+    score = round((usable - distortion - confusion) / total, 4)
+
+    record = {
+        "artifact_type": "map_projection_effectiveness_record",
+        "effectiveness_id": f"mpeff-{_hash([trace_id, score, created_at])[:16]}",
+        "created_at": created_at,
+        "trace_id": trace_id,
+        "window_size": total,
+        "usability_improvement_rate": round(usable / total, 4),
+        "semantic_distortion_rate": round(distortion / total, 4),
+        "authority_confusion_rate": round(confusion / total, 4),
+        "effectiveness_score": score,
+        "value_status": "improving" if score >= 0.3 else "degrading",
+    }
+    validate_artifact(record, "map_projection_effectiveness_record")
+    return record
+
+
+def run_map_boundary_redteam(*, fixtures: list[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    for row in fixtures:
+        if row.get("should_fail_closed") and row.get("observed") != "blocked":
+            findings.append({"fixture_id": str(row.get("fixture_id")), "class": "boundary_fail_open", "severity": "high"})
+    return sorted(findings, key=lambda row: row["fixture_id"])
+
+
+def run_map_semantic_redteam(*, fixtures: list[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    for row in fixtures:
+        if row.get("semantic_risk") and row.get("observed") != "blocked":
+            findings.append({"fixture_id": str(row.get("fixture_id")), "class": "semantic_presentation_fail_open", "severity": "high"})
+    return sorted(findings, key=lambda row: row["fixture_id"])
+
+
+def build_map_projection_bundle(*, projection_record: Mapping[str, Any], eval_result: Mapping[str, Any], readiness_record: Mapping[str, Any], conflict_record: Mapping[str, Any], debt_record: Mapping[str, Any], effectiveness_record: Mapping[str, Any], created_at: str, trace_id: str) -> dict[str, Any]:
+    bundle = {
+        "artifact_type": "map_projection_bundle",
+        "bundle_id": f"mpb-{_hash([trace_id, projection_record.get('projection_id'), created_at])[:16]}",
+        "created_at": created_at,
+        "trace_id": trace_id,
+        "projection_ref": f"map_projection_record:{projection_record.get('projection_id')}",
+        "eval_ref": f"map_projection_eval_result:{eval_result.get('eval_id')}",
+        "readiness_ref": f"map_projection_readiness_record:{readiness_record.get('readiness_id')}",
+        "conflict_ref": f"map_projection_conflict_record:{conflict_record.get('conflict_id')}",
+        "debt_ref": f"map_projection_debt_record:{debt_record.get('debt_id')}",
+        "effectiveness_ref": f"map_projection_effectiveness_record:{effectiveness_record.get('effectiveness_id')}",
+        "non_authority_assertions": projection_record.get("non_authority_assertions", []),
+    }
+    validate_artifact(bundle, "map_projection_bundle")
+    return bundle

--- a/spectrum_systems/modules/runtime/prg_hardening.py
+++ b/spectrum_systems/modules/runtime/prg_hardening.py
@@ -332,3 +332,19 @@ def build_governance_bundle(*, artifact_refs: list[str], created_at: str, trace_
     }
     validate_artifact(bundle, "prg_governance_bundle")
     return bundle
+
+
+def run_prg_closeout_gate(*, recommendation_replay_ok: bool, strategy_alignment_ok: bool, authority_boundary_failures: list[str], effectiveness_record: Mapping[str, Any]) -> dict[str, Any]:
+    checks = {
+        "recommendation_replay_validation": recommendation_replay_ok,
+        "strategy_alignment_integrity": strategy_alignment_ok,
+        "recommendation_vs_authority_protection": len(authority_boundary_failures) == 0,
+        "governance_effectiveness_tracking": bool(effectiveness_record.get("effectiveness_score") is not None),
+        "prg_non_authoritative_posture": bool(effectiveness_record.get("artifact_type") == "prg_governance_effectiveness_record"),
+    }
+    fail_reasons = [k for k, ok in checks.items() if not ok]
+    return {
+        "closeout_gate": "pass" if not fail_reasons else "fail",
+        "checks": checks,
+        "fail_reasons": fail_reasons,
+    }

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -257,6 +257,20 @@ class ContractSchemaTests(unittest.TestCase):
             instance = load_example(name)
             validate_artifact(instance, name)
 
+
+    def test_map_projection_contract_examples_validate(self) -> None:
+        for name in (
+            "map_projection_record",
+            "map_projection_eval_result",
+            "map_projection_readiness_record",
+            "map_projection_conflict_record",
+            "map_projection_bundle",
+            "map_projection_effectiveness_record",
+            "map_projection_debt_record",
+        ):
+            instance = load_example(name)
+            validate_artifact(instance, name)
+
     def test_rqx_redteam_contract_examples_validate(self) -> None:
         for name in (
             "redteam_review_request",

--- a/tests/test_map_projection_hardening.py
+++ b/tests/test_map_projection_hardening.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from spectrum_systems.contracts import load_example, validate_artifact
+from spectrum_systems.modules.runtime.map_projection_hardening import (
+    MAPProjectionError,
+    build_map_projection_bundle,
+    build_map_projection_conflict_record,
+    build_map_projection_debt_record,
+    build_map_projection_effectiveness,
+    build_map_projection_readiness,
+    build_map_projection_record,
+    enforce_map_boundary,
+    evaluate_map_projection,
+    run_map_boundary_redteam,
+    run_map_semantic_redteam,
+    validate_map_projection_replay,
+)
+
+
+def _source_bundle() -> dict:
+    return load_example("review_projection_bundle_artifact")
+
+
+def test_map_contract_examples_validate() -> None:
+    for name in (
+        "map_projection_record",
+        "map_projection_eval_result",
+        "map_projection_readiness_record",
+        "map_projection_conflict_record",
+        "map_projection_bundle",
+        "map_projection_effectiveness_record",
+        "map_projection_debt_record",
+    ):
+        validate_artifact(load_example(name), name)
+
+
+def test_map_01_to_09_foundation_pipeline() -> None:
+    source = _source_bundle()
+    boundary_fails = enforce_map_boundary(
+        upstream_artifact_type="review_projection_bundle_artifact",
+        claimed_actions=["format_projection"],
+        emitted_artifact_types=["map_projection_record", "map_projection_eval_result"],
+    )
+    assert boundary_fails == []
+
+    record = build_map_projection_record(
+        review_projection_bundle_artifact=source,
+        created_at="2026-04-13T00:00:00Z",
+        trace_id="trace-map-001",
+    )
+    eval_result = evaluate_map_projection(
+        source_bundle=source,
+        projection_record=record,
+        created_at="2026-04-13T00:00:00Z",
+        trace_id="trace-map-001",
+    )
+    assert eval_result["evaluation_status"] == "pass"
+
+    replay_ok, replay_fails = validate_map_projection_replay(
+        prior_input=source,
+        replay_input=copy.deepcopy(source),
+        prior_projection=record,
+        replay_projection=copy.deepcopy(record),
+    )
+    assert replay_ok is True
+    assert replay_fails == []
+
+    readiness = build_map_projection_readiness(
+        eval_result=eval_result,
+        evidence_refs=["ev:1", "ev:2"],
+        created_at="2026-04-13T00:00:00Z",
+        trace_id="trace-map-001",
+    )
+    assert readiness["readiness_status"] == "candidate_only"
+
+    conflict = build_map_projection_conflict_record(
+        eval_result=eval_result,
+        redteam_findings=[],
+        created_at="2026-04-13T00:00:00Z",
+        trace_id="trace-map-001",
+    )
+    debt = build_map_projection_debt_record(
+        incidents=[{"incident_code": "field_loss"}, {"incident_code": "field_loss"}],
+        created_at="2026-04-13T00:00:00Z",
+        trace_id="trace-map-001",
+    )
+    effectiveness = build_map_projection_effectiveness(
+        outcomes=[
+            {"usability_improved": True, "semantic_distortion_detected": False, "authority_confusion_detected": False},
+            {"usability_improved": True, "semantic_distortion_detected": False, "authority_confusion_detected": False},
+            {"usability_improved": False, "semantic_distortion_detected": True, "authority_confusion_detected": False},
+        ],
+        created_at="2026-04-13T00:00:00Z",
+        trace_id="trace-map-001",
+    )
+    bundle = build_map_projection_bundle(
+        projection_record=record,
+        eval_result=eval_result,
+        readiness_record=readiness,
+        conflict_record=conflict,
+        debt_record=debt,
+        effectiveness_record=effectiveness,
+        created_at="2026-04-13T00:00:00Z",
+        trace_id="trace-map-001",
+    )
+    assert bundle["artifact_type"] == "map_projection_bundle"
+
+
+def test_map_08a_08b_08d_08e_detectors_fail_closed() -> None:
+    source = _source_bundle()
+    record = build_map_projection_record(
+        review_projection_bundle_artifact=source,
+        created_at="2026-04-13T00:00:00Z",
+        trace_id="trace-map-001",
+    )
+
+    tampered = copy.deepcopy(record)
+    tampered["status_markers"]["blocker_present"] = False
+    tampered["projected_payload"]["roadmap_projection_ref"] = "rrp-ffffffffffffffff"
+    tampered["non_authority_assertions"] = ["looks_authoritative"]
+
+    result = evaluate_map_projection(
+        source_bundle=source,
+        projection_record=tampered,
+        created_at="2026-04-13T00:00:00Z",
+        trace_id="trace-map-001",
+    )
+    assert result["evaluation_status"] == "fail"
+    assert "status_washing_detector" in result["fail_reasons"]
+    assert "required_field_preservation" in result["fail_reasons"]
+    assert "projection_to_governance_integrity" in result["fail_reasons"]
+
+
+def test_map_rt1_fx1_and_rt2_fx2_exploits_become_regressions() -> None:
+    rt1 = run_map_boundary_redteam(
+        fixtures=[
+            {"fixture_id": "RT1-AUTHORITY-LOOKING", "should_fail_closed": True, "observed": "accepted"},
+            {"fixture_id": "RT1-BLOCKED", "should_fail_closed": True, "observed": "blocked"},
+        ]
+    )
+    rt2 = run_map_semantic_redteam(
+        fixtures=[
+            {"fixture_id": "RT2-STATUS-WASH", "semantic_risk": True, "observed": "accepted"},
+            {"fixture_id": "RT2-BLOCKED", "semantic_risk": True, "observed": "blocked"},
+        ]
+    )
+    assert [f["fixture_id"] for f in rt1] == ["RT1-AUTHORITY-LOOKING"]
+    assert [f["fixture_id"] for f in rt2] == ["RT2-STATUS-WASH"]
+
+    source = _source_bundle()
+    source_without_roadmap = copy.deepcopy(source)
+    source_without_roadmap.pop("roadmap_projection", None)
+    with pytest.raises(MAPProjectionError, match="required_projection_sections_missing"):
+        build_map_projection_record(
+            review_projection_bundle_artifact=source_without_roadmap,
+            created_at="2026-04-13T00:00:00Z",
+            trace_id="trace-map-001",
+        )
+
+
+def test_map_boundary_fencing_blocks_owner_creep() -> None:
+    fails = enforce_map_boundary(
+        upstream_artifact_type="review_integration_packet_artifact",
+        claimed_actions=["interpret_review:packet", "issue_policy:update"],
+        emitted_artifact_types=["closure_decision_artifact"],
+    )
+    assert "invalid_upstream_artifact:review_integration_packet_artifact" in fails
+    assert "forbidden_owner_overlap:interpret_review:packet" in fails
+    assert "forbidden_owner_overlap:issue_policy:update" in fails
+    assert "invalid_downstream_artifact:closure_decision_artifact" in fails
+
+
+def test_map_replay_detects_drift() -> None:
+    source = _source_bundle()
+    record = build_map_projection_record(
+        review_projection_bundle_artifact=source,
+        created_at="2026-04-13T00:00:00Z",
+        trace_id="trace-map-001",
+    )
+    drifted = copy.deepcopy(record)
+    drifted["projected_payload"]["readiness_item_count"] += 1
+
+    ok, fails = validate_map_projection_replay(
+        prior_input=source,
+        replay_input=source,
+        prior_projection=record,
+        replay_projection=drifted,
+    )
+    assert ok is False
+    assert fails == ["projection_replay_output_drift"]

--- a/tests/test_prg_hardening.py
+++ b/tests/test_prg_hardening.py
@@ -21,6 +21,7 @@ from spectrum_systems.modules.runtime.prg_hardening import (
     run_governance_eval,
     run_governance_recommendation_engine,
     run_prg_boundary_redteam,
+    run_prg_closeout_gate,
     run_prg_semantic_redteam,
     validate_recommendation_replay,
 )
@@ -197,3 +198,23 @@ def test_prg_05_08_08a_08b_08c_08d_08e_09_and_redteam_fix_loops() -> None:
             created_at="2026-04-13T00:00:00Z",
             trace_id="trace-prg-001",
         )
+
+
+def test_prg_10_closeout_gate() -> None:
+    gate = run_prg_closeout_gate(
+        recommendation_replay_ok=True,
+        strategy_alignment_ok=True,
+        authority_boundary_failures=[],
+        effectiveness_record={"artifact_type": "prg_governance_effectiveness_record", "effectiveness_score": 0.9},
+    )
+    assert gate["closeout_gate"] == "pass"
+
+    failed = run_prg_closeout_gate(
+        recommendation_replay_ok=False,
+        strategy_alignment_ok=True,
+        authority_boundary_failures=["recommendation_authority_leakage:a1"],
+        effectiveness_record={"artifact_type": "bad_record"},
+    )
+    assert failed["closeout_gate"] == "fail"
+    assert "recommendation_replay_validation" in failed["fail_reasons"]
+    assert "recommendation_vs_authority_protection" in failed["fail_reasons"]


### PR DESCRIPTION
### Motivation
- Provide a governed MAP mediation/projection foundation and ensure PRG is operationally safe for MAP to depend on by adding deterministic projection, eval, replay, integrity checks, and red-team driven regressions.

### Description
- Added a new MAP runtime module `spectrum_systems/modules/runtime/map_projection_hardening.py` implementing boundary enforcement, deterministic projection record construction, an eval harness with explicit checks (completeness, provenance retention, contradiction visibility, required-field preservation, formatting correctness), replay validation, readiness/conflict/debt/effectiveness builders, red-team runners (`run_map_boundary_redteam`, `run_map_semantic_redteam`), and bundle assembly.
- Added PRG closeout gate function `run_prg_closeout_gate` in `spectrum_systems/modules/runtime/prg_hardening.py` to verify recommendation replay, strategy alignment, authority-boundary protections, and effectiveness tracking.
- Introduced seven MAP contracts and examples in `contracts/schemas/` and `contracts/examples/` for projection, eval, readiness, conflict, bundle, effectiveness, and debt artifacts, and published them by bumping `contracts/standards-manifest.json` to version `1.3.124`.
- Added tests `tests/test_map_projection_hardening.py` exercising happy paths, detectors (field-loss, status-washing), replay checks, boundary fencing, and red-team exploitation → regression conversion, and extended `tests/test_prg_hardening.py` and `tests/test_contracts.py` to cover PRG closeout and MAP contract examples.
- Added a plan-first artifact `docs/review-actions/PLAN-MAP-001-PRG10-2026-04-13.md` and registered it in `PLANS.md`.

### Testing
- Ran `pytest tests/test_map_projection_hardening.py tests/test_prg_hardening.py` and all tests passed (10 passed).
- Ran `pytest tests/test_contracts.py tests/test_contract_enforcement.py` and observed success (126 passed).
- Ran `pytest tests/test_module_architecture.py` (47 passed).
- Executed `python scripts/run_contract_enforcement.py` which produced enforcement reports with no failures.
- Ran `.codex/skills/contract-boundary-audit/run.sh` which passed with non-blocking warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcce551d288329a7b3a0096a54dca5)