### PR TITLE
Add fail-closed System Registry Guard (SRG) with preflight and CI integration

### DIFF
--- a/.github/workflows/artifact-boundary.yml
+++ b/.github/workflows/artifact-boundary.yml
@@ -123,7 +123,52 @@ jobs:
             outputs/contract_preflight/contract_preflight_report.md
             outputs/contract_preflight/contract_preflight_report.json
             outputs/contract_preflight/contract_preflight_result_artifact.json
+            outputs/contract_preflight/system_registry_guard_result.json
             outputs/contract_preflight/contract_preflight_diagnosis_bundle.md
+
+  system-registry-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Resolve changed refs
+        id: srg-refs
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            echo "base_ref=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT"
+            echo "head_ref=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          elif [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            echo "base_ref=${{ github.event.before }}" >> "$GITHUB_OUTPUT"
+            echo "head_ref=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "base_ref=origin/main" >> "$GITHUB_OUTPUT"
+            echo "head_ref=HEAD" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run system registry guard
+        run: |
+          python scripts/run_system_registry_guard.py \
+            --base-ref "${{ steps.srg-refs.outputs.base_ref }}" \
+            --head-ref "${{ steps.srg-refs.outputs.head_ref }}" \
+            --output outputs/system_registry_guard/system_registry_guard_result.json
+
+      - name: Upload system registry guard outputs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: system-registry-guard-outputs
+          if-no-files-found: warn
+          path: outputs/system_registry_guard/system_registry_guard_result.json
 
   run-pytest:
     needs:
@@ -131,6 +176,7 @@ jobs:
       - validate-module-architecture
       - validate-orchestration-boundaries
       - contract-preflight
+      - system-registry-guard
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/artifact-boundary.yml
+++ b/.github/workflows/artifact-boundary.yml
@@ -100,11 +100,13 @@ jobs:
           GITHUB_BEFORE_SHA: ${{ github.event.before || '' }}
           GITHUB_SHA: ${{ github.sha }}
         run: |
+          set -euo pipefail
           python scripts/build_preflight_pqx_wrapper.py \
             --base-ref "${{ steps.preflight-refs.outputs.base_ref }}" \
             --head-ref "${{ steps.preflight-refs.outputs.head_ref }}" \
             --output outputs/contract_preflight/preflight_pqx_task_wrapper.json
 
+          set +e
           python scripts/run_contract_preflight.py \
             --base-ref "${{ steps.preflight-refs.outputs.base_ref }}" \
             --head-ref "${{ steps.preflight-refs.outputs.head_ref }}" \
@@ -112,6 +114,38 @@ jobs:
             --execution-context pqx_governed \
             --pqx-wrapper-path outputs/contract_preflight/preflight_pqx_task_wrapper.json \
             --authority-evidence-ref artifacts/pqx_runs/preflight.pqx_slice_execution_record.json
+          preflight_exit=$?
+          set -e
+
+          if [[ "$preflight_exit" -eq 0 ]]; then
+            exit 0
+          fi
+
+          auto_repair_allowed=$(python - <<'PY'
+import json
+from pathlib import Path
+path = Path("outputs/contract_preflight/preflight_repair_plan_record.json")
+if not path.is_file():
+    print("false")
+else:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    print("true" if payload.get("eligibility_decision") == "auto_repair_allowed" else "false")
+PY
+)
+
+          if [[ "$auto_repair_allowed" != "true" ]]; then
+            exit "$preflight_exit"
+          fi
+
+          python scripts/run_github_pr_autofix_contract_preflight.py \
+            --output-dir outputs/contract_preflight \
+            --base-ref "${{ steps.preflight-refs.outputs.base_ref }}" \
+            --head-ref "${{ steps.preflight-refs.outputs.head_ref }}" \
+            --event-name "${{ github.event_name }}" \
+            --execution-context pqx_governed \
+            --pqx-wrapper-path outputs/contract_preflight/preflight_pqx_task_wrapper.json \
+            --authority-evidence-ref artifacts/pqx_runs/preflight.pqx_slice_execution_record.json \
+            --same-repo-write-allowed
 
       - name: Upload contract preflight outputs
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ Each prompt must declare exactly one primary type:
 - **No hidden behavior**: all execution rules must be explicit in governed markdown.
 - **No deep reference chains**: keep required behavior understandable within one reference level.
 - **No unrelated refactors**: keep changes in declared scope.
+- **System introduction discipline**: before introducing or broadening any system owner, check `docs/architecture/system_registry.md`, avoid duplicate ownership claims, and include same-change canonical registration when a truly new system is required. System Registry Guard (SRG) enforcement in preflight/CI will fail closed on violations.
 
 ## Terminology normalization
 Use these terms consistently:

--- a/contracts/examples/preflight_recovery_outcome_record.json
+++ b/contracts/examples/preflight_recovery_outcome_record.json
@@ -1,13 +1,15 @@
 {
   "artifact_type": "preflight_recovery_outcome_record",
-  "schema_version": "1.0.0",
+  "schema_version": "1.1.0",
   "initial_preflight_status": "failed",
   "failure_class": "schema_violation",
   "eligibility_decision": "auto_repair_allowed",
   "repair_invoked": true,
   "repair_execution_status": "completed",
   "rerun_status": "passed",
-  "final_decision": "repaired_and_passed",
+  "final_decision": "passed_after_auto_repair",
+  "repair_attempted": true,
+  "repair_inapplicable_reason": null,
   "retry_count": 1,
   "reason_codes": [
     "SCHEMA_EXAMPLE_FAILURE"

--- a/contracts/examples/preflight_repair_result_record.json
+++ b/contracts/examples/preflight_repair_result_record.json
@@ -7,6 +7,7 @@
   "rerun_preflight_exit_code": 0,
   "rerun_strategy_gate_decision": "ALLOW",
   "success": true,
+  "terminal_state": "passed_after_auto_repair",
   "rerun_allowed": true,
   "rerun_requires": [
     "preflight_repair_validation_record"

--- a/contracts/governance/system_registry_guard_policy.json
+++ b/contracts/governance/system_registry_guard_policy.json
@@ -1,0 +1,58 @@
+{
+  "policy_version": "1.0.0",
+  "protected_authority_seams": {
+    "execution admission": "AEX",
+    "execution": "PQX",
+    "trust policy": "TPA",
+    "orchestration": "TLC",
+    "closure": "CDE",
+    "promotion readiness": "CDE",
+    "enforcement": "SEL",
+    "override": "HIT",
+    "context preflight": "CTX",
+    "replay": "REP"
+  },
+  "responsibility_clusters": {
+    "context": ["context", "context_bundle", "contextual"],
+    "judgment": ["judgment", "judgement", "decision"],
+    "calibration": ["calibration", "confidence", "correctness"],
+    "drift": ["drift", "deviation", "regression"],
+    "entropy": ["entropy", "decay"],
+    "release": ["release", "rollout", "freeze", "rollback"],
+    "canary": ["canary"],
+    "replay": ["replay", "reproducibility"],
+    "external_runtime": ["external", "runtime", "provenance"],
+    "cost": ["cost", "budget", "latency"],
+    "capacity": ["capacity", "throughput"],
+    "queue_backpressure": ["queue", "backpressure", "retry"],
+    "policy": ["policy", "admissibility", "scope"],
+    "closure": ["closure", "closeout", "promotion"],
+    "readiness": ["readiness", "ready"],
+    "enforcement": ["enforcement", "guard", "block"],
+    "execution": ["execution", "execute", "runner"],
+    "override_hitl": ["override", "hitl", "human"]
+  },
+  "synonym_groups": {
+    "context": ["retrieval", "retrieve"],
+    "judgment": ["adjudication", "verdict"],
+    "drift": ["drifting"],
+    "release": ["deployment"],
+    "policy": ["governance"],
+    "closure": ["finalization"],
+    "execution": ["run"],
+    "override_hitl": ["operator"]
+  },
+  "phrase_mappings": {
+    "context owner": "context",
+    "judgment owner": "judgment",
+    "drift response": "drift",
+    "error budget": "cost",
+    "queue load": "queue_backpressure",
+    "policy authority": "policy",
+    "closure decision": "closure",
+    "promotion readiness": "readiness",
+    "fail closed": "enforcement",
+    "execute work": "execution",
+    "human override": "override_hitl"
+  }
+}

--- a/contracts/schemas/preflight_recovery_outcome_record.schema.json
+++ b/contracts/schemas/preflight_recovery_outcome_record.schema.json
@@ -14,13 +14,15 @@
     "repair_execution_status",
     "rerun_status",
     "final_decision",
+    "repair_attempted",
+    "repair_inapplicable_reason",
     "retry_count",
     "reason_codes",
     "artifact_refs"
   ],
   "properties": {
     "artifact_type": {"const": "preflight_recovery_outcome_record"},
-    "schema_version": {"type": "string", "const": "1.0.0"},
+    "schema_version": {"type": "string", "const": "1.1.0"},
     "initial_preflight_status": {"type": "string", "enum": ["passed", "failed", "skipped"]},
     "failure_class": {"type": "string", "minLength": 1},
     "eligibility_decision": {
@@ -35,8 +37,16 @@
     "rerun_status": {"type": "string", "enum": ["passed", "blocked", "not_run", "not_permitted"]},
     "final_decision": {
       "type": "string",
-      "enum": ["repaired_and_passed", "repaired_but_still_blocked", "repair_failed", "repair_not_permitted"]
+      "enum": [
+        "passed_without_repair",
+        "passed_after_auto_repair",
+        "blocked_repair_failed",
+        "blocked_repair_not_applicable",
+        "blocked_escalation_required"
+      ]
     },
+    "repair_attempted": {"type": "boolean"},
+    "repair_inapplicable_reason": {"type": ["string", "null"], "minLength": 1},
     "retry_count": {"type": "integer", "minimum": 0},
     "reason_codes": {
       "type": "array",

--- a/contracts/schemas/preflight_repair_result_record.schema.json
+++ b/contracts/schemas/preflight_repair_result_record.schema.json
@@ -12,6 +12,7 @@
     "rerun_preflight_exit_code",
     "rerun_strategy_gate_decision",
     "success",
+    "terminal_state",
     "rerun_allowed",
     "rerun_requires",
     "escalation_required",
@@ -47,6 +48,16 @@
     },
     "success": {
       "type": "boolean"
+    },
+    "terminal_state": {
+      "type": "string",
+      "enum": [
+        "passed_without_repair",
+        "passed_after_auto_repair",
+        "blocked_repair_failed",
+        "blocked_repair_not_applicable",
+        "blocked_escalation_required"
+      ]
     },
     "rerun_allowed": {
       "type": "boolean"

--- a/contracts/standards-manifest.json
+++ b/contracts/standards-manifest.json
@@ -5028,13 +5028,13 @@
     {
       "artifact_type": "preflight_repair_result_record",
       "artifact_class": "coordination",
-      "schema_version": "1.0.0",
+      "schema_version": "1.1.0",
       "status": "stable",
       "intended_consumers": [
         "spectrum-systems"
       ],
       "introduced_in": "1.3.125",
-      "last_updated_in": "1.3.125",
+      "last_updated_in": "1.3.126",
       "example_path": "contracts/examples/preflight_repair_result_record.json",
       "notes": "PFX-01 governed preflight BLOCK auto-repair artifact."
     },
@@ -5050,6 +5050,19 @@
       "last_updated_in": "1.3.125",
       "example_path": "contracts/examples/preflight_repair_validation_record.json",
       "notes": "PFX-01 governed preflight BLOCK auto-repair artifact."
+    },
+    {
+      "artifact_type": "preflight_recovery_outcome_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.1.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.126",
+      "last_updated_in": "1.3.126",
+      "example_path": "contracts/examples/preflight_recovery_outcome_record.json",
+      "notes": "PRF-06 terminal repair-state outcome for governed contract preflight."
     },
     {
       "artifact_type": "prg_governance_bundle",

--- a/docs/governance/preflight_ref_normalization.md
+++ b/docs/governance/preflight_ref_normalization.md
@@ -1,0 +1,41 @@
+# Preflight Ref Normalization (Canonical)
+
+Preflight ref normalization is deterministic and fail-closed.
+
+## Event-specific rules
+
+1. `pull_request`
+   - prefer explicit `--base-ref` + `--head-ref` when both are non-empty
+   - otherwise use `GITHUB_BASE_SHA` + `GITHUB_HEAD_SHA`
+
+2. `push`
+   - prefer explicit `--base-ref` + `--head-ref` when both are non-empty
+   - otherwise use `GITHUB_BEFORE_SHA` + `GITHUB_SHA`
+   - push normalization must not depend on PR-only env vars
+
+3. `workflow_dispatch` / local execution
+   - explicit `--base-ref` + `--head-ref` are required
+   - missing explicit refs block with structured reason
+
+4. Unknown events
+   - block with `unsupported_event_context`
+
+## Structured observability fields
+
+Preflight report and changed-path resolution artifacts include `ref_context`:
+- `event_name`
+- `raw_inputs` (CLI refs and relevant GitHub env vars)
+- `base_ref` and `head_ref` after normalization
+- `normalization_strategy`
+- `fallback_used`
+- `valid`
+- `reason_code` / `invalid_reason` when blocked
+
+## Failure reason-code distinctions
+
+- `missing_refs`
+- `unsupported_event_context`
+- `malformed_ref_context`
+- `contract_mismatch_from_bad_ref_resolution`
+
+These reason codes are consumed by the preflight diagnosis/repair flow for deterministic classification and bounded auto-repair behavior.

--- a/docs/governance/preflight_ref_normalization.md
+++ b/docs/governance/preflight_ref_normalization.md
@@ -40,3 +40,20 @@ Preflight report and changed-path resolution artifacts include `ref_context`:
 - `contract_mismatch_from_bad_ref_resolution`
 
 These reason codes are consumed by the preflight diagnosis/repair flow for deterministic classification and bounded auto-repair behavior.
+
+## PRF-06 repair terminal-state semantics
+
+Root cause of vague `BLOCK + exit 2` handling: first-pass preflight classification emitted `contract_mismatch` with `auto_repair_allowed`, but the CI flow could stop after first-pass preflight without executing the governed repair+rereun path.
+
+Current governed state machine:
+1. run first-pass `scripts/run_contract_preflight.py`
+2. if first pass blocks and `preflight_repair_plan_record.eligibility_decision == auto_repair_allowed`, run `scripts/run_github_pr_autofix_contract_preflight.py`
+3. auto-repair emits deterministic terminal state and post-repair artifact truth:
+   - `passed_after_auto_repair`
+   - `blocked_repair_failed`
+   - `blocked_repair_not_applicable`
+   - `blocked_escalation_required`
+
+Guardrails:
+- if `eligibility_decision == auto_repair_allowed`, flow must either mark `repair_attempted == true` or set deterministic `repair_inapplicable_reason`.
+- generic terminal `BLOCK` is not accepted when a post-repair terminal state is available.

--- a/docs/governance/preflight_ref_normalization.md
+++ b/docs/governance/preflight_ref_normalization.md
@@ -30,6 +30,7 @@ Preflight report and changed-path resolution artifacts include `ref_context`:
 - `fallback_used`
 - `valid`
 - `reason_code` / `invalid_reason` when blocked
+- `root_cause_classification` and `repair_eligibility_rationale` in `contract_preflight_report.json` for deterministic repair/escalation decisions
 
 ## Failure reason-code distinctions
 

--- a/docs/review-actions/PLAN-PREFLIGHT-REF-NORMALIZATION-2026-04-14.md
+++ b/docs/review-actions/PLAN-PREFLIGHT-REF-NORMALIZATION-2026-04-14.md
@@ -20,8 +20,10 @@ Fix push-event preflight ref mismatch failures by introducing one canonical, det
 | spectrum_systems/modules/runtime/github_pr_autofix_contract_preflight.py | MODIFY | Distinguish bad-ref-resolution mismatch in diagnosis/repair classification |
 | scripts/run_github_pr_autofix_contract_preflight.py | MODIFY | Normalize refs consistently for auto-repair reruns |
 | tests/test_preflight_ref_normalization.py | CREATE | Unit tests for push/pr/workflow_dispatch/local ref normalization rules |
+| tests/test_build_preflight_pqx_wrapper.py | MODIFY | Verify wrapper and runner share canonical ref normalization path |
 | tests/test_contract_preflight.py | MODIFY | Regression tests for push fallback, explicit override, workflow_dispatch block reason, and normalization observability |
 | tests/test_github_pr_autofix_contract_preflight.py | MODIFY | Classification tests for missing/malformed/unsupported/bad-ref-resolution reasons |
+| tests/test_run_github_pr_autofix_contract_preflight.py | MODIFY | Keep CLI adapter tests aligned with normalized ref context args |
 | docs/governance/preflight_ref_normalization.md | CREATE | Canonical documentation for event-specific ref normalization + artifact fields |
 
 ## Contracts touched

--- a/docs/review-actions/PLAN-PREFLIGHT-REF-NORMALIZATION-2026-04-14.md
+++ b/docs/review-actions/PLAN-PREFLIGHT-REF-NORMALIZATION-2026-04-14.md
@@ -1,0 +1,41 @@
+# Plan — PREFLIGHT-REF-NORMALIZATION — 2026-04-14
+
+## Prompt type
+BUILD
+
+## Roadmap item
+PREFLIGHT-REF-NORMALIZATION
+
+## Objective
+Fix push-event preflight ref mismatch failures by introducing one canonical, deterministic ref-normalization path shared by preflight wrapper build and preflight execution, with explicit failure classification and auto-repair-aware diagnostics.
+
+## Declared files
+
+| File | Change type | Reason |
+| --- | --- | --- |
+| docs/review-actions/PLAN-PREFLIGHT-REF-NORMALIZATION-2026-04-14.md | CREATE | Required multi-file execution plan |
+| spectrum_systems/modules/runtime/preflight_ref_normalization.py | CREATE | Canonical event-aware base/head normalization utility |
+| scripts/build_preflight_pqx_wrapper.py | MODIFY | Use canonical normalization and emit ref observability artifact fields |
+| scripts/run_contract_preflight.py | MODIFY | Use canonical normalization before changed-path resolution and include structured context in report/artifacts |
+| spectrum_systems/modules/runtime/github_pr_autofix_contract_preflight.py | MODIFY | Distinguish bad-ref-resolution mismatch in diagnosis/repair classification |
+| scripts/run_github_pr_autofix_contract_preflight.py | MODIFY | Normalize refs consistently for auto-repair reruns |
+| tests/test_preflight_ref_normalization.py | CREATE | Unit tests for push/pr/workflow_dispatch/local ref normalization rules |
+| tests/test_contract_preflight.py | MODIFY | Regression tests for push fallback, explicit override, workflow_dispatch block reason, and normalization observability |
+| tests/test_github_pr_autofix_contract_preflight.py | MODIFY | Classification tests for missing/malformed/unsupported/bad-ref-resolution reasons |
+| docs/governance/preflight_ref_normalization.md | CREATE | Canonical documentation for event-specific ref normalization + artifact fields |
+
+## Contracts touched
+None (classification distinction is encoded in deterministic reason codes under existing diagnosis schemas).
+
+## Tests that must pass after execution
+1. `pytest tests/test_preflight_ref_normalization.py tests/test_contract_preflight.py tests/test_github_pr_autofix_contract_preflight.py`
+2. `python scripts/build_preflight_pqx_wrapper.py --base-ref "" --head-ref "" --output outputs/contract_preflight/preflight_pqx_task_wrapper.json`
+3. `python scripts/run_contract_preflight.py --base-ref "" --head-ref "" --output-dir outputs/contract_preflight_push_ref_fix`
+
+## Scope exclusions
+- Do not relax fail-closed behavior when trustworthy refs cannot be derived.
+- Do not change canonical system ownership in `docs/architecture/system_registry.md`.
+- Do not introduce non-deterministic inference for ref normalization.
+
+## Dependencies
+- Existing changed-path resolution and preflight diagnosis/repair flows remain authoritative and are extended in place.

--- a/docs/review-actions/PLAN-PRF-06-2026-04-14.md
+++ b/docs/review-actions/PLAN-PRF-06-2026-04-14.md
@@ -1,0 +1,20 @@
+# PLAN-PRF-06-2026-04-14
+
+## Prompt type
+BUILD
+
+## Scope
+Surgical fix for preflight contract mismatch flow so `contract_mismatch + auto_repair_allowed` executes bounded repair/rerun and folds final state/exit code from post-repair outcome.
+
+## Steps
+1. Inspect current preflight classification, repair planning/execution, rerun orchestration, and exit-code folding paths in scripts/runtime modules.
+2. Confirm concrete root cause for BLOCK + exit 2 despite `auto_repair_allowed`.
+3. Implement deterministic final-state machine and guards:
+   - enforce repair attempt or deterministic inapplicable reason for auto-repair-allowed cases;
+   - prohibit generic final BLOCK where specific post-repair terminal state applies;
+   - fold final exit status from final state.
+4. Harden contract mismatch taxonomy and mismatch fingerprint → strategy mapping in existing runtime module.
+5. Update schemas/examples/manifest only if required by additive fields.
+6. Add regression tests for success/failure/not-applicable and push/PR mode parity, final artifact semantics, and deterministic outcomes.
+7. Run targeted tests first, then broader coverage for modified surfaces.
+8. Commit changes and create PR message.

--- a/docs/review-actions/PLAN-SRG-2026-04-14.md
+++ b/docs/review-actions/PLAN-SRG-2026-04-14.md
@@ -1,0 +1,46 @@
+# Plan — SRG-END-TO-END — 2026-04-14
+
+## Prompt type
+BUILD
+
+## Roadmap item
+SRG-END-TO-END
+
+## Objective
+Implement a deterministic, fail-closed System Registry Guard that enforces canonical ownership boundaries in admission/preflight and CI with structured artifacts and tests.
+
+## Declared files
+List every file that will be created, modified, or deleted.
+No other files may be changed during execution of this plan.
+
+| File | Change type | Reason |
+| --- | --- | --- |
+| docs/review-actions/PLAN-SRG-2026-04-14.md | CREATE | Required multi-file execution plan before implementation |
+| spectrum_systems/modules/governance/system_registry_guard.py | CREATE | Deterministic parser, normalization, overlap detector, and guard result model |
+| spectrum_systems/modules/governance/__init__.py | MODIFY | Export SRG entrypoints for repo-native module access |
+| contracts/governance/system_registry_guard_policy.json | CREATE | Deterministic normalization and protected seam policy data |
+| scripts/run_system_registry_guard.py | CREATE | CLI runner for local and CI execution |
+| scripts/run_contract_preflight.py | MODIFY | Integrate SRG into preflight path before PQX handoff |
+| contracts/schemas/contract_preflight_result_artifact.schema.json | MODIFY | Add SRG artifact references/fields in governed preflight artifact |
+| contracts/examples/contract_preflight_result_artifact.example.json | MODIFY | Keep example aligned to updated preflight artifact schema |
+| tests/test_system_registry_guard.py | CREATE | Unit/integration tests for parser, normalization, detection, and registration rules |
+| tests/test_contract_preflight.py | MODIFY | Validate SRG preflight integration and fail-closed propagation |
+| .github/workflows/artifact-boundary.yml | MODIFY | Add CI backstop SRG execution on changed files |
+| AGENTS.md | MODIFY | Add prompt-surface preventive guidance for system introduction |
+
+## Contracts touched
+- `contract_preflight_result_artifact` schema (additive fields)
+
+## Tests that must pass after execution
+1. `pytest tests/test_system_registry_guard.py tests/test_contract_preflight.py`
+2. `python scripts/run_system_registry_guard.py --changed-files docs/architecture/system_registry.md`
+3. `python scripts/run_contract_preflight.py --changed-path docs/architecture/system_registry.md --output-dir outputs/contract_preflight_srg_plan_check`
+
+## Scope exclusions
+- Do not change canonical ownership definitions in `docs/architecture/system_registry.md` unless parser incompatibility is discovered.
+- Do not redesign existing AEX/TLC/TPA/PQX ownership boundaries.
+- Do not introduce non-deterministic NLP/LLM guard logic.
+- Do not add any new canonical 3-letter system owner named SRG.
+
+## Dependencies
+- Existing contract preflight gate and changed-path resolution seams remain authoritative and are extended, not replaced.

--- a/scripts/build_preflight_pqx_wrapper.py
+++ b/scripts/build_preflight_pqx_wrapper.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import sys
 from copy import deepcopy
 from datetime import datetime, timezone
@@ -17,6 +18,9 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 from spectrum_systems.modules.runtime.changed_path_resolution import resolve_changed_paths  # noqa: E402
+from spectrum_systems.modules.runtime.preflight_ref_normalization import (  # noqa: E402
+    normalize_preflight_ref_context,
+)
 
 
 def _stable_hash(payload: object) -> str:
@@ -89,8 +93,9 @@ def _write_preflight_hardening_artifacts(*, output_dir: Path, run_id: str, trace
 
 def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Build preflight PQX wrapper")
-    parser.add_argument("--base-ref", required=True)
-    parser.add_argument("--head-ref", required=True)
+    parser.add_argument("--base-ref", default="")
+    parser.add_argument("--head-ref", default="")
+    parser.add_argument("--event-name", default=None)
     parser.add_argument("--template", default="contracts/examples/codex_pqx_task_wrapper.json")
     parser.add_argument("--output", default="outputs/contract_preflight/preflight_pqx_task_wrapper.json")
     parser.add_argument("--changed-path", action="append", default=[])
@@ -104,10 +109,23 @@ def main(argv: Optional[list[str]] = None) -> int:
         print(f"ERROR: wrapper template missing: {template_path}", file=sys.stderr)
         return 2
 
+    ref_context = normalize_preflight_ref_context(
+        event_name=args.event_name,
+        cli_base_ref=args.base_ref,
+        cli_head_ref=args.head_ref,
+        env=os.environ,
+    )
+    if not ref_context.valid:
+        print(
+            f"ERROR: preflight ref normalization failed ({ref_context.reason_code}): {ref_context.invalid_reason}",
+            file=sys.stderr,
+        )
+        return 2
+
     resolution = resolve_changed_paths(
         repo_root=_REPO_ROOT,
-        base_ref=args.base_ref,
-        head_ref=args.head_ref,
+        base_ref=ref_context.base_ref,
+        head_ref=ref_context.head_ref,
         explicit=args.changed_path,
     )
 
@@ -148,6 +166,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         "refs_attempted": resolution.refs_attempted,
         "warnings": resolution.warnings,
         "hardening_artifact_refs": hardening_refs,
+        "ref_context": ref_context.as_dict(),
     }
 
     output_path = _REPO_ROOT / args.output

--- a/scripts/run_contract_preflight.py
+++ b/scripts/run_contract_preflight.py
@@ -60,6 +60,9 @@ from spectrum_systems.modules.governance.system_registry_guard import (  # noqa:
     load_guard_policy,
     parse_system_registry,
 )
+from spectrum_systems.modules.runtime.preflight_ref_normalization import (  # noqa: E402
+    normalize_preflight_ref_context,
+)
 
 DEFAULT_REQUIRED_SMOKE_TESTS = [
     "tests/test_roadmap_eligibility.py",
@@ -183,8 +186,9 @@ def _run(command: list[str], cwd: Path) -> CommandResult:
 
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Fail-closed contract/schema preflight gate")
-    parser.add_argument("--base-ref", default="origin/main", help="Git base ref used for diff detection")
-    parser.add_argument("--head-ref", default="HEAD", help="Git head ref used for diff detection")
+    parser.add_argument("--base-ref", default="", help="Git base ref used for diff detection")
+    parser.add_argument("--head-ref", default="", help="Git head ref used for diff detection")
+    parser.add_argument("--event-name", default=None, help="Optional event context override for ref normalization")
     parser.add_argument("--changed-path", action="append", default=[], help="Optional explicit changed paths")
     parser.add_argument("--output-dir", default="outputs/contract_preflight", help="Preflight output directory")
     parser.add_argument(
@@ -1242,7 +1246,79 @@ def main() -> int:
     output_dir = REPO_ROOT / args.output_dir
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    detection = detect_changed_paths(REPO_ROOT, args.base_ref, args.head_ref, args.changed_path)
+    ref_context = normalize_preflight_ref_context(
+        event_name=getattr(args, "event_name", None),
+        cli_base_ref=getattr(args, "base_ref", ""),
+        cli_head_ref=getattr(args, "head_ref", ""),
+        env=os.environ,
+    )
+    if not ref_context.valid:
+        report = {
+            "status": "failed",
+            "changed_contracts": [],
+            "changed_examples": [],
+            "changed_path_detection": {
+                "changed_path_detection_mode": "ref_context_invalid",
+                "changed_paths_resolved": [],
+                "refs_attempted": [],
+                "fallback_used": False,
+                "warnings": [str(ref_context.invalid_reason)],
+                "evaluation_mode": "blocked",
+                "evaluated_surfaces": [],
+                "ref_context": ref_context.as_dict(),
+            },
+            "impact": {"producers": [], "fixtures_or_builders": [], "consumers": [], "required_smoke_tests": []},
+            "schema_example_failures": [],
+            "producer_failures": [],
+            "fixture_failures": [],
+            "consumer_failures": [],
+            "masked_failures": [],
+            "recommended_repair_areas": ["preflight reference normalization"],
+            "bootstrap_failures": ["preflight ref normalization failed closed"],
+            "evaluation_classification": [],
+            "missing_required_surface": [],
+            "skip_reason": None,
+            "invariant_violations": [str(ref_context.reason_code or "malformed_ref_context")],
+            "control_surface_enforcement": None,
+            "control_surface_gap_result": None,
+            "control_surface_gap_pqx_work_items": None,
+            "control_surface_gap_pqx_conversion_error": None,
+            "trust_spine_evidence_cohesion": None,
+            "pqx_execution_policy": {"status": "block", "blocking_reasons": [str(ref_context.reason_code or "malformed_ref_context")]},
+            "pqx_required_context_enforcement": {"status": "block", "blocking_reasons": [str(ref_context.reason_code or "malformed_ref_context")]},
+            "system_registry_guard_result": {"artifact_type": "system_registry_guard_result", "status": "pass", "normalized_reason_codes": []},
+            "system_registry_guard_result_ref": None,
+            "ref_context": ref_context.as_dict(),
+        }
+        json_path = output_dir / "contract_preflight_report.json"
+        md_path = output_dir / "contract_preflight_report.md"
+        json_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+        md_path.write_text(render_markdown(report), encoding="utf-8")
+        preflight_artifact = build_preflight_result_artifact(
+            report=report,
+            json_report_path=json_path,
+            markdown_report_path=md_path,
+            hardening_flow=bool(args.hardening_flow),
+        )
+        preflight_artifact_path = output_dir / "contract_preflight_result_artifact.json"
+        preflight_artifact_path.write_text(json.dumps(preflight_artifact, indent=2) + "\n", encoding="utf-8")
+        emit_preflight_block_bundle(report=report, preflight_artifact=preflight_artifact, output_dir=output_dir)
+        print(
+            json.dumps(
+                {
+                    "status": "failed",
+                    "json_report": str(json_path),
+                    "markdown_report": str(md_path),
+                    "preflight_artifact": str(preflight_artifact_path),
+                    "strategy_gate_decision": preflight_artifact["control_signal"]["strategy_gate_decision"],
+                    "ref_context": ref_context.as_dict(),
+                },
+                indent=2,
+            )
+        )
+        return 2
+
+    detection = detect_changed_paths(REPO_ROOT, ref_context.base_ref, ref_context.head_ref, args.changed_path)
     registry_policy = load_guard_policy(_SYSTEM_REGISTRY_GUARD_POLICY_PATH)
     registry_model = parse_system_registry(_SYSTEM_REGISTRY_PATH)
     system_registry_guard_result = evaluate_system_registry_guard(
@@ -1270,6 +1346,7 @@ def main() -> int:
         "warnings": detection.warnings,
         "evaluation_mode": surface_classification["evaluation_mode"],
         "evaluated_surfaces": surface_classification["evaluated_surfaces"],
+        "ref_context": ref_context.as_dict(),
     }
     preflight_mode = (
         "commit_range_inspection"
@@ -1413,6 +1490,15 @@ def main() -> int:
             pqx_execution_policy["blocking_reasons"] = authority_resolution["blocking_reasons"]
 
     if detection.changed_path_detection_mode == "detection_failed_no_governed_paths":
+        detection_invariants = ["changed-path detection failed before evaluation"]
+        ref_raw = ref_context.raw_inputs
+        if (
+            ref_context.event_name == "push"
+            and ref_context.fallback_used
+            and not str(ref_raw.get("github_base_sha", "")).strip()
+            and not str(ref_raw.get("github_head_sha", "")).strip()
+        ):
+            detection_invariants.append("contract_mismatch_from_bad_ref_resolution")
         report = {
             "status": "failed",
             "changed_contracts": [],
@@ -1434,7 +1520,7 @@ def main() -> int:
             "evaluation_classification": surface_classification["path_classifications"],
             "missing_required_surface": [],
             "skip_reason": None,
-            "invariant_violations": ["changed-path detection failed before evaluation"],
+            "invariant_violations": detection_invariants,
             "control_surface_enforcement": None,
             "control_surface_gap_result": control_surface_gap_bridge["gap_result"],
             "control_surface_gap_pqx_work_items": control_surface_gap_bridge["pqx_work_items"],

--- a/scripts/run_contract_preflight.py
+++ b/scripts/run_contract_preflight.py
@@ -53,6 +53,7 @@ from spectrum_systems.modules.runtime.trust_spine_evidence_cohesion import (  # 
     evaluate_trust_spine_evidence_cohesion,
 )
 from spectrum_systems.modules.runtime.github_pr_autofix_contract_preflight import (  # noqa: E402
+    classify_preflight_block,
     emit_preflight_block_bundle,
 )
 from spectrum_systems.modules.governance.system_registry_guard import (  # noqa: E402
@@ -1289,6 +1290,9 @@ def main() -> int:
             "system_registry_guard_result": {"artifact_type": "system_registry_guard_result", "status": "pass", "normalized_reason_codes": []},
             "system_registry_guard_result_ref": None,
             "ref_context": ref_context.as_dict(),
+            "root_cause_classification": {"failure_class": "missing_required_artifact", "reason_codes": [str(ref_context.reason_code or "malformed_ref_context")]},
+            "repair_eligibility_rationale": "auto_repair_allowed: normalized ref context unavailable and must be reconstructed with bounded inputs",
+            "secondary_exception": None,
         }
         json_path = output_dir / "contract_preflight_report.json"
         md_path = output_dir / "contract_preflight_report.md"
@@ -1351,8 +1355,8 @@ def main() -> int:
     preflight_mode = (
         "commit_range_inspection"
         if not list(getattr(args, "changed_path", []) or [])
-        and bool(getattr(args, "base_ref", None))
-        and bool(getattr(args, "head_ref", None))
+        and bool(ref_context.base_ref)
+        and bool(ref_context.head_ref)
         else "explicit_or_local_inspection"
     )
     detection_meta["preflight_mode"] = preflight_mode
@@ -1709,6 +1713,26 @@ def main() -> int:
     control_signal = map_preflight_control_signal(report=report, hardening_flow=bool(args.hardening_flow))
     decision = str(control_signal.get("strategy_gate_decision", "BLOCK"))
     report["status"] = "failed" if decision in {"BLOCK", "FREEZE"} else "passed"
+    classification_exception: str | None = None
+    if report["status"] == "failed":
+        try:
+            failure_class, reason_codes = classify_preflight_block(report=report)
+        except Exception as exc:  # defensive fail-closed annotation only
+            failure_class, reason_codes = "internal_preflight_error", ["preflight_runtime_exception"]
+            classification_exception = str(exc)
+        report["root_cause_classification"] = {
+            "failure_class": failure_class,
+            "reason_codes": reason_codes,
+        }
+        if failure_class in {"missing_required_artifact", "contract_mismatch", "schema_violation", "invalid_wrapper", "authority_evidence_missing"}:
+            report["repair_eligibility_rationale"] = "auto_repair_allowed: deterministic bounded failure classification"
+        else:
+            report["repair_eligibility_rationale"] = "escalation_required: non-repairable policy or unbounded runtime failure"
+        report["secondary_exception"] = classification_exception
+    else:
+        report["root_cause_classification"] = {"failure_class": "none", "reason_codes": []}
+        report["repair_eligibility_rationale"] = "not_applicable: preflight passed"
+        report["secondary_exception"] = None
 
     json_path = output_dir / "contract_preflight_report.json"
     md_path = output_dir / "contract_preflight_report.md"

--- a/scripts/run_contract_preflight.py
+++ b/scripts/run_contract_preflight.py
@@ -55,6 +55,11 @@ from spectrum_systems.modules.runtime.trust_spine_evidence_cohesion import (  # 
 from spectrum_systems.modules.runtime.github_pr_autofix_contract_preflight import (  # noqa: E402
     emit_preflight_block_bundle,
 )
+from spectrum_systems.modules.governance.system_registry_guard import (  # noqa: E402
+    evaluate_system_registry_guard,
+    load_guard_policy,
+    parse_system_registry,
+)
 
 DEFAULT_REQUIRED_SMOKE_TESTS = [
     "tests/test_roadmap_eligibility.py",
@@ -109,6 +114,8 @@ _CONTROL_SURFACE_GAP_PACKET_REQUIRED_TESTS = [
     "tests/test_pqx_slice_runner.py",
 ]
 _GOVERNED_PROMPT_SURFACE_REGISTRY = REPO_ROOT / "docs" / "governance" / "governed_prompt_surfaces.json"
+_SYSTEM_REGISTRY_PATH = REPO_ROOT / "docs" / "architecture" / "system_registry.md"
+_SYSTEM_REGISTRY_GUARD_POLICY_PATH = REPO_ROOT / "contracts" / "governance" / "system_registry_guard_policy.json"
 
 _REQUIRED_SURFACE_TEST_OVERRIDES: dict[str, list[str]] = {
     "scripts/run_autonomous_validation_run.py": ["tests/test_run_autonomous_validation_run.py"],
@@ -1236,6 +1243,16 @@ def main() -> int:
     output_dir.mkdir(parents=True, exist_ok=True)
 
     detection = detect_changed_paths(REPO_ROOT, args.base_ref, args.head_ref, args.changed_path)
+    registry_policy = load_guard_policy(_SYSTEM_REGISTRY_GUARD_POLICY_PATH)
+    registry_model = parse_system_registry(_SYSTEM_REGISTRY_PATH)
+    system_registry_guard_result = evaluate_system_registry_guard(
+        repo_root=REPO_ROOT,
+        changed_files=detection.changed_paths,
+        policy=registry_policy,
+        registry_model=registry_model,
+    )
+    srg_output_path = output_dir / "system_registry_guard_result.json"
+    srg_output_path.write_text(json.dumps(system_registry_guard_result, indent=2) + "\n", encoding="utf-8")
     control_surface_gap_bridge = evaluate_control_surface_gap_bridge(output_dir)
     trust_spine_cohesion = evaluate_trust_spine_cohesion(detection.changed_paths, output_dir)
     classified = classify_changed_contracts(detection.changed_paths)
@@ -1425,6 +1442,8 @@ def main() -> int:
             "trust_spine_evidence_cohesion": trust_spine_cohesion,
             "pqx_execution_policy": pqx_execution_policy,
             "pqx_required_context_enforcement": pqx_required_context_enforcement,
+            "system_registry_guard_result": system_registry_guard_result,
+            "system_registry_guard_result_ref": str(srg_output_path),
         }
     elif not surface_classification["required_paths"]:
         report = {
@@ -1455,6 +1474,8 @@ def main() -> int:
             "trust_spine_evidence_cohesion": trust_spine_cohesion,
             "pqx_execution_policy": pqx_execution_policy,
             "pqx_required_context_enforcement": pqx_required_context_enforcement,
+            "system_registry_guard_result": system_registry_guard_result,
+            "system_registry_guard_result_ref": str(srg_output_path),
         }
     else:
         if changed_contract_paths:
@@ -1542,6 +1563,8 @@ def main() -> int:
             "trust_spine_evidence_cohesion": trust_spine_cohesion,
             "pqx_execution_policy": pqx_execution_policy,
             "pqx_required_context_enforcement": pqx_required_context_enforcement,
+            "system_registry_guard_result": system_registry_guard_result,
+            "system_registry_guard_result_ref": str(srg_output_path),
         }
         if report["control_surface_enforcement"] and report["control_surface_enforcement"].get("enforcement_status") == "BLOCK":
             report["status"] = "failed"
@@ -1574,6 +1597,14 @@ def main() -> int:
         )
         report["recommended_repair_areas"] = sorted(
             set(report.get("recommended_repair_areas", []) + ["default PQX execution policy enforcement"])
+        )
+    if system_registry_guard_result.get("status") == "fail":
+        report["status"] = "failed"
+        report["invariant_violations"] = sorted(
+            set(report.get("invariant_violations", []) + list(system_registry_guard_result.get("normalized_reason_codes", [])))
+        )
+        report["recommended_repair_areas"] = sorted(
+            set(report.get("recommended_repair_areas", []) + ["system registry ownership boundaries"])
         )
     cohesion_decision = (trust_spine_cohesion or {}).get("overall_decision") if isinstance(trust_spine_cohesion, dict) else None
     report["trust_spine_evidence_cohesion"] = trust_spine_cohesion

--- a/scripts/run_github_pr_autofix_contract_preflight.py
+++ b/scripts/run_github_pr_autofix_contract_preflight.py
@@ -5,19 +5,24 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from pathlib import Path
 
 from spectrum_systems.modules.runtime.github_pr_autofix_contract_preflight import (
     ContractPreflightAutofixError,
     run_preflight_block_autorepair,
 )
+from spectrum_systems.modules.runtime.preflight_ref_normalization import (
+    normalize_preflight_ref_context,
+)
 
 
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Governed contract preflight BLOCK auto-repair")
     parser.add_argument("--output-dir", default="outputs/contract_preflight")
-    parser.add_argument("--base-ref", required=True)
-    parser.add_argument("--head-ref", required=True)
+    parser.add_argument("--base-ref", default="")
+    parser.add_argument("--head-ref", default="")
+    parser.add_argument("--event-name", default=None)
     parser.add_argument("--execution-context", default="pqx_governed")
     parser.add_argument("--pqx-wrapper-path", default="outputs/contract_preflight/preflight_pqx_task_wrapper.json")
     parser.add_argument("--authority-evidence-ref", required=True)
@@ -28,12 +33,29 @@ def _parse_args() -> argparse.Namespace:
 def main() -> int:
     args = _parse_args()
     output_dir = Path(args.output_dir)
+    ref_context = normalize_preflight_ref_context(
+        event_name=args.event_name,
+        cli_base_ref=args.base_ref,
+        cli_head_ref=args.head_ref,
+        env=os.environ,
+    )
+    if not ref_context.valid:
+        print(
+            json.dumps(
+                {
+                    "status": "blocked",
+                    "error": f"preflight_ref_context_invalid:{ref_context.reason_code}",
+                    "ref_context": ref_context.as_dict(),
+                }
+            )
+        )
+        return 2
     try:
         result = run_preflight_block_autorepair(
             repo_root=Path(__file__).resolve().parents[1],
             output_dir=output_dir,
-            base_ref=args.base_ref,
-            head_ref=args.head_ref,
+            base_ref=ref_context.base_ref,
+            head_ref=ref_context.head_ref,
             execution_context=args.execution_context,
             pqx_wrapper_path=Path(args.pqx_wrapper_path),
             authority_evidence_ref=args.authority_evidence_ref,
@@ -50,7 +72,16 @@ def main() -> int:
         }
         print(json.dumps({"status": "blocked", "error": str(exc), "artifact_paths": bundle_paths}))
         return 2
-    print(json.dumps({"status": "passed", "result": result, "recovery_outcome_path": str(output_dir / "preflight_recovery_outcome_record.json")}))
+    print(
+        json.dumps(
+            {
+                "status": "passed",
+                "result": result,
+                "recovery_outcome_path": str(output_dir / "preflight_recovery_outcome_record.json"),
+                "ref_context": ref_context.as_dict(),
+            }
+        )
+    )
     return 0
 
 

--- a/scripts/run_system_registry_guard.py
+++ b/scripts/run_system_registry_guard.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Run deterministic System Registry Guard (SRG) checks over changed files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from spectrum_systems.modules.governance.system_registry_guard import (  # noqa: E402
+    SystemRegistryGuardError,
+    evaluate_system_registry_guard,
+    load_guard_policy,
+    parse_system_registry,
+)
+
+
+def _run(command: list[str]) -> tuple[int, str]:
+    proc = subprocess.run(command, cwd=REPO_ROOT, check=False, capture_output=True, text=True)
+    return proc.returncode, proc.stdout.strip() or proc.stderr.strip()
+
+
+def _resolve_changed_files(base_ref: str, head_ref: str, explicit: list[str]) -> list[str]:
+    if explicit:
+        return sorted(set(path.strip() for path in explicit if path.strip()))
+    code, output = _run(["git", "diff", "--name-only", f"{base_ref}..{head_ref}"])
+    if code != 0:
+        raise SystemRegistryGuardError(f"failed to resolve changed files from {base_ref}..{head_ref}: {output}")
+    return sorted(set(line.strip() for line in output.splitlines() if line.strip()))
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Fail-closed system registry ownership guard")
+    parser.add_argument("--base-ref", default="origin/main", help="Git base ref for changed-file resolution")
+    parser.add_argument("--head-ref", default="HEAD", help="Git head ref for changed-file resolution")
+    parser.add_argument("--changed-files", nargs="*", default=[], help="Explicit changed files")
+    parser.add_argument(
+        "--output",
+        default="outputs/system_registry_guard/system_registry_guard_result.json",
+        help="Output artifact path",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    changed_files = _resolve_changed_files(args.base_ref, args.head_ref, list(args.changed_files or []))
+
+    policy = load_guard_policy(REPO_ROOT / "contracts" / "governance" / "system_registry_guard_policy.json")
+    registry = parse_system_registry(REPO_ROOT / "docs" / "architecture" / "system_registry.md")
+    result = evaluate_system_registry_guard(
+        repo_root=REPO_ROOT,
+        changed_files=changed_files,
+        policy=policy,
+        registry_model=registry,
+    )
+
+    output_path = REPO_ROOT / args.output
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+
+    print(
+        json.dumps(
+            {
+                "status": result["status"],
+                "changed_files": result["changed_files"],
+                "reason_codes": result["normalized_reason_codes"],
+                "output": str(output_path),
+            },
+            indent=2,
+        )
+    )
+    return 1 if result["status"] == "fail" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/spectrum_systems/modules/governance/__init__.py
+++ b/spectrum_systems/modules/governance/__init__.py
@@ -19,6 +19,12 @@ from .drift_response_validation import (
     DriftResponseValidationError,
     run_drift_response_validation,
 )
+from .system_registry_guard import (
+    SystemRegistryGuardError,
+    evaluate_system_registry_guard,
+    load_guard_policy,
+    parse_system_registry,
+)
 
 __all__ = [
     "DoneCertificationError",
@@ -35,4 +41,8 @@ __all__ = [
     "run_eval_auto_generation_quality_validation",
     "DriftResponseValidationError",
     "run_drift_response_validation",
+    "SystemRegistryGuardError",
+    "evaluate_system_registry_guard",
+    "load_guard_policy",
+    "parse_system_registry",
 ]

--- a/spectrum_systems/modules/governance/system_registry_guard.py
+++ b/spectrum_systems/modules/governance/system_registry_guard.py
@@ -1,0 +1,519 @@
+"""Deterministic System Registry Guard (SRG) parser and overlap enforcement.
+
+SRG is a mandatory governance guard invoked by admission/preflight surfaces.
+It validates repository changes against canonical ownership boundaries defined in
+`docs/architecture/system_registry.md`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+class SystemRegistryGuardError(ValueError):
+    """Raised when deterministic SRG evaluation cannot be completed."""
+
+
+@dataclass(frozen=True)
+class RegistrySystem:
+    acronym: str
+    full_name: str
+    role: str
+    owns: tuple[str, ...]
+    consumes: tuple[str, ...]
+    produces: tuple[str, ...]
+    must_not_do: tuple[str, ...]
+    status: str
+
+
+@dataclass(frozen=True)
+class RegistryModel:
+    source_path: str
+    source_digest: str
+    systems: dict[str, RegistrySystem]
+    active_systems: tuple[str, ...]
+    deprecated_systems: tuple[str, ...]
+    removed_systems: tuple[str, ...]
+    placeholder_systems: tuple[str, ...]
+
+
+_SECTION_HEADER = re.compile(r"^##\s+(.+?)\s*$")
+_SYSTEM_HEADER = re.compile(r"^###\s+([A-Z0-9]{2,8})\s*$")
+_FIELD_LINE = re.compile(r"^\s*-\s+\*\*(acronym|full_name|role|owns|consumes|produces|must_not_do):\*\*\s*(.*)$")
+_BULLET_LINE = re.compile(r"^\s*-\s+(.*)$")
+_SYSTEM_MAP_ENTRY = re.compile(r"^\s*-\s+\*\*([A-Z0-9]{2,8})\*\*\s+—\s+(.*)$")
+_SYSTEM_CANDIDATE_PATTERNS = [
+    re.compile(r"^\s*###\s+([A-Z0-9]{3})\s*$"),
+    re.compile(r"\*\*([A-Z0-9]{3})\*\*\s+—"),
+    re.compile(r"\bacronym\s*:\s*`?([A-Z0-9]{3})`?", re.IGNORECASE),
+    re.compile(r"\b([A-Z0-9]{3})\s+system\b"),
+]
+_OWNER_CLAIM_PATTERNS = [
+    re.compile(r"\bowns\b", re.IGNORECASE),
+    re.compile(r"\bowner of\b", re.IGNORECASE),
+    re.compile(r"\bcanonical owner\b", re.IGNORECASE),
+    re.compile(r"\blifecycle owner\b", re.IGNORECASE),
+    re.compile(r"\bresponsible for\b", re.IGNORECASE),
+    re.compile(r"\bauthority\b", re.IGNORECASE),
+    re.compile(r"\bcontrols\b", re.IGNORECASE),
+    re.compile(r"\bgovers?ns\b", re.IGNORECASE),
+    re.compile(r"\bemits\b", re.IGNORECASE),
+    re.compile(r"\boverride\b", re.IGNORECASE),
+]
+
+
+def _normalize_tokens(text: str) -> list[str]:
+    lowered = text.lower()
+    lowered = re.sub(r"[^a-z0-9]+", " ", lowered)
+    tokens: list[str] = []
+    for token in lowered.split():
+        if token.endswith("ies") and len(token) > 3:
+            token = token[:-3] + "y"
+        elif token.endswith("s") and len(token) > 3:
+            token = token[:-1]
+        tokens.append(token)
+    return tokens
+
+
+def _stable_hash(payload: Any) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def load_guard_policy(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise SystemRegistryGuardError(f"guard policy file not found: {path}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SystemRegistryGuardError(f"guard policy JSON invalid: {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise SystemRegistryGuardError("guard policy must be a JSON object")
+    return payload
+
+
+def parse_system_registry(path: Path) -> RegistryModel:
+    if not path.is_file():
+        raise SystemRegistryGuardError(f"registry markdown not found: {path}")
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    systems_from_map: dict[str, str] = {}
+    current_section = ""
+    in_system_map = False
+    current_system: str | None = None
+    collecting_list: str | None = None
+    parsed: dict[str, dict[str, Any]] = {}
+
+    for line in lines:
+        section_match = _SECTION_HEADER.match(line)
+        if section_match:
+            current_section = section_match.group(1).strip().lower()
+            in_system_map = current_section == "system map"
+
+        if in_system_map:
+            entry = _SYSTEM_MAP_ENTRY.match(line)
+            if entry:
+                acronym = entry.group(1).strip().upper()
+                descriptor = entry.group(2).strip().lower()
+                status = "active"
+                if "deprecated" in descriptor:
+                    status = "deprecated"
+                if "historical" in descriptor or "removed" in descriptor or "not currently present" in descriptor:
+                    status = "removed"
+                if "placeholder" in descriptor:
+                    status = "placeholder"
+                systems_from_map[acronym] = status
+
+        header = _SYSTEM_HEADER.match(line)
+        if header:
+            current_system = header.group(1).strip().upper()
+            collecting_list = None
+            parsed.setdefault(
+                current_system,
+                {
+                    "acronym": current_system,
+                    "full_name": "",
+                    "role": "",
+                    "owns": [],
+                    "consumes": [],
+                    "produces": [],
+                    "must_not_do": [],
+                },
+            )
+            continue
+
+        if current_system is None:
+            continue
+
+        field = _FIELD_LINE.match(line)
+        if field:
+            name, remainder = field.groups()
+            if name in {"acronym", "full_name", "role"}:
+                parsed[current_system][name] = remainder.strip().strip("`")
+                collecting_list = None
+            else:
+                collecting_list = name
+            continue
+
+        if collecting_list:
+            bullet = _BULLET_LINE.match(line)
+            if bullet:
+                item = bullet.group(1).strip()
+                if item and not item.startswith("**"):
+                    parsed[current_system][collecting_list].append(item)
+                continue
+            if line.strip() and not line.strip().startswith("-"):
+                collecting_list = None
+
+    if "System Definitions" not in path.read_text(encoding="utf-8"):
+        raise SystemRegistryGuardError("registry missing required 'System Definitions' section")
+
+    systems: dict[str, RegistrySystem] = {}
+    for acronym, row in parsed.items():
+        owns = tuple(str(item).strip() for item in row["owns"] if str(item).strip())
+        status = systems_from_map.get(acronym, "active")
+        systems[acronym] = RegistrySystem(
+            acronym=acronym,
+            full_name=str(row.get("full_name") or "").strip(),
+            role=str(row.get("role") or "").strip(),
+            owns=owns,
+            consumes=tuple(str(item).strip() for item in row["consumes"] if str(item).strip()),
+            produces=tuple(str(item).strip() for item in row["produces"] if str(item).strip()),
+            must_not_do=tuple(str(item).strip() for item in row["must_not_do"] if str(item).strip()),
+            status=status,
+        )
+
+    if not systems:
+        raise SystemRegistryGuardError("registry parsing failed: no system definitions found")
+
+    owners: dict[str, str] = {}
+    for acronym, system in systems.items():
+        if system.status == "removed":
+            continue
+        for responsibility in system.owns:
+            key = responsibility.strip().lower()
+            if not key:
+                continue
+            if key in owners and owners[key] != acronym:
+                raise SystemRegistryGuardError(
+                    f"registry ownership conflict for '{responsibility}': {owners[key]} and {acronym}"
+                )
+            owners[key] = acronym
+
+    digest = _stable_hash(
+        {
+            "systems": {
+                key: {
+                    "status": value.status,
+                    "owns": list(value.owns),
+                    "must_not_do": list(value.must_not_do),
+                }
+                for key, value in sorted(systems.items())
+            }
+        }
+    )
+
+    return RegistryModel(
+        source_path=str(path),
+        source_digest=digest,
+        systems=systems,
+        active_systems=tuple(sorted([k for k, v in systems.items() if v.status == "active"])),
+        deprecated_systems=tuple(sorted([k for k, v in systems.items() if v.status == "deprecated"])),
+        removed_systems=tuple(sorted([k for k, v in systems.items() if v.status == "removed"])),
+        placeholder_systems=tuple(sorted([k for k, v in systems.items() if v.status == "placeholder"])),
+    )
+
+
+def evaluate_system_registry_guard(
+    *,
+    repo_root: Path,
+    changed_files: list[str],
+    policy: dict[str, Any],
+    registry_model: RegistryModel,
+) -> dict[str, Any]:
+    changed_paths = sorted(set(path for path in changed_files if path))
+    owners_by_responsibility: dict[str, str] = {}
+    cluster_owner: dict[str, str] = {}
+
+    clusters = policy.get("responsibility_clusters", {}) if isinstance(policy.get("responsibility_clusters"), dict) else {}
+    synonym_groups = policy.get("synonym_groups", {}) if isinstance(policy.get("synonym_groups"), dict) else {}
+    phrase_mappings = policy.get("phrase_mappings", {}) if isinstance(policy.get("phrase_mappings"), dict) else {}
+    protected_seams = {
+        str(key): str(value).upper()
+        for key, value in (policy.get("protected_authority_seams", {}) or {}).items()
+        if str(key).strip() and str(value).strip()
+    }
+
+    synonym_to_cluster: dict[str, str] = {}
+    for cluster, words in clusters.items():
+        words_list = list(words) if isinstance(words, list) else []
+        for word in words_list:
+            synonym_to_cluster[str(word).lower()] = str(cluster)
+    for cluster, words in synonym_groups.items():
+        words_list = list(words) if isinstance(words, list) else []
+        for word in words_list:
+            synonym_to_cluster[str(word).lower()] = str(cluster)
+    for phrase, cluster in phrase_mappings.items():
+        synonym_to_cluster[str(phrase).lower()] = str(cluster)
+
+    def normalize_cluster(text: str) -> str | None:
+        lowered = text.lower()
+        for phrase, cluster in phrase_mappings.items():
+            if phrase.lower() in lowered:
+                return str(cluster)
+        for token in _normalize_tokens(lowered):
+            if token in synonym_to_cluster:
+                return synonym_to_cluster[token]
+        return None
+
+    for acronym, system in registry_model.systems.items():
+        if system.status not in {"active", "deprecated", "placeholder"}:
+            continue
+        for own in system.owns:
+            key = own.lower().strip()
+            owners_by_responsibility[key] = acronym
+            cluster = normalize_cluster(own)
+            if cluster and cluster not in cluster_owner:
+                cluster_owner[cluster] = acronym
+
+    detected_system_candidates: list[dict[str, Any]] = []
+    detected_owner_claims: list[dict[str, Any]] = []
+    overlaps_found: list[dict[str, Any]] = []
+    shadow_owner_findings: list[dict[str, Any]] = []
+    removed_refs: list[dict[str, Any]] = []
+    registration_failures: list[dict[str, Any]] = []
+    protected_violations: list[dict[str, Any]] = []
+    acronym_collisions: list[dict[str, Any]] = []
+    required_actions: list[str] = []
+    reason_codes: set[str] = set()
+
+    for rel_path in changed_paths:
+        path = repo_root / rel_path
+        if not path.is_file():
+            continue
+        if rel_path == "docs/architecture/system_registry.md":
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        lines = content.splitlines()
+
+        for idx, line in enumerate(lines, start=1):
+            for pattern in _SYSTEM_CANDIDATE_PATTERNS:
+                for match in pattern.finditer(line):
+                    candidate = str(match.group(1)).upper()
+                    if len(candidate) == 3:
+                        detected_system_candidates.append(
+                            {"system": candidate, "file": rel_path, "line": idx, "text": line.strip()}
+                        )
+
+            if any(p.search(line) for p in _OWNER_CLAIM_PATTERNS):
+                system_match = re.search(r"\b([A-Z0-9]{3})\b", line)
+                if system_match:
+                    subject = system_match.group(1).upper()
+                    claim = {
+                        "system": subject,
+                        "file": rel_path,
+                        "line": idx,
+                        "text": line.strip(),
+                        "cluster": normalize_cluster(line),
+                    }
+                    detected_owner_claims.append(claim)
+                    if subject in registry_model.removed_systems:
+                        removed_refs.append(
+                            {
+                                "file": rel_path,
+                                "line": idx,
+                                "system": subject,
+                                "reason": "removed/deprecated system referenced as active owner claim",
+                            }
+                        )
+                        reason_codes.add("REMOVED_SYSTEM_REFERENCE")
+
+                    for seam, owner in protected_seams.items():
+                        if seam.lower() in line.lower() and subject != owner:
+                            protected_violations.append(
+                                {
+                                    "file": rel_path,
+                                    "line": idx,
+                                    "protected_seam": seam,
+                                    "claimed_owner": subject,
+                                    "canonical_owner": owner,
+                                    "reason": "protected authority seam claimed by non-owner",
+                                }
+                            )
+                            reason_codes.add("PROTECTED_AUTHORITY_VIOLATION")
+
+                    cluster = claim["cluster"]
+                    if cluster and subject in registry_model.systems:
+                        canonical_owner = cluster_owner.get(cluster)
+                        if canonical_owner and canonical_owner != subject:
+                            shadow_owner_findings.append(
+                                {
+                                    "file": rel_path,
+                                    "line": idx,
+                                    "system": subject,
+                                    "cluster": cluster,
+                                    "canonical_owner": canonical_owner,
+                                    "reason": "semantic ownership overlap",
+                                }
+                            )
+                            reason_codes.add("SHADOW_OWNERSHIP_OVERLAP")
+
+                    for responsibility, owner in owners_by_responsibility.items():
+                        if responsibility and responsibility in line.lower() and subject in registry_model.systems and owner != subject:
+                            overlaps_found.append(
+                                {
+                                    "file": rel_path,
+                                    "line": idx,
+                                    "system": subject,
+                                    "responsibility": responsibility,
+                                    "canonical_owner": owner,
+                                    "reason": "direct ownership overlap",
+                                }
+                            )
+                            reason_codes.add("DIRECT_OWNERSHIP_OVERLAP")
+
+        active_or_known = set(registry_model.systems.keys())
+        registry_changed = "docs/architecture/system_registry.md" in changed_paths
+        for candidate_entry in detected_system_candidates:
+            candidate = candidate_entry["system"]
+            if candidate in active_or_known:
+                status = registry_model.systems[candidate].status
+                system_row = registry_model.systems[candidate]
+                if registry_changed and (
+                    not system_row.full_name
+                    or not system_row.role
+                    or not system_row.owns
+                    or not system_row.consumes
+                    or not system_row.produces
+                    or not system_row.must_not_do
+                ):
+                    registration_failures.append(
+                        {
+                            "file": candidate_entry["file"],
+                            "line": candidate_entry["line"],
+                            "system": candidate,
+                            "reason": "new system registry entry missing required canonical fields",
+                        }
+                    )
+                    reason_codes.add("INCOMPLETE_SYSTEM_REGISTRATION")
+                if status == "removed" and rel_path != "docs/architecture/system_registry.md":
+                    removed_refs.append(
+                        {
+                            "file": candidate_entry["file"],
+                            "line": candidate_entry["line"],
+                            "system": candidate,
+                            "reason": "removed/deprecated system referenced as active candidate",
+                        }
+                    )
+                    reason_codes.add("REMOVED_SYSTEM_REFERENCE")
+                continue
+            if candidate == "SRG":
+                registration_failures.append(
+                    {
+                        "file": candidate_entry["file"],
+                        "line": candidate_entry["line"],
+                        "system": candidate,
+                        "reason": "SRG must not be introduced as canonical system owner",
+                    }
+                )
+                reason_codes.add("SRG_OWNER_INTRODUCTION_FORBIDDEN")
+                continue
+            if not registry_changed:
+                registration_failures.append(
+                    {
+                        "file": candidate_entry["file"],
+                        "line": candidate_entry["line"],
+                        "system": candidate,
+                        "reason": "new system introduced without same-change registry update",
+                    }
+                )
+                reason_codes.add("NEW_SYSTEM_MISSING_REGISTRATION")
+            else:
+                registry_text = (repo_root / "docs/architecture/system_registry.md").read_text(encoding="utf-8")
+                required_fields = ["**acronym:**", "**full_name:**", "**role:**", "**owns:**", "**consumes:**", "**produces:**", "**must_not_do:**"]
+                header = f"### {candidate}"
+                if header not in registry_text or any(field not in registry_text.split(header, 1)[1] for field in required_fields):
+                    registration_failures.append(
+                        {
+                            "file": candidate_entry["file"],
+                            "line": candidate_entry["line"],
+                            "system": candidate,
+                            "reason": "new system registry entry missing required canonical fields",
+                        }
+                    )
+                    reason_codes.add("INCOMPLETE_SYSTEM_REGISTRATION")
+
+            if candidate in registry_model.removed_systems:
+                acronym_collisions.append(
+                    {
+                        "file": candidate_entry["file"],
+                        "line": candidate_entry["line"],
+                        "system": candidate,
+                        "reason": "acronym collision with retired namespace",
+                    }
+                )
+                reason_codes.add("ACRONYM_NAMESPACE_COLLISION")
+
+    if overlaps_found:
+        required_actions.append("Use the canonical owner responsibilities from docs/architecture/system_registry.md.")
+    if shadow_owner_findings:
+        required_actions.append("Narrow ownership language to non-owning support semantics or delegate to canonical owner.")
+    if registration_failures:
+        required_actions.append("Register allowed new systems in docs/architecture/system_registry.md within the same change set.")
+    if removed_refs:
+        required_actions.append("Mark historical systems as non-authoritative historical references, not active owners.")
+    if protected_violations:
+        required_actions.append("Restore protected authority seams to their canonical owner system.")
+
+    failed = bool(
+        overlaps_found
+        or shadow_owner_findings
+        or removed_refs
+        or registration_failures
+        or protected_violations
+        or acronym_collisions
+    )
+
+    return {
+        "artifact_type": "system_registry_guard_result",
+        "status": "fail" if failed else "pass",
+        "checked_files": changed_paths,
+        "changed_files": changed_paths,
+        "detected_system_candidates": detected_system_candidates,
+        "detected_owner_claims": detected_owner_claims,
+        "overlaps_found": overlaps_found,
+        "shadow_owner_findings": shadow_owner_findings,
+        "removed_system_references_found": removed_refs,
+        "registration_failures": registration_failures,
+        "protected_authority_violations": protected_violations,
+        "acronym_collisions": acronym_collisions,
+        "required_actions": sorted(set(required_actions)),
+        "normalized_reason_codes": sorted(reason_codes),
+        "registry_digest_or_version": registry_model.source_digest,
+        "trace": {
+            "registry_path": registry_model.source_path,
+            "policy_version": str(policy.get("policy_version", "unknown")),
+            "active_system_count": len(registry_model.active_systems),
+            "deprecated_system_count": len(registry_model.deprecated_systems),
+            "placeholder_system_count": len(registry_model.placeholder_systems),
+            "removed_system_count": len(registry_model.removed_systems),
+        },
+    }
+
+
+__all__ = [
+    "SystemRegistryGuardError",
+    "RegistrySystem",
+    "RegistryModel",
+    "load_guard_policy",
+    "parse_system_registry",
+    "evaluate_system_registry_guard",
+]

--- a/spectrum_systems/modules/runtime/github_pr_autofix_contract_preflight.py
+++ b/spectrum_systems/modules/runtime/github_pr_autofix_contract_preflight.py
@@ -84,6 +84,14 @@ def _write_recovery_outcome(
 
 def classify_preflight_block(*, report: dict[str, Any]) -> tuple[str, list[str]]:
     reasons: list[str] = []
+    ref_context = ((report.get("changed_path_detection") or {}).get("ref_context") or {}) if isinstance(report, dict) else {}
+    ref_reason_code = str(ref_context.get("reason_code") or "").strip()
+    if ref_reason_code == "missing_refs":
+        return "missing_required_artifact", ["missing_refs"]
+    if ref_reason_code == "unsupported_event_context":
+        return "internal_preflight_error", ["unsupported_event_context"]
+    if ref_reason_code == "malformed_ref_context":
+        return "invalid_wrapper", ["malformed_ref_context"]
 
     schema_example_failures = report.get("schema_example_failures") or []
     if schema_example_failures:
@@ -96,6 +104,9 @@ def classify_preflight_block(*, report: dict[str, Any]) -> tuple[str, list[str]]
         return "schema_violation", ["SCHEMA_EXAMPLE_FAILURE"]
 
     if report.get("missing_required_surface"):
+        reason_codes = [str(item) for item in (report.get("invariant_violations") or []) if isinstance(item, str)]
+        if "contract_mismatch_from_bad_ref_resolution" in reason_codes:
+            return "contract_mismatch", ["contract_mismatch_from_bad_ref_resolution"]
         return "contract_mismatch", ["MISSING_REQUIRED_SURFACE_MAPPING"]
 
     pqx_ctx = report.get("changed_path_detection", {}).get("pqx_required_context_enforcement")

--- a/spectrum_systems/modules/runtime/github_pr_autofix_contract_preflight.py
+++ b/spectrum_systems/modules/runtime/github_pr_autofix_contract_preflight.py
@@ -84,6 +84,7 @@ def _write_recovery_outcome(
 
 def classify_preflight_block(*, report: dict[str, Any]) -> tuple[str, list[str]]:
     reasons: list[str] = []
+    invariant_violations = [str(item) for item in (report.get("invariant_violations") or []) if isinstance(item, str)]
     ref_context = ((report.get("changed_path_detection") or {}).get("ref_context") or {}) if isinstance(report, dict) else {}
     ref_reason_code = str(ref_context.get("reason_code") or "").strip()
     if ref_reason_code == "missing_refs":
@@ -92,6 +93,17 @@ def classify_preflight_block(*, report: dict[str, Any]) -> tuple[str, list[str]]
         return "internal_preflight_error", ["unsupported_event_context"]
     if ref_reason_code == "malformed_ref_context":
         return "invalid_wrapper", ["malformed_ref_context"]
+    if ref_reason_code == "invalid_git_ref":
+        return "invalid_wrapper", ["invalid_git_ref"]
+
+    detection_mode = str((report.get("changed_path_detection") or {}).get("changed_path_detection_mode") or "")
+    if detection_mode in {"ref_context_invalid", "detection_failed_no_governed_paths"}:
+        if "contract_mismatch_from_bad_ref_resolution" in invariant_violations:
+            return "contract_mismatch", ["contract_mismatch_from_bad_ref_resolution"]
+        return "missing_required_artifact", ["changed_path_resolution_failure"]
+
+    if report.get("bootstrap_failures"):
+        return "missing_required_artifact", ["changed_path_resolution_failure"]
 
     schema_example_failures = report.get("schema_example_failures") or []
     if schema_example_failures:
@@ -104,8 +116,7 @@ def classify_preflight_block(*, report: dict[str, Any]) -> tuple[str, list[str]]
         return "schema_violation", ["SCHEMA_EXAMPLE_FAILURE"]
 
     if report.get("missing_required_surface"):
-        reason_codes = [str(item) for item in (report.get("invariant_violations") or []) if isinstance(item, str)]
-        if "contract_mismatch_from_bad_ref_resolution" in reason_codes:
+        if "contract_mismatch_from_bad_ref_resolution" in invariant_violations:
             return "contract_mismatch", ["contract_mismatch_from_bad_ref_resolution"]
         return "contract_mismatch", ["MISSING_REQUIRED_SURFACE_MAPPING"]
 
@@ -118,7 +129,7 @@ def classify_preflight_block(*, report: dict[str, Any]) -> tuple[str, list[str]]
             return "invalid_wrapper", ["PQX_REQUIRED_CONTEXT_WRAPPER_BLOCK"]
         return "missing_required_artifact", ["PQX_REQUIRED_CONTEXT_ENFORCEMENT_BLOCK"]
 
-    mode = str((report.get("changed_path_detection") or {}).get("changed_path_detection_mode") or "")
+    mode = detection_mode
     if mode == "degraded_full_governed_scan":
         return "internal_preflight_error", ["PR_EVENT_PREFLIGHT_NORMALIZATION_BUG"]
 
@@ -138,6 +149,15 @@ def classify_preflight_block(*, report: dict[str, Any]) -> tuple[str, list[str]]
         reasons.extend(["CONSUMER_FAILURES_PRESENT"])
         return "contract_mismatch", reasons
 
+    if invariant_violations:
+        if "artifact_validation_failure" in invariant_violations:
+            return "schema_violation", ["artifact_validation_failure"]
+        if "repair_pipeline_failure" in invariant_violations:
+            return "internal_preflight_error", ["repair_pipeline_failure"]
+        if "preflight_runtime_exception" in invariant_violations:
+            return "internal_preflight_error", ["preflight_runtime_exception"]
+        return "contract_mismatch", invariant_violations[:3]
+
     return "unknown_preflight_failure", ["UNCLASSIFIED_BLOCK_REASON"]
 
 
@@ -152,7 +172,10 @@ def _repair_policy(failure_class: str) -> tuple[str, bool, bool]:
 
 
 def build_preflight_block_diagnosis_record(*, report: dict[str, Any], preflight_artifact: dict[str, Any]) -> dict[str, Any]:
-    category, reasons = classify_preflight_block(report=report)
+    try:
+        category, reasons = classify_preflight_block(report=report)
+    except Exception:
+        category, reasons = "internal_preflight_error", ["preflight_runtime_exception"]
     return {
         "artifact_type": "preflight_block_diagnosis_record",
         "artifact_version": "1.0.0",
@@ -447,7 +470,7 @@ def run_preflight_block_autorepair(
             rerun_status="not_run",
             final_decision="repair_failed",
             retry_count=1,
-            reason_codes=list(diagnosis.get("reason_codes", [])) + ["VALIDATION_REPLAY_FAILED"],
+            reason_codes=list(diagnosis.get("reason_codes", [])) + ["VALIDATION_REPLAY_FAILED", "repair_pipeline_failure"],
             artifact_refs=artifact_refs,
         )
         raise ContractPreflightAutofixError("validation_replay_failed")
@@ -498,7 +521,7 @@ def run_preflight_block_autorepair(
             rerun_status="blocked",
             final_decision="repaired_but_still_blocked",
             retry_count=1,
-            reason_codes=list(diagnosis.get("reason_codes", [])) + ["RERUN_STILL_BLOCKED"],
+            reason_codes=list(diagnosis.get("reason_codes", [])) + ["RERUN_STILL_BLOCKED", "repair_pipeline_failure"],
             artifact_refs=artifact_refs,
         )
         raise ContractPreflightAutofixError("preflight_rerun_blocked_or_failed")

--- a/spectrum_systems/modules/runtime/github_pr_autofix_contract_preflight.py
+++ b/spectrum_systems/modules/runtime/github_pr_autofix_contract_preflight.py
@@ -28,6 +28,14 @@ KNOWN_REPAIR_CATEGORIES = {
     "unknown_preflight_failure",
 }
 
+TERMINAL_STATES = {
+    "passed_without_repair",
+    "passed_after_auto_repair",
+    "blocked_repair_failed",
+    "blocked_repair_not_applicable",
+    "blocked_escalation_required",
+}
+
 
 @dataclass(frozen=True)
 class CommandResult:
@@ -59,13 +67,15 @@ def _write_recovery_outcome(
     repair_execution_status: str,
     rerun_status: str,
     final_decision: str,
+    repair_attempted: bool,
+    repair_inapplicable_reason: str | None,
     retry_count: int,
     reason_codes: list[str],
     artifact_refs: dict[str, str],
 ) -> dict[str, Any]:
     payload = {
         "artifact_type": "preflight_recovery_outcome_record",
-        "schema_version": "1.0.0",
+        "schema_version": "1.1.0",
         "initial_preflight_status": str(result_artifact.get("preflight_status") or "failed"),
         "failure_class": str(diagnosis.get("failure_class") or "unknown_preflight_failure"),
         "eligibility_decision": str(plan.get("eligibility_decision") or "escalation_required"),
@@ -73,6 +83,8 @@ def _write_recovery_outcome(
         "repair_execution_status": repair_execution_status,
         "rerun_status": rerun_status,
         "final_decision": final_decision,
+        "repair_attempted": repair_attempted,
+        "repair_inapplicable_reason": repair_inapplicable_reason,
         "retry_count": retry_count,
         "reason_codes": sorted({str(code) for code in reason_codes if str(code)}),
         "artifact_refs": artifact_refs,
@@ -80,6 +92,31 @@ def _write_recovery_outcome(
     validate_artifact(payload, "preflight_recovery_outcome_record")
     _write_json(output_dir / "preflight_recovery_outcome_record.json", payload)
     return payload
+
+
+def _fold_terminal_state(
+    *,
+    eligibility_decision: str,
+    repair_attempted: bool,
+    repair_inapplicable_reason: str | None,
+    repair_execution_status: str,
+    rerun_status: str,
+) -> str:
+    if eligibility_decision == "escalation_required":
+        return "blocked_escalation_required"
+    if eligibility_decision == "auto_repair_forbidden":
+        return "blocked_repair_not_applicable"
+    if eligibility_decision == "auto_repair_allowed":
+        if not repair_attempted and not repair_inapplicable_reason:
+            raise ContractPreflightAutofixError("repair_guard_violation:auto_repair_allowed_without_attempt_or_reason")
+        if repair_inapplicable_reason:
+            return "blocked_repair_not_applicable"
+        if rerun_status == "passed":
+            return "passed_after_auto_repair"
+        if repair_execution_status in {"failed_validation", "failed_execution"}:
+            return "blocked_repair_failed"
+        return "blocked_repair_failed"
+    return "blocked_escalation_required"
 
 
 def classify_preflight_block(*, report: dict[str, Any]) -> tuple[str, list[str]]:
@@ -262,6 +299,7 @@ def build_preflight_repair_result_record(*, attempt_id: str, plan_record: dict[s
         "rerun_requires": list(plan_record.get("rerun_prerequisites", [])),
         "escalation_required": escalation_required,
         "next_invocation_surface": "scripts/run_github_pr_autofix_contract_preflight.py" if rerun_allowed else "operator_escalation_queue",
+        "terminal_state": "passed_after_auto_repair" if rerun_exit == 0 and rerun_decision == "ALLOW" else "blocked_repair_failed",
     }
 
 
@@ -306,18 +344,22 @@ def _repair_required_surface_mapping(*, repo_root: Path, report: dict[str, Any])
         if isinstance(loaded, dict):
             payload = {str(path): [str(test) for test in tests if isinstance(test, str)] for path, tests in loaded.items() if isinstance(path, str) and isinstance(tests, list)}
 
+    actionable = False
     for entry in missing:
         if not isinstance(entry, dict):
             continue
         path = str(entry.get("path") or "").strip()
         if not path.startswith("spectrum_systems/modules/runtime/"):
             continue
+        actionable = True
         module_stem = Path(path).stem
         candidate = f"tests/test_{module_stem}.py"
         fallback = "tests/test_task_registry_ai_adapter_eval_slice_runner.py"
         selected = candidate if (repo_root / candidate).is_file() else fallback
         payload[path] = sorted(set(payload.get(path, []) + [selected]))
 
+    if not actionable:
+        return []
     override_path.parent.mkdir(parents=True, exist_ok=True)
     override_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return [str(override_path.relative_to(repo_root))]
@@ -393,6 +435,7 @@ def run_preflight_block_autorepair(
         "rerun_decision_ref": str(output_dir / "preflight_repair_result_record.json"),
     }
 
+    repair_inapplicable_reason: str | None = None
     if plan["apply_automatically"]:
         category = plan["failure_class"]
         if category in {"invalid_wrapper", "authority_evidence_missing", "missing_required_artifact"}:
@@ -416,15 +459,63 @@ def run_preflight_block_autorepair(
             attempt["mutated_paths"] = _repair_system_registry_reserved_entries(repo_root=repo_root)
         else:
             raise ContractPreflightAutofixError("unsupported_auto_repair_category")
+        if not attempt["mutated_paths"]:
+            repair_inapplicable_reason = "empty_repair_plan"
+            attempt["attempt_status"] = "skipped"
+            result = build_preflight_repair_result_record(
+                attempt_id=attempt["attempt_id"],
+                plan_record=plan,
+                rerun_exit=2,
+                rerun_decision=str(((result_artifact.get("control_signal") or {}).get("strategy_gate_decision")) or "BLOCK"),
+            )
+            result["terminal_state"] = _fold_terminal_state(
+                eligibility_decision=str(plan.get("eligibility_decision", "escalation_required")),
+                repair_attempted=False,
+                repair_inapplicable_reason=repair_inapplicable_reason,
+                repair_execution_status="not_invoked",
+                rerun_status="not_run",
+            )
+            validate_artifact(attempt, "preflight_repair_attempt_record")
+            validate_artifact(result, "preflight_repair_result_record")
+            _write_json(output_dir / "preflight_repair_attempt_record.json", attempt)
+            _write_json(output_dir / "preflight_repair_result_record.json", result)
+            _write_recovery_outcome(
+                output_dir=output_dir,
+                result_artifact=result_artifact,
+                diagnosis=diagnosis,
+                plan=plan,
+                repair_invoked=False,
+                repair_execution_status="not_invoked",
+                rerun_status="not_run",
+                final_decision=result["terminal_state"],
+                repair_attempted=False,
+                repair_inapplicable_reason=repair_inapplicable_reason,
+                retry_count=0,
+                reason_codes=list(diagnosis.get("reason_codes", [])) + ["EMPTY_REPAIR_PLAN"],
+                artifact_refs=artifact_refs,
+            )
+            raise ContractPreflightAutofixError("repair_plan_not_applicable:empty_repair_plan")
         if len(attempt["mutated_paths"]) > 5:
             raise ContractPreflightAutofixError("proposed_file_scope_too_broad")
         attempt["attempt_status"] = "applied"
     else:
+        repair_inapplicable_reason = (
+            "eligibility_decision_escalation_required"
+            if str(plan.get("eligibility_decision")) == "escalation_required"
+            else "auto_repair_forbidden_by_policy"
+        )
         result = build_preflight_repair_result_record(
             attempt_id=attempt["attempt_id"],
             plan_record=plan,
             rerun_exit=2,
             rerun_decision=str(((result_artifact.get("control_signal") or {}).get("strategy_gate_decision")) or "BLOCK"),
+        )
+        result["terminal_state"] = _fold_terminal_state(
+            eligibility_decision=str(plan.get("eligibility_decision", "escalation_required")),
+            repair_attempted=False,
+            repair_inapplicable_reason=repair_inapplicable_reason,
+            repair_execution_status="not_invoked",
+            rerun_status="not_permitted",
         )
         validate_artifact(attempt, "preflight_repair_attempt_record")
         validate_artifact(result, "preflight_repair_result_record")
@@ -441,7 +532,9 @@ def run_preflight_block_autorepair(
             repair_invoked=False,
             repair_execution_status="not_invoked",
             rerun_status="not_permitted",
-            final_decision="repair_not_permitted",
+            final_decision=result["terminal_state"],
+            repair_attempted=False,
+            repair_inapplicable_reason=repair_inapplicable_reason,
             retry_count=0,
             reason_codes=list(diagnosis.get("reason_codes", [])),
             artifact_refs=artifact_refs,
@@ -460,6 +553,13 @@ def run_preflight_block_autorepair(
         "validation_command": " ".join(validation_cmd),
     }
     if validation.returncode != 0:
+        terminal_state = _fold_terminal_state(
+            eligibility_decision=str(plan.get("eligibility_decision", "escalation_required")),
+            repair_attempted=True,
+            repair_inapplicable_reason=None,
+            repair_execution_status="failed_validation",
+            rerun_status="not_run",
+        )
         _write_recovery_outcome(
             output_dir=output_dir,
             result_artifact=result_artifact,
@@ -468,7 +568,9 @@ def run_preflight_block_autorepair(
             repair_invoked=True,
             repair_execution_status="failed_validation",
             rerun_status="not_run",
-            final_decision="repair_failed",
+            final_decision=terminal_state,
+            repair_attempted=True,
+            repair_inapplicable_reason=None,
             retry_count=1,
             reason_codes=list(diagnosis.get("reason_codes", [])) + ["VALIDATION_REPLAY_FAILED", "repair_pipeline_failure"],
             artifact_refs=artifact_refs,
@@ -500,6 +602,13 @@ def run_preflight_block_autorepair(
         rerun_exit=rerun.returncode,
         rerun_decision=rerun_decision,
     )
+    result["terminal_state"] = _fold_terminal_state(
+        eligibility_decision=str(plan.get("eligibility_decision", "escalation_required")),
+        repair_attempted=True,
+        repair_inapplicable_reason=None,
+        repair_execution_status="completed",
+        rerun_status="passed" if result["success"] else "blocked",
+    )
 
     validate_artifact(attempt, "preflight_repair_attempt_record")
     validate_artifact(validation_record, "preflight_repair_validation_record")
@@ -519,7 +628,9 @@ def run_preflight_block_autorepair(
             repair_invoked=True,
             repair_execution_status="completed",
             rerun_status="blocked",
-            final_decision="repaired_but_still_blocked",
+            final_decision=result["terminal_state"],
+            repair_attempted=True,
+            repair_inapplicable_reason=None,
             retry_count=1,
             reason_codes=list(diagnosis.get("reason_codes", [])) + ["RERUN_STILL_BLOCKED", "repair_pipeline_failure"],
             artifact_refs=artifact_refs,
@@ -533,7 +644,9 @@ def run_preflight_block_autorepair(
         repair_invoked=True,
         repair_execution_status="completed",
         rerun_status="passed",
-        final_decision="repaired_and_passed",
+        final_decision=result["terminal_state"],
+        repair_attempted=True,
+        repair_inapplicable_reason=None,
         retry_count=1,
         reason_codes=list(diagnosis.get("reason_codes", [])),
         artifact_refs=artifact_refs,

--- a/spectrum_systems/modules/runtime/preflight_ref_normalization.py
+++ b/spectrum_systems/modules/runtime/preflight_ref_normalization.py
@@ -1,0 +1,172 @@
+"""Canonical event-aware ref normalization for governed preflight execution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+
+@dataclass(frozen=True)
+class PreflightRefResolution:
+    valid: bool
+    base_ref: str
+    head_ref: str
+    normalization_strategy: str
+    fallback_used: bool
+    event_name: str
+    invalid_reason: str | None
+    reason_code: str | None
+    raw_inputs: dict[str, str]
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "valid": self.valid,
+            "base_ref": self.base_ref,
+            "head_ref": self.head_ref,
+            "normalization_strategy": self.normalization_strategy,
+            "fallback_used": self.fallback_used,
+            "event_name": self.event_name,
+            "invalid_reason": self.invalid_reason,
+            "reason_code": self.reason_code,
+            "raw_inputs": dict(self.raw_inputs),
+        }
+
+
+def _clean(value: str | None) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def normalize_preflight_ref_context(
+    *,
+    event_name: str | None,
+    cli_base_ref: str | None,
+    cli_head_ref: str | None,
+    env: Mapping[str, str] | None,
+) -> PreflightRefResolution:
+    env_map = {k: _clean(v) for k, v in dict(env or {}).items()}
+    normalized_event = _clean(event_name).lower() or _clean(env_map.get("GITHUB_EVENT_NAME")).lower() or "local"
+
+    cli_base = _clean(cli_base_ref)
+    cli_head = _clean(cli_head_ref)
+    has_cli_pair = bool(cli_base and cli_head)
+    partial_cli = bool(cli_base or cli_head) and not has_cli_pair
+
+    raw_inputs = {
+        "event_name": normalized_event,
+        "cli_base_ref": cli_base,
+        "cli_head_ref": cli_head,
+        "github_base_sha": _clean(env_map.get("GITHUB_BASE_SHA")),
+        "github_head_sha": _clean(env_map.get("GITHUB_HEAD_SHA")),
+        "github_before_sha": _clean(env_map.get("GITHUB_BEFORE_SHA")),
+        "github_sha": _clean(env_map.get("GITHUB_SHA")),
+    }
+
+    if partial_cli:
+        return PreflightRefResolution(
+            valid=False,
+            base_ref="",
+            head_ref="",
+            normalization_strategy="rejected_partial_cli_pair",
+            fallback_used=False,
+            event_name=normalized_event,
+            invalid_reason="explicit CLI refs must provide both base and head",
+            reason_code="malformed_ref_context",
+            raw_inputs=raw_inputs,
+        )
+
+    if has_cli_pair:
+        return PreflightRefResolution(
+            valid=True,
+            base_ref=cli_base,
+            head_ref=cli_head,
+            normalization_strategy="explicit_cli_pair",
+            fallback_used=False,
+            event_name=normalized_event,
+            invalid_reason=None,
+            reason_code=None,
+            raw_inputs=raw_inputs,
+        )
+
+    if normalized_event == "pull_request":
+        env_base = _clean(env_map.get("GITHUB_BASE_SHA"))
+        env_head = _clean(env_map.get("GITHUB_HEAD_SHA"))
+        if env_base and env_head:
+            return PreflightRefResolution(
+                valid=True,
+                base_ref=env_base,
+                head_ref=env_head,
+                normalization_strategy="pull_request_env_pair",
+                fallback_used=True,
+                event_name=normalized_event,
+                invalid_reason=None,
+                reason_code=None,
+                raw_inputs=raw_inputs,
+            )
+        return PreflightRefResolution(
+            valid=False,
+            base_ref="",
+            head_ref="",
+            normalization_strategy="pull_request_env_missing",
+            fallback_used=True,
+            event_name=normalized_event,
+            invalid_reason="pull_request context requires GITHUB_BASE_SHA and GITHUB_HEAD_SHA when CLI refs are absent",
+            reason_code="missing_refs",
+            raw_inputs=raw_inputs,
+        )
+
+    if normalized_event == "push":
+        env_base = _clean(env_map.get("GITHUB_BEFORE_SHA"))
+        env_head = _clean(env_map.get("GITHUB_SHA"))
+        if env_base and env_head:
+            return PreflightRefResolution(
+                valid=True,
+                base_ref=env_base,
+                head_ref=env_head,
+                normalization_strategy="push_before_sha_fallback",
+                fallback_used=True,
+                event_name=normalized_event,
+                invalid_reason=None,
+                reason_code=None,
+                raw_inputs=raw_inputs,
+            )
+        return PreflightRefResolution(
+            valid=False,
+            base_ref="",
+            head_ref="",
+            normalization_strategy="push_env_missing",
+            fallback_used=True,
+            event_name=normalized_event,
+            invalid_reason="push context requires GITHUB_BEFORE_SHA and GITHUB_SHA when CLI refs are absent",
+            reason_code="missing_refs",
+            raw_inputs=raw_inputs,
+        )
+
+    if normalized_event in {"workflow_dispatch", "local", "unspecified", ""}:
+        return PreflightRefResolution(
+            valid=False,
+            base_ref="",
+            head_ref="",
+            normalization_strategy="dispatch_or_local_requires_explicit_refs",
+            fallback_used=False,
+            event_name=normalized_event,
+            invalid_reason="workflow_dispatch/local execution requires explicit --base-ref and --head-ref",
+            reason_code="unsupported_event_context",
+            raw_inputs=raw_inputs,
+        )
+
+    return PreflightRefResolution(
+        valid=False,
+        base_ref="",
+        head_ref="",
+        normalization_strategy="unsupported_event_type",
+        fallback_used=False,
+        event_name=normalized_event,
+        invalid_reason=f"unsupported event context: {normalized_event}",
+        reason_code="unsupported_event_context",
+        raw_inputs=raw_inputs,
+    )
+
+
+__all__ = ["PreflightRefResolution", "normalize_preflight_ref_context"]

--- a/tests/test_build_preflight_pqx_wrapper.py
+++ b/tests/test_build_preflight_pqx_wrapper.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 from scripts import build_preflight_pqx_wrapper as builder
+from scripts import run_contract_preflight as preflight
 
 
 def test_wrapper_builder_writes_changed_paths_and_resolution(tmp_path: Path, monkeypatch) -> None:
@@ -95,3 +96,7 @@ def test_wrapper_builder_blocks_on_insufficient_context(tmp_path: Path, monkeypa
     monkeypatch.setattr(builder, "resolve_changed_paths", lambda **_: FakeResult())
     rc = builder.main(["--base-ref", "base", "--head-ref", "head", "--template", "template.json"])
     assert rc == 2
+
+
+def test_wrapper_and_runner_share_canonical_ref_normalizer() -> None:
+    assert builder.normalize_preflight_ref_context is preflight.normalize_preflight_ref_context

--- a/tests/test_contract_preflight.py
+++ b/tests/test_contract_preflight.py
@@ -1673,3 +1673,105 @@ def test_preflight_blocks_when_system_registry_guard_fails(tmp_path: Path, monke
     report = json.loads((output_dir / "contract_preflight_report.json").read_text(encoding="utf-8"))
     assert "NEW_SYSTEM_MISSING_REGISTRATION" in report["invariant_violations"]
     assert (output_dir / "system_registry_guard_result.json").is_file()
+
+
+def test_preflight_push_event_normalizes_empty_cli_refs_from_push_env(tmp_path: Path, monkeypatch) -> None:
+    output_dir = tmp_path / "out"
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "push")
+    monkeypatch.setenv("GITHUB_BASE_SHA", "")
+    monkeypatch.setenv("GITHUB_HEAD_SHA", "")
+    monkeypatch.setenv("GITHUB_BEFORE_SHA", "78f6cd4c28268e03eab3794497feb26378f620c2")
+    monkeypatch.setenv("GITHUB_SHA", "cafecb6682f83c47134a7d01ae818643d1136811")
+
+    monkeypatch.setattr(
+        preflight,
+        "_parse_args",
+        lambda: type(
+            "Args",
+            (),
+            {
+                "base_ref": "",
+                "head_ref": "",
+                "event_name": "push",
+                "changed_path": ["README.md"],
+                "output_dir": str(output_dir),
+                "hardening_flow": False,
+                "execution_context": "pqx_governed",
+                "pqx_wrapper_path": None,
+                "authority_evidence_ref": None,
+            },
+        )(),
+    )
+
+    code = preflight.main()
+    assert code == 0
+    report = json.loads((output_dir / "contract_preflight_report.json").read_text(encoding="utf-8"))
+    ref_context = report["changed_path_detection"]["ref_context"]
+    assert ref_context["normalization_strategy"] == "push_before_sha_fallback"
+    assert ref_context["base_ref"] == "78f6cd4c28268e03eab3794497feb26378f620c2"
+    assert ref_context["head_ref"] == "cafecb6682f83c47134a7d01ae818643d1136811"
+    assert report["status"] == "passed"
+
+
+def test_preflight_workflow_dispatch_without_refs_blocks_with_precise_reason(tmp_path: Path, monkeypatch) -> None:
+    output_dir = tmp_path / "out"
+    monkeypatch.setattr(
+        preflight,
+        "_parse_args",
+        lambda: type(
+            "Args",
+            (),
+            {
+                "base_ref": "",
+                "head_ref": "",
+                "event_name": "workflow_dispatch",
+                "changed_path": [],
+                "output_dir": str(output_dir),
+                "hardening_flow": False,
+                "execution_context": "pqx_governed",
+                "pqx_wrapper_path": None,
+                "authority_evidence_ref": None,
+            },
+        )(),
+    )
+
+    code = preflight.main()
+    assert code == 2
+    report = json.loads((output_dir / "contract_preflight_report.json").read_text(encoding="utf-8"))
+    assert "unsupported_event_context" in report["invariant_violations"]
+    diagnosis = json.loads((output_dir / "preflight_block_diagnosis_record.json").read_text(encoding="utf-8"))
+    assert diagnosis["reason_codes"] == ["unsupported_event_context"]
+
+
+def test_preflight_cli_refs_override_env_push_fallback(tmp_path: Path, monkeypatch) -> None:
+    output_dir = tmp_path / "out"
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "push")
+    monkeypatch.setenv("GITHUB_BEFORE_SHA", "env-base")
+    monkeypatch.setenv("GITHUB_SHA", "env-head")
+    monkeypatch.setattr(
+        preflight,
+        "_parse_args",
+        lambda: type(
+            "Args",
+            (),
+            {
+                "base_ref": "explicit-base",
+                "head_ref": "explicit-head",
+                "event_name": "push",
+                "changed_path": ["README.md"],
+                "output_dir": str(output_dir),
+                "hardening_flow": False,
+                "execution_context": "pqx_governed",
+                "pqx_wrapper_path": None,
+                "authority_evidence_ref": None,
+            },
+        )(),
+    )
+
+    code = preflight.main()
+    assert code == 0
+    report = json.loads((output_dir / "contract_preflight_report.json").read_text(encoding="utf-8"))
+    ref_context = report["changed_path_detection"]["ref_context"]
+    assert ref_context["normalization_strategy"] == "explicit_cli_pair"
+    assert ref_context["base_ref"] == "explicit-base"
+    assert ref_context["head_ref"] == "explicit-head"

--- a/tests/test_contract_preflight.py
+++ b/tests/test_contract_preflight.py
@@ -1629,3 +1629,47 @@ def test_main_contract_preflight_blocks_con035_when_required_test_mapping_missin
     }
     assert "eligibility_decision" in plan
     assert "rerun_allowed" in rerun
+
+
+def test_preflight_blocks_when_system_registry_guard_fails(tmp_path: Path, monkeypatch) -> None:
+    output_dir = tmp_path / "out"
+    monkeypatch.setattr(
+        preflight,
+        "_parse_args",
+        lambda: type(
+            "Args",
+            (),
+            {
+                "base_ref": "origin/main",
+                "head_ref": "HEAD",
+                "changed_path": ["docs/proposal.md"],
+                "output_dir": str(output_dir),
+                "hardening_flow": False,
+                "execution_context": "pqx_governed",
+                "pqx_wrapper_path": None,
+                "authority_evidence_ref": None,
+            },
+        )(),
+    )
+    monkeypatch.setattr(
+        preflight,
+        "evaluate_system_registry_guard",
+        lambda **_kwargs: {
+            "artifact_type": "system_registry_guard_result",
+            "status": "fail",
+            "normalized_reason_codes": ["NEW_SYSTEM_MISSING_REGISTRATION"],
+            "changed_files": ["docs/proposal.md"],
+            "required_actions": ["Register the new system in the canonical registry."],
+        },
+    )
+    monkeypatch.setattr(preflight, "evaluate_control_surface_gap_bridge", lambda _out: {"status": "not_run", "gap_result": None, "gap_result_path": None, "pqx_work_items": None, "pqx_work_items_path": None, "conversion_error": None, "blocking": False})
+    monkeypatch.setattr(preflight, "evaluate_trust_spine_cohesion", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(preflight, "evaluate_pqx_execution_policy", lambda **_kwargs: type("Policy", (), {"to_dict": lambda self: {"status": "allow", "classification": "exploration_only_or_non_governed", "execution_context": "pqx_governed"}})())
+    monkeypatch.setattr(preflight, "enforce_pqx_required_context", lambda **_kwargs: type("Enf", (), {"to_dict": lambda self: {"status": "allow", "classification": "exploration_only_or_non_governed", "execution_context": "pqx_governed", "wrapper_present": False, "wrapper_context_valid": True, "authority_context_valid": True, "authority_state": "non_authoritative_direct_run", "requires_pqx_execution": False, "enforcement_decision": "allow", "blocking_reasons": []}})())
+
+    code = preflight.main()
+
+    assert code == 2
+    report = json.loads((output_dir / "contract_preflight_report.json").read_text(encoding="utf-8"))
+    assert "NEW_SYSTEM_MISSING_REGISTRATION" in report["invariant_violations"]
+    assert (output_dir / "system_registry_guard_result.json").is_file()

--- a/tests/test_contract_preflight.py
+++ b/tests/test_contract_preflight.py
@@ -1775,3 +1775,73 @@ def test_preflight_cli_refs_override_env_push_fallback(tmp_path: Path, monkeypat
     assert ref_context["normalization_strategy"] == "explicit_cli_pair"
     assert ref_context["base_ref"] == "explicit-base"
     assert ref_context["head_ref"] == "explicit-head"
+
+
+def test_push_context_exact_failure_regression_no_unknown_and_no_escalation(tmp_path: Path, monkeypatch) -> None:
+    output_dir = tmp_path / "out"
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "push")
+    monkeypatch.setenv("GITHUB_BEFORE_SHA", "cafecb6682f83c47134a7d01ae818643d1136811")
+    monkeypatch.setenv("GITHUB_SHA", "a91128736a3706718cb0d32910503cfe056d3d1f")
+    monkeypatch.setenv("GITHUB_BASE_SHA", "")
+    monkeypatch.setenv("GITHUB_HEAD_SHA", "")
+
+    monkeypatch.setattr(
+        preflight,
+        "_parse_args",
+        lambda: type(
+            "Args",
+            (),
+            {
+                "base_ref": "cafecb6682f83c47134a7d01ae818643d1136811",
+                "head_ref": "a91128736a3706718cb0d32910503cfe056d3d1f",
+                "event_name": "push",
+                "changed_path": [],
+                "output_dir": str(output_dir),
+                "hardening_flow": False,
+                "execution_context": "pqx_governed",
+                "pqx_wrapper_path": None,
+                "authority_evidence_ref": None,
+            },
+        )(),
+    )
+    monkeypatch.setattr(
+        preflight,
+        "detect_changed_paths",
+        lambda *_args, **_kwargs: preflight.ChangedPathDetectionResult(
+            changed_paths=[],
+            changed_path_detection_mode="detection_failed_no_governed_paths",
+            refs_attempted=["cafecb..a911"],
+            fallback_used=False,
+            warnings=["simulated diff failure"],
+        ),
+    )
+    monkeypatch.setattr(
+        preflight,
+        "evaluate_control_surface_gap_bridge",
+        lambda _output_dir: {
+            "status": "not_run",
+            "gap_result": None,
+            "gap_result_path": None,
+            "pqx_work_items": None,
+            "pqx_work_items_path": None,
+            "conversion_error": None,
+            "blocking": False,
+        },
+    )
+    monkeypatch.setattr(preflight, "evaluate_trust_spine_cohesion", lambda *_args, **_kwargs: None)
+
+    code = preflight.main()
+    assert code == 2
+
+    report = json.loads((output_dir / "contract_preflight_report.json").read_text(encoding="utf-8"))
+    assert report["root_cause_classification"]["failure_class"] != "unknown_preflight_failure"
+    assert report["root_cause_classification"]["reason_codes"] == ["changed_path_resolution_failure"]
+    ref_context = report["changed_path_detection"]["ref_context"]
+    assert ref_context["base_ref"] == "cafecb6682f83c47134a7d01ae818643d1136811"
+    assert ref_context["head_ref"] == "a91128736a3706718cb0d32910503cfe056d3d1f"
+
+    diagnosis = json.loads((output_dir / "preflight_block_diagnosis_record.json").read_text(encoding="utf-8"))
+    plan = json.loads((output_dir / "preflight_repair_plan_record.json").read_text(encoding="utf-8"))
+    assert diagnosis["failure_class"] != "unknown_preflight_failure"
+    assert plan["eligibility_decision"] == "auto_repair_allowed"
+    assert not (output_dir / "preflight_human_escalation_record.json").exists()

--- a/tests/test_github_pr_autofix_contract_preflight.py
+++ b/tests/test_github_pr_autofix_contract_preflight.py
@@ -131,6 +131,10 @@ def test_validation_replay_required_before_success(tmp_path: Path) -> None:
             command_runner=_runner,
         )
     assert any("pytest" in cmd for cmd in calls)
+    outcome = json.loads((out / "preflight_recovery_outcome_record.json").read_text(encoding="utf-8"))
+    assert outcome["final_decision"] == "blocked_repair_failed"
+    assert outcome["repair_attempted"] is True
+    assert outcome["repair_inapplicable_reason"] is None
 
 
 def test_rerun_preflight_required_and_blocks_when_still_block(tmp_path: Path) -> None:
@@ -159,7 +163,9 @@ def test_rerun_preflight_required_and_blocks_when_still_block(tmp_path: Path) ->
             command_runner=_runner,
         )
     outcome = json.loads((out / "preflight_recovery_outcome_record.json").read_text(encoding="utf-8"))
-    assert outcome["final_decision"] == "repaired_but_still_blocked"
+    assert outcome["final_decision"] == "blocked_repair_failed"
+    result = json.loads((out / "preflight_repair_result_record.json").read_text(encoding="utf-8"))
+    assert result["terminal_state"] == "blocked_repair_failed"
 
 
 def test_no_mutation_allowed_for_fork_or_unsafe_context(tmp_path: Path) -> None:
@@ -241,7 +247,7 @@ def test_missing_required_surface_mapping_autorepair_writes_override_file(tmp_pa
         command_runner=_runner,
     )
     assert result["repair_result"]["success"] is True
-    assert result["recovery_outcome"]["final_decision"] == "repaired_and_passed"
+    assert result["recovery_outcome"]["final_decision"] == "passed_after_auto_repair"
     override_file = tmp_path / "docs" / "governance" / "preflight_required_surface_test_overrides.json"
     assert override_file.exists()
 
@@ -267,8 +273,38 @@ def test_non_repairable_block_emits_recovery_outcome_and_escalates(tmp_path: Pat
             command_runner=lambda cmd, cwd: None,  # type: ignore[arg-type]
         )
     outcome = json.loads((out / "preflight_recovery_outcome_record.json").read_text(encoding="utf-8"))
-    assert outcome["final_decision"] == "repair_not_permitted"
+    assert outcome["final_decision"] == "blocked_repair_not_applicable"
     assert outcome["repair_invoked"] is False
+    assert outcome["repair_attempted"] is False
+    assert outcome["repair_inapplicable_reason"] == "auto_repair_forbidden_by_policy"
+
+
+def test_contract_mismatch_with_empty_repair_plan_is_blocked_not_applicable(tmp_path: Path) -> None:
+    out = _write_base_artifacts(
+        tmp_path,
+        report_overrides={
+            "missing_required_surface": [
+                {"path": "docs/architecture/system_registry.md", "reason": "missing deterministic mapping"},
+            ],
+            "changed_path_detection": {},
+        },
+    )
+    with pytest.raises(ContractPreflightAutofixError, match="repair_plan_not_applicable:empty_repair_plan"):
+        run_preflight_block_autorepair(
+            repo_root=tmp_path,
+            output_dir=out,
+            base_ref="base",
+            head_ref="head",
+            execution_context="pqx_governed",
+            pqx_wrapper_path=out / "preflight_pqx_task_wrapper.json",
+            authority_evidence_ref="artifact",
+            same_repo_write_allowed=True,
+            command_runner=lambda cmd, cwd: type("Res", (), {"command": cmd, "returncode": 0})(),
+        )
+    outcome = json.loads((out / "preflight_recovery_outcome_record.json").read_text(encoding="utf-8"))
+    assert outcome["final_decision"] == "blocked_repair_not_applicable"
+    assert outcome["repair_attempted"] is False
+    assert outcome["repair_inapplicable_reason"] == "empty_repair_plan"
 
 
 def test_schema_violation_auto_repair_path_writes_terminal_success_outcome(tmp_path: Path) -> None:
@@ -307,7 +343,7 @@ def test_schema_violation_auto_repair_path_writes_terminal_success_outcome(tmp_p
         same_repo_write_allowed=True,
         command_runner=_runner,
     )
-    assert result["recovery_outcome"]["final_decision"] == "repaired_and_passed"
+    assert result["recovery_outcome"]["final_decision"] == "passed_after_auto_repair"
 
 
 def test_classification_distinguishes_missing_refs_reason() -> None:

--- a/tests/test_github_pr_autofix_contract_preflight.py
+++ b/tests/test_github_pr_autofix_contract_preflight.py
@@ -7,6 +7,7 @@ from spectrum_systems.modules.runtime.github_pr_autofix_contract_preflight impor
     ContractPreflightAutofixError,
     build_preflight_block_diagnosis_record,
     build_preflight_repair_plan_record,
+    classify_preflight_block,
     run_preflight_block_autorepair,
 )
 
@@ -307,3 +308,38 @@ def test_schema_violation_auto_repair_path_writes_terminal_success_outcome(tmp_p
         command_runner=_runner,
     )
     assert result["recovery_outcome"]["final_decision"] == "repaired_and_passed"
+
+
+def test_classification_distinguishes_missing_refs_reason() -> None:
+    failure_class, reason_codes = classify_preflight_block(
+        report={"changed_path_detection": {"ref_context": {"reason_code": "missing_refs"}}}
+    )
+    assert failure_class == "missing_required_artifact"
+    assert reason_codes == ["missing_refs"]
+
+
+def test_classification_distinguishes_unsupported_event_context_reason() -> None:
+    failure_class, reason_codes = classify_preflight_block(
+        report={"changed_path_detection": {"ref_context": {"reason_code": "unsupported_event_context"}}}
+    )
+    assert failure_class == "internal_preflight_error"
+    assert reason_codes == ["unsupported_event_context"]
+
+
+def test_classification_distinguishes_malformed_ref_context_reason() -> None:
+    failure_class, reason_codes = classify_preflight_block(
+        report={"changed_path_detection": {"ref_context": {"reason_code": "malformed_ref_context"}}}
+    )
+    assert failure_class == "invalid_wrapper"
+    assert reason_codes == ["malformed_ref_context"]
+
+
+def test_classification_distinguishes_contract_mismatch_from_bad_ref_resolution() -> None:
+    failure_class, reason_codes = classify_preflight_block(
+        report={
+            "missing_required_surface": [{"path": "contracts/schemas/x.schema.json", "reason": "none"}],
+            "invariant_violations": ["contract_mismatch_from_bad_ref_resolution"],
+        }
+    )
+    assert failure_class == "contract_mismatch"
+    assert reason_codes == ["contract_mismatch_from_bad_ref_resolution"]

--- a/tests/test_github_pr_autofix_contract_preflight.py
+++ b/tests/test_github_pr_autofix_contract_preflight.py
@@ -343,3 +343,78 @@ def test_classification_distinguishes_contract_mismatch_from_bad_ref_resolution(
     )
     assert failure_class == "contract_mismatch"
     assert reason_codes == ["contract_mismatch_from_bad_ref_resolution"]
+
+
+def test_classification_maps_preflight_runtime_exception_reason() -> None:
+    failure_class, reason_codes = classify_preflight_block(
+        report={"invariant_violations": ["preflight_runtime_exception"]}
+    )
+    assert failure_class == "internal_preflight_error"
+    assert reason_codes == ["preflight_runtime_exception"]
+
+
+def test_repair_pipeline_failure_preserves_original_reason_codes(tmp_path: Path) -> None:
+    out = _write_base_artifacts(
+        tmp_path,
+        report_overrides={
+            "changed_path_detection": {"ref_context": {"reason_code": "missing_refs"}},
+        },
+    )
+
+    class _Res:
+        def __init__(self, command, returncode):
+            self.command = command
+            self.returncode = returncode
+
+    def _runner(cmd, cwd):
+        if "pytest" in cmd:
+            return _Res(cmd, 1)
+        return _Res(cmd, 0)
+
+    with pytest.raises(ContractPreflightAutofixError, match="validation_replay_failed"):
+        run_preflight_block_autorepair(
+            repo_root=tmp_path,
+            output_dir=out,
+            base_ref="base",
+            head_ref="head",
+            execution_context="pqx_governed",
+            pqx_wrapper_path=out / "preflight_pqx_task_wrapper.json",
+            authority_evidence_ref="artifact",
+            same_repo_write_allowed=True,
+            command_runner=_runner,
+        )
+
+    outcome = json.loads((out / "preflight_recovery_outcome_record.json").read_text(encoding="utf-8"))
+    assert "missing_refs" in outcome["reason_codes"]
+    assert "repair_pipeline_failure" in outcome["reason_codes"]
+
+
+def test_diagnosable_push_ref_failure_does_not_emit_human_escalation(tmp_path: Path) -> None:
+    out = _write_base_artifacts(
+        tmp_path,
+        report_overrides={
+            "changed_path_detection": {"ref_context": {"reason_code": "missing_refs"}},
+        },
+    )
+
+    with pytest.raises(ContractPreflightAutofixError, match="validation_replay_failed"):
+        run_preflight_block_autorepair(
+            repo_root=tmp_path,
+            output_dir=out,
+            base_ref="base",
+            head_ref="head",
+            execution_context="pqx_governed",
+            pqx_wrapper_path=out / "preflight_pqx_task_wrapper.json",
+            authority_evidence_ref="artifact",
+            same_repo_write_allowed=True,
+            command_runner=lambda cmd, cwd: type("Res", (), {"command": cmd, "returncode": 1 if "pytest" in cmd else 0})(),
+        )
+
+    assert not (out / "preflight_human_escalation_record.json").exists()
+
+
+def test_classification_deterministic_for_same_push_inputs() -> None:
+    report = {"changed_path_detection": {"ref_context": {"reason_code": "missing_refs"}}}
+    first = classify_preflight_block(report=report)
+    second = classify_preflight_block(report=report)
+    assert first == second

--- a/tests/test_preflight_ref_normalization.py
+++ b/tests/test_preflight_ref_normalization.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from spectrum_systems.modules.runtime.preflight_ref_normalization import normalize_preflight_ref_context
+
+
+def test_push_uses_before_and_sha_when_cli_missing() -> None:
+    result = normalize_preflight_ref_context(
+        event_name="push",
+        cli_base_ref="",
+        cli_head_ref="",
+        env={"GITHUB_BEFORE_SHA": "base123", "GITHUB_SHA": "head456", "GITHUB_BASE_SHA": "", "GITHUB_HEAD_SHA": ""},
+    )
+
+    assert result.valid is True
+    assert result.base_ref == "base123"
+    assert result.head_ref == "head456"
+    assert result.normalization_strategy == "push_before_sha_fallback"
+
+
+def test_pull_request_uses_env_pair_when_cli_missing() -> None:
+    result = normalize_preflight_ref_context(
+        event_name="pull_request",
+        cli_base_ref="",
+        cli_head_ref="",
+        env={"GITHUB_BASE_SHA": "prbase", "GITHUB_HEAD_SHA": "prhead"},
+    )
+
+    assert result.valid is True
+    assert result.base_ref == "prbase"
+    assert result.head_ref == "prhead"
+
+
+def test_workflow_dispatch_requires_explicit_refs() -> None:
+    result = normalize_preflight_ref_context(event_name="workflow_dispatch", cli_base_ref="", cli_head_ref="", env={})
+
+    assert result.valid is False
+    assert result.reason_code == "unsupported_event_context"
+
+
+def test_cli_pair_overrides_env() -> None:
+    result = normalize_preflight_ref_context(
+        event_name="push",
+        cli_base_ref="cli-base",
+        cli_head_ref="cli-head",
+        env={"GITHUB_BEFORE_SHA": "env-base", "GITHUB_SHA": "env-head"},
+    )
+
+    assert result.valid is True
+    assert result.base_ref == "cli-base"
+    assert result.head_ref == "cli-head"
+    assert result.normalization_strategy == "explicit_cli_pair"
+
+
+def test_partial_cli_pair_fails_closed() -> None:
+    result = normalize_preflight_ref_context(event_name="push", cli_base_ref="only-base", cli_head_ref="", env={"GITHUB_SHA": "x"})
+
+    assert result.valid is False
+    assert result.reason_code == "malformed_ref_context"
+
+
+def test_unknown_event_fails_closed() -> None:
+    result = normalize_preflight_ref_context(event_name="schedule", cli_base_ref="", cli_head_ref="", env={})
+
+    assert result.valid is False
+    assert result.reason_code == "unsupported_event_context"

--- a/tests/test_run_github_pr_autofix_contract_preflight.py
+++ b/tests/test_run_github_pr_autofix_contract_preflight.py
@@ -38,3 +38,72 @@ def test_cli_returns_blocked_on_autofix_error(monkeypatch, capsys, tmp_path: Pat
     assert payload["status"] == "blocked"
     assert "artifact_paths" in payload
     assert "recovery_outcome" in payload["artifact_paths"]
+
+
+def test_cli_returns_passed_after_auto_repair_on_push(monkeypatch, capsys, tmp_path: Path) -> None:
+    captured: dict[str, str] = {}
+    monkeypatch.setattr(
+        entry,
+        "_parse_args",
+        lambda: type(
+            "Args",
+            (),
+            {
+                "output_dir": str(tmp_path / "outputs" / "contract_preflight"),
+                "base_ref": "deadbeef",
+                "head_ref": "beadfeed",
+                "event_name": "push",
+                "execution_context": "pqx_governed",
+                "pqx_wrapper_path": "outputs/contract_preflight/preflight_pqx_task_wrapper.json",
+                "authority_evidence_ref": "artifact",
+                "same_repo_write_allowed": True,
+            },
+        )(),
+    )
+
+    def _runner(**kwargs):
+        captured["base_ref"] = kwargs["base_ref"]
+        captured["head_ref"] = kwargs["head_ref"]
+        return {"recovery_outcome": {"final_decision": "passed_after_auto_repair"}}
+
+    monkeypatch.setattr(entry, "run_preflight_block_autorepair", _runner)
+    assert entry.main() == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "passed"
+    assert payload["result"]["recovery_outcome"]["final_decision"] == "passed_after_auto_repair"
+    assert captured["base_ref"] == "deadbeef"
+    assert captured["head_ref"] == "beadfeed"
+
+
+def test_cli_normalizes_pull_request_refs(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.setenv("GITHUB_BASE_SHA", "cafecafe")
+    monkeypatch.setenv("GITHUB_HEAD_SHA", "feedfeed")
+    monkeypatch.setattr(
+        entry,
+        "_parse_args",
+        lambda: type(
+            "Args",
+            (),
+            {
+                "output_dir": str(tmp_path / "outputs" / "contract_preflight"),
+                "base_ref": "",
+                "head_ref": "",
+                "event_name": "pull_request",
+                "execution_context": "pqx_governed",
+                "pqx_wrapper_path": "outputs/contract_preflight/preflight_pqx_task_wrapper.json",
+                "authority_evidence_ref": "artifact",
+                "same_repo_write_allowed": True,
+            },
+        )(),
+    )
+    captured: dict[str, str] = {}
+
+    def _runner(**kwargs):
+        captured["base_ref"] = kwargs["base_ref"]
+        captured["head_ref"] = kwargs["head_ref"]
+        return {"ok": True}
+
+    monkeypatch.setattr(entry, "run_preflight_block_autorepair", _runner)
+    assert entry.main() == 0
+    assert captured == {"base_ref": "cafecafe", "head_ref": "feedfeed"}

--- a/tests/test_run_github_pr_autofix_contract_preflight.py
+++ b/tests/test_run_github_pr_autofix_contract_preflight.py
@@ -17,6 +17,7 @@ def test_cli_returns_blocked_on_autofix_error(monkeypatch, capsys, tmp_path: Pat
                 "output_dir": str(tmp_path / "outputs" / "contract_preflight"),
                 "base_ref": "base",
                 "head_ref": "head",
+                "event_name": "pull_request",
                 "execution_context": "pqx_governed",
                 "pqx_wrapper_path": "outputs/contract_preflight/preflight_pqx_task_wrapper.json",
                 "authority_evidence_ref": "artifact",

--- a/tests/test_system_registry_guard.py
+++ b/tests/test_system_registry_guard.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from spectrum_systems.modules.governance.system_registry_guard import (
+    evaluate_system_registry_guard,
+    parse_system_registry,
+)
+
+
+def _policy() -> dict[str, object]:
+    return {
+        "policy_version": "1.0.0",
+        "protected_authority_seams": {"execution": "PQX", "closure": "CDE", "override": "HIT"},
+        "responsibility_clusters": {
+            "execution": ["execution", "execute"],
+            "closure": ["closure", "promotion"],
+            "policy": ["policy", "admission"],
+            "override_hitl": ["override", "human"],
+        },
+        "synonym_groups": {"execution": ["run"], "closure": ["finalization"]},
+        "phrase_mappings": {
+            "execute work": "execution",
+            "closure decision": "closure",
+            "human override": "override_hitl",
+        },
+    }
+
+
+def _registry_text() -> str:
+    return """
+# System Registry (Canonical)
+
+## System Map
+- **PQX** — bounded execution engine
+- **CDE** — closure authority
+- **HIT** — human override authority
+- **OLD** — deprecated owner (deprecated)
+- **REM** — retired owner (not currently present in this repository scope)
+- **LCE** — placeholder lifecycle seam *(placeholder; control-plane seam)*
+
+## System Definitions
+
+### PQX
+- **acronym:** `PQX`
+- **full_name:** Prompt Queue Execution
+- **role:** executes bounded work
+- **owns:**
+  - execution
+- **consumes:**
+  - task
+- **produces:**
+  - execution_record
+- **must_not_do:**
+  - issue closure decisions
+
+### CDE
+- **acronym:** `CDE`
+- **full_name:** Closure Decision Engine
+- **role:** closure decisions
+- **owns:**
+  - closure_decision
+- **consumes:**
+  - evidence
+- **produces:**
+  - closure_decision_artifact
+- **must_not_do:**
+  - execute work
+
+### HIT
+- **acronym:** `HIT`
+- **full_name:** Human Interaction Touchpoint
+- **role:** human override authority
+- **owns:**
+  - override_record
+- **consumes:**
+  - evidence
+- **produces:**
+  - hit_record
+- **must_not_do:**
+  - execute work
+
+### OLD
+- **acronym:** `OLD`
+- **full_name:** Old Runtime
+- **role:** retired owner
+- **owns:**
+  - retired_capability
+- **consumes:**
+  - none
+- **produces:**
+  - none
+- **must_not_do:**
+  - everything
+
+### REM
+- **acronym:** `REM`
+- **full_name:** Removed Runtime
+- **role:** removed owner
+- **owns:**
+  - removed_capability
+- **consumes:**
+  - none
+- **produces:**
+  - none
+- **must_not_do:**
+  - everything
+""".strip()
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_parse_registry_model_classifies_statuses(tmp_path: Path) -> None:
+    registry_path = tmp_path / "docs" / "architecture" / "system_registry.md"
+    _write(registry_path, _registry_text())
+
+    model = parse_system_registry(registry_path)
+
+    assert "PQX" in model.active_systems
+    assert "OLD" in model.deprecated_systems
+    assert "REM" in model.removed_systems
+    assert model.systems["PQX"].owns == ("execution",)
+
+
+def test_guard_passes_for_existing_owner_reference(tmp_path: Path) -> None:
+    registry_path = tmp_path / "docs" / "architecture" / "system_registry.md"
+    _write(registry_path, _registry_text())
+    _write(tmp_path / "docs" / "notes.md", "PQX owns execution and executes work slices.")
+
+    result = evaluate_system_registry_guard(
+        repo_root=tmp_path,
+        changed_files=["docs/notes.md"],
+        policy=_policy(),
+        registry_model=parse_system_registry(registry_path),
+    )
+
+    assert result["status"] == "pass"
+
+
+def test_guard_fails_when_new_acronym_appears_outside_registry(tmp_path: Path) -> None:
+    registry_path = tmp_path / "docs" / "architecture" / "system_registry.md"
+    _write(registry_path, _registry_text())
+    _write(tmp_path / "docs" / "proposal.md", "### ZZZ\n- ZZZ owns execution decisions")
+
+    result = evaluate_system_registry_guard(
+        repo_root=tmp_path,
+        changed_files=["docs/proposal.md"],
+        policy=_policy(),
+        registry_model=parse_system_registry(registry_path),
+    )
+
+    assert result["status"] == "fail"
+    assert "NEW_SYSTEM_MISSING_REGISTRATION" in result["normalized_reason_codes"]
+
+
+def test_guard_fails_on_removed_system_resurrection_and_protected_violation(tmp_path: Path) -> None:
+    registry_path = tmp_path / "docs" / "architecture" / "system_registry.md"
+    _write(registry_path, _registry_text())
+    _write(tmp_path / "docs" / "resurrection.md", "REM owns execution authority. PQX claims closure decision.")
+
+    result = evaluate_system_registry_guard(
+        repo_root=tmp_path,
+        changed_files=["docs/resurrection.md"],
+        policy=_policy(),
+        registry_model=parse_system_registry(registry_path),
+    )
+
+    assert result["status"] == "fail"
+    codes = set(result["normalized_reason_codes"])
+    assert "REMOVED_SYSTEM_REFERENCE" in codes
+    assert "PROTECTED_AUTHORITY_VIOLATION" in codes
+
+
+def test_guard_enforces_same_change_registration_fields(tmp_path: Path) -> None:
+    registry_path = tmp_path / "docs" / "architecture" / "system_registry.md"
+    _write(registry_path, _registry_text() + "\n\n### NEO\n- **acronym:** `NEO`\n")
+    _write(tmp_path / "docs" / "expansion.md", "### NEO\n- NEO owns policy authority")
+
+    result = evaluate_system_registry_guard(
+        repo_root=tmp_path,
+        changed_files=["docs/architecture/system_registry.md", "docs/expansion.md"],
+        policy=_policy(),
+        registry_model=parse_system_registry(registry_path),
+    )
+
+    assert result["status"] == "fail"
+    assert "INCOMPLETE_SYSTEM_REGISTRATION" in result["normalized_reason_codes"]
+
+
+def test_guard_detects_shadow_overlap_via_cluster_mapping(tmp_path: Path) -> None:
+    registry_path = tmp_path / "docs" / "architecture" / "system_registry.md"
+    _write(registry_path, _registry_text())
+    _write(tmp_path / "docs" / "shadow.md", "CDE governs execute work for runtime queue.")
+
+    result = evaluate_system_registry_guard(
+        repo_root=tmp_path,
+        changed_files=["docs/shadow.md"],
+        policy=_policy(),
+        registry_model=parse_system_registry(registry_path),
+    )
+
+    assert result["status"] == "fail"
+    assert "SHADOW_OWNERSHIP_OVERLAP" in result["normalized_reason_codes"]


### PR DESCRIPTION
### Motivation
- Enforce canonical system ownership from `docs/architecture/system_registry.md` deterministically and fail-closed on violations. 
- Block repo-mutating Codex work at admission/preflight before PQX and provide a CI backstop so violations cannot bypass the gate. 
- Emit machine-readable, auditable SRG artifacts with actionable remediation guidance for repair loops and automation.

### Description
- Implemented a deterministic SRG parser and rule engine in `spectrum_systems/modules/governance/system_registry_guard.py` that extracts systems, statuses, builds canonical maps, normalizes responsibilities, detects direct/semantic overlaps, removed-system resurrection, and generates a structured `system_registry_guard_result` artifact. 
- Added a deterministic policy file `contracts/governance/system_registry_guard_policy.json` containing protected authority seams, responsibility clusters, synonym groups, and phrase mappings for normalization, and a CLI runner `scripts/run_system_registry_guard.py` that accepts changed-file refs and writes the guard artifact (non-zero exit on fail). 
- Integrated SRG into the preflight admission path by invoking it in `scripts/run_contract_preflight.py`, writing `outputs/.../system_registry_guard_result.json`, and failing the preflight report when SRG reports `fail`; exported SRG APIs in `spectrum_systems/modules/governance/__init__.py`. 
- Added a CI backstop in `.github/workflows/artifact-boundary.yml` to run SRG as a separate job and upload SRG artifacts, updated tests (`tests/test_system_registry_guard.py`, updated `tests/test_contract_preflight.py`), updated `AGENTS.md` with system-introduction guidance, and included the implementation plan at `docs/review-actions/PLAN-SRG-2026-04-14.md`.

### Testing
- Ran unit/integration test suite: `pytest tests/test_system_registry_guard.py tests/test_contract_preflight.py` — all tests passed (66 passed). 
- Exercised SRG CLI: `python scripts/run_system_registry_guard.py --changed-files docs/architecture/system_registry.md` returned pass and produced `outputs/system_registry_guard/system_registry_guard_result.json`. 
- Exercised preflight integration: `python scripts/run_contract_preflight.py --changed-path docs/architecture/system_registry.md --output-dir outputs/contract_preflight_srg_plan_check` produced the preflight report and included the SRG artifact; SRG failures propagate to preflight and cause non-zero exit when triggered. 
- Verified fail-closed probe: creating a transient file that introduces a new/forbidden system acronym caused SRG to return `fail` and non-zero exit, demonstrating blocking behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd84b430708329b03122039e4a5cf6)