### PR TITLE
3LS-50: enforce canonical 3-letter ownership policy across registry, runtime, and preflight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ Each prompt must declare exactly one primary type:
 - **No hidden behavior**: all execution rules must be explicit in governed markdown.
 - **No deep reference chains**: keep required behavior understandable within one reference level.
 - **No unrelated refactors**: keep changes in declared scope.
+- **Governed ownership admission**: new governed runtime/script paths must be validated by `scripts/validate_governed_runtime_ownership.py` with either a 3-letter owner or explicit support-only classification.
 
 ## Terminology normalization
 Use these terms consistently:

--- a/contracts/examples/system_registry_artifact.json
+++ b/contracts/examples/system_registry_artifact.json
@@ -5,32 +5,57 @@
   "registry_version": "v1.3.0",
   "systems": [
     {
+      "acronym": "ABS",
+      "full_name": "Abstention System",
+      "role": "Abstention System governance authority.",
+      "owns": [
+        "abstention_taxonomy"
+      ],
+      "consumes": [
+        "governed_inputs"
+      ],
+      "produces": [
+        "abs_governance_record"
+      ],
+      "prohibited_behaviors": [
+        "closure_decisioning",
+        "work_execution"
+      ],
+      "upstream_dependencies": [
+        "TLC"
+      ],
+      "downstream_consumers": [
+        "CDE",
+        "SEL"
+      ]
+    },
+    {
       "acronym": "AEX",
       "full_name": "Admission & Execution eXchange",
       "role": "Canonical entry point for all Codex execution requests that may mutate repository state.",
       "owns": [
+        "entrypoint_enforcement",
         "execution_admission",
-        "request_validation",
         "execution_classification",
         "intake_artifact_creation",
-        "entrypoint_enforcement"
+        "request_validation"
       ],
       "consumes": [
         "codex_build_request",
         "system_context"
       ],
       "produces": [
+        "admission_rejection_record",
         "build_admission_record",
-        "normalized_execution_request",
-        "admission_rejection_record"
+        "normalized_execution_request"
       ],
       "prohibited_behaviors": [
-        "work_execution",
-        "workflow_orchestration",
-        "trust_policy_adjudication",
-        "output_evaluation",
         "closure_decisioning",
-        "runtime_enforcement"
+        "output_evaluation",
+        "runtime_enforcement",
+        "trust_policy_adjudication",
+        "work_execution",
+        "workflow_orchestration"
       ],
       "upstream_dependencies": [
         "PRG"
@@ -44,22 +69,22 @@
       "full_name": "Budget Authority eXecutor",
       "role": "Determines cost/quality/risk budget status for governed execution.",
       "owns": [
-        "system_budget_governance",
+        "budget_decision_artifacts",
         "merged_budget_status",
-        "budget_decision_artifacts"
+        "system_budget_governance"
       ],
       "consumes": [
         "budget_consumption_record",
-        "system_budget_policy",
-        "evaluation_control_decision"
+        "evaluation_control_decision",
+        "system_budget_policy"
       ],
       "produces": [
-        "system_budget_status_v2",
-        "budget_control_decision"
+        "budget_control_decision",
+        "system_budget_status_v2"
       ],
       "prohibited_behaviors": [
-        "runtime_enforcement",
         "closure_decisioning",
+        "runtime_enforcement",
         "termination_execution"
       ],
       "upstream_dependencies": [
@@ -76,10 +101,10 @@
       "role": "Classifies impact/irreversibility and escalation support requirements.",
       "owns": [
         "blast_radius_assessment",
-        "irreversibility_classification",
-        "rollback_difficulty_score",
         "escalation_requirement_record",
-        "multi_review_requirement_record"
+        "irreversibility_classification",
+        "multi_review_requirement_record",
+        "rollback_difficulty_score"
       ],
       "consumes": [
         "change_impact_artifact"
@@ -93,137 +118,6 @@
       ],
       "upstream_dependencies": [
         "RIL"
-      ],
-      "downstream_consumers": [
-        "CDE",
-        "SEL"
-      ]
-    },
-    {
-      "acronym": "REL",
-      "full_name": "Canary Rollout Governance",
-      "role": "Owns staged rollout, canary evidence, and rollback governance artifacts.",
-      "owns": [
-        "canary_rollout_artifacts",
-        "rollback_decision_artifacts",
-        "staged_release_guardrails"
-      ],
-      "consumes": [
-        "prompt_policy_route_judge_change_sets",
-        "rollout_eval_records",
-        "rollback_trigger_signals"
-      ],
-      "produces": [
-        "can_rollout_plan_artifact",
-        "can_canary_outcome_record",
-        "can_rollback_action_record"
-      ],
-      "prohibited_behaviors": [
-        "work_execution",
-        "trust_policy_adjudication",
-        "closure_decisioning"
-      ],
-      "upstream_dependencies": [
-        "TLC"
-      ],
-      "downstream_consumers": [
-        "CDE",
-        "SEL"
-      ]
-    },
-    {
-      "acronym": "CAP",
-      "full_name": "Capacity and Budget Governance",
-      "role": "Owns governed cost/latency/queue depth/capacity budget artifacts and decisions.",
-      "owns": [
-        "cost_budget_artifacts",
-        "latency_capacity_budget_artifacts",
-        "capacity_control_decision_signals"
-      ],
-      "consumes": [
-        "cost_latency_queue_signals",
-        "capacity_forecast_artifacts",
-        "budget_policy_artifacts"
-      ],
-      "produces": [
-        "cap_budget_status_record",
-        "cap_capacity_pressure_report",
-        "cap_control_budget_decision"
-      ],
-      "prohibited_behaviors": [
-        "work_execution",
-        "closure_decisioning",
-        "runtime_enforcement"
-      ],
-      "upstream_dependencies": [
-        "TLC"
-      ],
-      "downstream_consumers": [
-        "CDE",
-        "SEL"
-      ]
-    },
-    {
-      "acronym": "CDE",
-      "full_name": "Closure Decision Engine",
-      "role": "Determines closure state from governed evidence and review outputs.",
-      "owns": [
-        "closure_decisions",
-        "closure_lock_state",
-        "bounded_next_step_classification"
-      ],
-      "consumes": [
-        "review_projection_bundle_artifact",
-        "review_signal_artifact",
-        "review_action_tracker_artifact"
-      ],
-      "produces": [
-        "closure_decision_artifact"
-      ],
-      "prohibited_behaviors": [
-        "work_execution",
-        "direct_enforcement_action",
-        "repair_plan_generation"
-      ],
-      "upstream_dependencies": [
-        "RIL",
-        "TLC"
-      ],
-      "downstream_consumers": [
-        "SEL",
-        "TLC"
-      ]
-    },
-    {
-      "acronym": "CHX",
-      "full_name": "Chaos Harness eXchange",
-      "role": "Owns controlled failure injection and adversarial scenario execution across governed seams.",
-      "owns": [
-        "chaos_failure_injection",
-        "chaos_scenario_definition",
-        "chaos_campaign_execution",
-        "chaos_failure_surface_reporting"
-      ],
-      "consumes": [
-        "governed_scenario_inputs",
-        "replayable_system_bundles",
-        "certification_scope_inputs"
-      ],
-      "produces": [
-        "chx_injection_record",
-        "chx_scenario_pack",
-        "chx_campaign_result",
-        "chx_failure_surface_report"
-      ],
-      "prohibited_behaviors": [
-        "execute_production_workflows",
-        "replace_pqx_execution",
-        "issue_policy_authority",
-        "issue_closure_authority",
-        "mutate_live_state_outside_controlled_injection"
-      ],
-      "upstream_dependencies": [
-        "TLC"
       ],
       "downstream_consumers": [
         "CDE",
@@ -250,187 +144,23 @@
       "downstream_consumers": []
     },
     {
-      "acronym": "CON",
-      "full_name": "Contract Interface Governance",
-      "role": "Owns explicit interface contract hardening between systems.",
+      "acronym": "CAP",
+      "full_name": "Capacity and Budget Governance",
+      "role": "Owns governed cost/latency/queue depth/capacity budget artifacts and decisions.",
       "owns": [
-        "interface_contract_registry",
-        "contract_compatibility_gates",
-        "hidden_coupling_detection"
+        "capacity_control_decision_signals",
+        "cost_budget_artifacts",
+        "latency_capacity_budget_artifacts"
       ],
       "consumes": [
-        "system_interface_contracts",
-        "compatibility_reports",
-        "orchestration_handoff_records"
+        "budget_policy_artifacts",
+        "capacity_forecast_artifacts",
+        "cost_latency_queue_signals"
       ],
       "produces": [
-        "con_interface_contract_record",
-        "con_compatibility_gate_result",
-        "con_hidden_coupling_report"
-      ],
-      "prohibited_behaviors": [
-        "work_execution",
-        "trust_policy_adjudication",
-        "closure_decisioning"
-      ],
-      "upstream_dependencies": [
-        "TLC"
-      ],
-      "downstream_consumers": [
-        "CDE",
-        "SEL"
-      ]
-    },
-    {
-      "acronym": "CTX",
-      "full_name": "Context eXchange",
-      "role": "Owns governed context assembly, bundling, manifest hashing, provenance, TTL/freshness, trust levels, conflict handling, and context preflight.",
-      "owns": [
-        "context_bundle",
-        "context_recipe",
-        "context_manifest",
-        "context_conflict_record",
-        "context_preflight_result"
-      ],
-      "consumes": [
-        "source_context_artifacts",
-        "policy_admission_rules"
-      ],
-      "produces": [
-        "context_bundle",
-        "context_manifest",
-        "context_preflight_result"
-      ],
-      "prohibited_behaviors": [
-        "bypass_policy_source_admission",
-        "emit_implicit_context",
-        "allow_untraceable_or_stale_context_through_strict_mode"
-      ],
-      "upstream_dependencies": [
-        "TPA"
-      ],
-      "downstream_consumers": [
-        "PQX",
-        "CDE"
-      ]
-    },
-    {
-      "acronym": "CVX",
-      "full_name": "Consistency Validation eXchange",
-      "role": "Owns multi-run consistency comparison, divergence scoring, and instability classification.",
-      "owns": [
-        "multi_run_comparison",
-        "divergence_scoring",
-        "instability_classification"
-      ],
-      "consumes": [
-        "repeated_run_outputs",
-        "replay_bundles",
-        "evidence_chain_artifacts"
-      ],
-      "produces": [
-        "cvx_run_comparison_record",
-        "cvx_consistency_score",
-        "cvx_instability_report",
-        "cvx_consistency_bundle"
-      ],
-      "prohibited_behaviors": [
-        "alter_execution_outputs",
-        "override_decision_authority",
-        "replace_replay_engines"
-      ],
-      "upstream_dependencies": [
-        "TLC"
-      ],
-      "downstream_consumers": [
-        "CDE",
-        "SEL"
-      ]
-    },
-    {
-      "acronym": "DAT",
-      "full_name": "Dataset Registry Authority",
-      "role": "Owns evaluation dataset registry lineage and version governance.",
-      "owns": [
-        "eval_dataset_registry",
-        "dataset_lineage_tracking",
-        "dataset_version_governance"
-      ],
-      "consumes": [
-        "dataset_manifests",
-        "eval_case_manifests",
-        "failure_derived_dataset_inputs"
-      ],
-      "produces": [
-        "dat_dataset_registry_record",
-        "dat_dataset_lineage_record",
-        "dat_dataset_version_resolution"
-      ],
-      "prohibited_behaviors": [
-        "work_execution",
-        "closure_decisioning",
-        "runtime_enforcement"
-      ],
-      "upstream_dependencies": [
-        "TLC"
-      ],
-      "downstream_consumers": [
-        "CDE",
-        "SEL"
-      ]
-    },
-    {
-      "acronym": "DCL",
-      "full_name": "Doctrine Compilation Layer",
-      "role": "Compiles institutional doctrine artifacts with conflict and lineage records.",
-      "owns": [
-        "doctrine_artifact",
-        "doctrine_update_candidate",
-        "doctrine_supersession_record",
-        "doctrine_conflict_record",
-        "doctrine_lineage_record"
-      ],
-      "consumes": [
-        "judgment_eval_result",
-        "policy_change_candidate",
-        "precedent_archive"
-      ],
-      "produces": [
-        "dcl_doctrine_artifact"
-      ],
-      "prohibited_behaviors": [
-        "policy_authority_decisioning",
-        "closure_decisioning",
-        "runtime_enforcement"
-      ],
-      "upstream_dependencies": [
-        "RIL",
-        "PRG"
-      ],
-      "downstream_consumers": [
-        "TPA",
-        "PRG"
-      ]
-    },
-    {
-      "acronym": "DEM",
-      "full_name": "Decision Economics Modeler",
-      "role": "Produces recommendation-grade economics and tradeoff artifacts.",
-      "owns": [
-        "decision_economics_artifact",
-        "cost_of_delay_model",
-        "false_positive_cost_model",
-        "false_negative_cost_model",
-        "human_review_cost_model",
-        "tradeoff_surface_artifact",
-        "economic_decision_score"
-      ],
-      "consumes": [
-        "portfolio_posture_signal",
-        "external_outcome_impact_artifact"
-      ],
-      "produces": [
-        "dem_decision_economics_artifact"
+        "cap_budget_status_record",
+        "cap_capacity_pressure_report",
+        "cap_control_budget_decision"
       ],
       "prohibited_behaviors": [
         "closure_decisioning",
@@ -438,40 +168,6 @@
         "work_execution"
       ],
       "upstream_dependencies": [
-        "RSM",
-        "XRL"
-      ],
-      "downstream_consumers": [
-        "PRG"
-      ]
-    },
-    {
-      "acronym": "DEX",
-      "full_name": "Decision Explainability eXchange",
-      "role": "Owns deterministic decision explanation reconstruction from governed evidence and prior decisions.",
-      "owns": [
-        "decision_explanation_reconstruction",
-        "explanation_consistency_checking",
-        "explanation_compression_views"
-      ],
-      "consumes": [
-        "decision_artifacts",
-        "evidence_chain_artifacts",
-        "control_eval_artifacts",
-        "provenance_replay_refs"
-      ],
-      "produces": [
-        "dex_explanation_record",
-        "dex_explanation_consistency_result",
-        "dex_explanation_summary",
-        "dex_explanation_bundle"
-      ],
-      "prohibited_behaviors": [
-        "make_decisions",
-        "reinterpret_upstream_semantics",
-        "override_authority_paths"
-      ],
-      "upstream_dependencies": [
         "TLC"
       ],
       "downstream_consumers": [
@@ -480,963 +176,63 @@
       ]
     },
     {
-      "acronym": "DRT",
-      "full_name": "Drift Signal Runtime",
-      "role": "Owns deterministic drift signal artifacts for control consumption.",
+      "acronym": "CDE",
+      "full_name": "Closure Decision Engine",
+      "role": "Determines closure state from governed evidence and review outputs.",
       "owns": [
-        "drift_signal_emission",
-        "drift_type_classification",
-        "drift_signal_aggregation"
+        "bounded_next_step_classification",
+        "closure_decisions",
+        "closure_lock_state"
       ],
       "consumes": [
-        "input_outcome_route_override_signals",
-        "contradiction_artifacts",
-        "historical_baseline_artifacts"
-      ],
-      "produces": [
-        "drt_input_drift_artifact",
-        "drt_outcome_drift_artifact",
-        "drt_route_override_contradiction_bundle"
-      ],
-      "prohibited_behaviors": [
-        "work_execution",
-        "runtime_enforcement",
-        "closure_decisioning"
-      ],
-      "upstream_dependencies": [
-        "TLC"
-      ],
-      "downstream_consumers": [
-        "CDE",
-        "SEL"
-      ]
-    },
-    {
-      "acronym": "DRX",
-      "full_name": "Drift Response eXecutor",
-      "role": "Owns recurring drift/entropy detection and governed maintain-stage responses.",
-      "owns": [
-        "drift_signal_record",
-        "drift_response_plan",
-        "maintain_cycle_record",
-        "invariant_gap_record",
-        "eval_expansion_record"
-      ],
-      "consumes": [
-        "trace_drift_metrics",
-        "eval_coverage_metrics"
-      ],
-      "produces": [
-        "drift_signal_record",
-        "maintain_cycle_record",
-        "eval_expansion_record"
-      ],
-      "prohibited_behaviors": [
-        "silently_mutate_governance",
-        "auto_fix_without_governed_artifacts",
-        "emit_drift_claims_without_trace_and_evidence_linkage"
-      ],
-      "upstream_dependencies": [
-        "PQX",
-        "OBS"
-      ],
-      "downstream_consumers": [
-        "CDE",
-        "PRG"
-      ]
-    },
-    {
-      "acronym": "ENT",
-      "full_name": "Entropy Management Loop",
-      "role": "Owns recurring drift/exception accumulation detection and correction-mining governance outputs.",
-      "owns": [
-        "entropy_accumulation_detection",
-        "override_backlog_reporting",
-        "correction_mining_outputs"
-      ],
-      "consumes": [
-        "drift_exception_history",
-        "override_backlog_artifacts",
-        "architecture_lint_signals"
-      ],
-      "produces": [
-        "ent_entropy_report",
-        "ent_override_backlog_record",
-        "ent_correction_mining_bundle"
-      ],
-      "prohibited_behaviors": [
-        "work_execution",
-        "closure_decisioning",
-        "runtime_enforcement"
-      ],
-      "upstream_dependencies": [
-        "TLC"
-      ],
-      "downstream_consumers": [
-        "CDE",
-        "SEL"
-      ]
-    },
-    {
-      "acronym": "EVL",
-      "full_name": "Evaluation Registry Layer",
-      "role": "Owns required evaluation registry, required-case governance, and evaluation readiness gating signals.",
-      "owns": [
-        "required_eval_registry",
-        "required_eval_case_governance",
-        "eval_completion_blocking"
-      ],
-      "consumes": [
-        "eval_run_artifacts",
-        "eval_registry_updates",
-        "required_case_policy"
-      ],
-      "produces": [
-        "evl_required_eval_set",
-        "evl_eval_completion_record",
-        "evl_eval_block_signal"
-      ],
-      "prohibited_behaviors": [
-        "work_execution",
-        "closure_decisioning",
-        "runtime_enforcement"
-      ],
-      "upstream_dependencies": [
-        "TLC"
-      ],
-      "downstream_consumers": [
-        "CDE",
-        "SEL"
-      ]
-    },
-    {
-      "acronym": "FRE",
-      "full_name": "Failure Recovery Engine",
-      "role": "Diagnoses failures and emits bounded repair plans.",
-      "owns": [
-        "failure_diagnosis",
-        "repair_plan_generation",
-        "recurrence_prevention_recommendation"
-      ],
-      "consumes": [
-        "agent_failure_record",
-        "system_enforcement_result_artifact",
+        "review_action_tracker_artifact",
+        "review_projection_bundle_artifact",
         "review_signal_artifact"
       ],
       "produces": [
-        "failure_diagnosis_artifact",
-        "repair_prompt_artifact",
-        "recurrence_prevention_record"
+        "closure_decision_artifact"
       ],
       "prohibited_behaviors": [
-        "work_execution",
-        "direct_enforcement_mutation",
-        "closure_decisioning"
+        "direct_enforcement_action",
+        "repair_plan_generation",
+        "work_execution"
       ],
       "upstream_dependencies": [
-        "PQX",
+        "RIL",
+        "TLC"
+      ],
+      "downstream_consumers": [
         "SEL",
         "TLC"
-      ],
-      "downstream_consumers": [
-        "TLC",
-        "PRG"
       ]
     },
     {
-      "acronym": "HIT",
-      "full_name": "Human Intervention Tracker",
-      "role": "Owns human review, override, correction diff, and downstream learning artifacts.",
+      "acronym": "CHX",
+      "full_name": "Chaos Harness eXchange",
+      "role": "Owns controlled failure injection and adversarial scenario execution across governed seams.",
       "owns": [
-        "human_override_artifacts",
-        "correction_diff_artifacts",
-        "override_learning_linkage"
+        "chaos_campaign_execution",
+        "chaos_failure_injection",
+        "chaos_failure_surface_reporting",
+        "chaos_scenario_definition"
       ],
       "consumes": [
-        "human_review_records",
-        "override_requests",
-        "downstream_learning_signals"
+        "certification_scope_inputs",
+        "governed_scenario_inputs",
+        "replayable_system_bundles"
       ],
       "produces": [
-        "hit_override_record",
-        "hit_correction_diff",
-        "hit_learning_linkage_artifact"
+        "chx_campaign_result",
+        "chx_failure_surface_report",
+        "chx_injection_record",
+        "chx_scenario_pack"
       ],
       "prohibited_behaviors": [
-        "work_execution",
-        "runtime_enforcement",
-        "closure_decisioning"
-      ],
-      "upstream_dependencies": [
-        "TLC"
-      ],
-      "downstream_consumers": [
-        "CDE",
-        "SEL"
-      ]
-    },
-    {
-      "acronym": "HIX",
-      "full_name": "Human Interaction eXchange",
-      "role": "Owns governed human interaction contracts, override auditing, and structured feedback exchange.",
-      "owns": [
-        "human_action_contracts",
-        "override_audit_artifacts",
-        "human_feedback_exchange_artifacts"
-      ],
-      "consumes": [
-        "hitl_checkpoints",
-        "override_requests",
-        "structured_human_feedback_inputs"
-      ],
-      "produces": [
-        "hix_human_action_record",
-        "hix_override_audit_record",
-        "hix_feedback_exchange_record",
-        "hix_human_interaction_bundle"
-      ],
-      "prohibited_behaviors": [
-        "bypass_governance_layers",
-        "mutate_state_outside_owner_flows",
-        "replace_cde_tpa_sel_authority"
-      ],
-      "upstream_dependencies": [
-        "TLC"
-      ],
-      "downstream_consumers": [
-        "CDE",
-        "SEL"
-      ]
-    },
-    {
-      "acronym": "JDX",
-      "full_name": "Judgment Governance",
-      "role": "Owns high-impact governed judgment artifact requirements.",
-      "owns": [
-        "judgment_artifact_requirements",
-        "evidence_sufficiency_judgments",
-        "escalation_judgment_records"
-      ],
-      "consumes": [
-        "readiness_policy_evidence_artifacts",
-        "certification_evidence_bundles",
-        "escalation_context_artifacts"
-      ],
-      "produces": [
-        "jdg_judgment_record",
-        "jdg_evidence_sufficiency_report",
-        "jdg_escalation_decision_artifact"
-      ],
-      "prohibited_behaviors": [
-        "work_execution",
-        "review_interpretation",
-        "closure_decisioning"
-      ],
-      "upstream_dependencies": [
-        "TLC"
-      ],
-      "downstream_consumers": [
-        "CDE",
-        "SEL"
-      ]
-    },
-    {
-      "acronym": "JSX",
-      "full_name": "Judgment State eXchange",
-      "role": "Owns judgment lifecycle, active-set management, supersession, conflict records, and policy extraction handoff.",
-      "owns": [
-        "judgment_status_record",
-        "judgment_supersession_record",
-        "judgment_active_set_record",
-        "judgment_conflict_record",
-        "judgment_policy_extraction_record"
-      ],
-      "consumes": [
-        "judgment_artifacts"
-      ],
-      "produces": [
-        "judgment_active_set_record",
-        "judgment_policy_extraction_record"
-      ],
-      "prohibited_behaviors": [
-        "replace_control_authority",
-        "treat_stale_judgments_as_active",
-        "leave_conflict_resolution_implicit"
-      ],
-      "upstream_dependencies": [
-        "RIL"
-      ],
-      "downstream_consumers": [
-        "TPA",
-        "CDE"
-      ]
-    },
-    {
-      "acronym": "LIN",
-      "full_name": "Lineage Integrity Network",
-      "role": "Owns end-to-end lineage completeness requirements for promotion-relevant artifacts.",
-      "owns": [
-        "lineage_completeness_rules",
-        "lineage_graph_integrity_checks",
-        "lineage_promotion_gates"
-      ],
-      "consumes": [
-        "admission_lineage_artifacts",
-        "execution_lineage_artifacts",
-        "certification_lineage_artifacts"
-      ],
-      "produces": [
-        "lin_lineage_completeness_report",
-        "lin_lineage_graph_artifact",
-        "lin_lineage_promotion_block"
-      ],
-      "prohibited_behaviors": [
-        "work_execution",
-        "trust_policy_adjudication",
-        "closure_decisioning"
-      ],
-      "upstream_dependencies": [
-        "TLC"
-      ],
-      "downstream_consumers": [
-        "CDE",
-        "SEL"
-      ]
-    },
-    {
-      "acronym": "MCL",
-      "full_name": "Memory Compaction Layer",
-      "role": "Manages compaction/archive/retention artifacts for governed memory surfaces.",
-      "owns": [
-        "memory_compaction_plan",
-        "archival_tier_assignment",
-        "retention_policy_artifact",
-        "memory_entropy_report",
-        "canonical_memory_promotion_candidate",
-        "archive_prune_record"
-      ],
-      "consumes": [
-        "precedent_archive",
-        "judgment_archive",
-        "policy_archive"
-      ],
-      "produces": [
-        "mcl_memory_compaction_plan"
-      ],
-      "prohibited_behaviors": [
-        "closure_decisioning",
-        "runtime_enforcement",
-        "ungoverned_delete_execution"
-      ],
-      "upstream_dependencies": [
-        "RIL"
-      ],
-      "downstream_consumers": [
-        "RSM",
-        "PRG"
-      ]
-    },
-    {
-      "acronym": "OBS",
-      "full_name": "Observability Contract System",
-      "role": "Owns cross-system observability contracts for trace/span/correlation completeness.",
-      "owns": [
-        "observability_contracts",
-        "trace_span_correlation_requirements",
-        "observability_completeness_checks"
-      ],
-      "consumes": [
-        "runtime_trace_artifacts",
-        "review_trace_artifacts",
-        "control_trace_artifacts"
-      ],
-      "produces": [
-        "obs_observability_contract_record",
-        "obs_completeness_report",
-        "obs_correlation_validation_record"
-      ],
-      "prohibited_behaviors": [
-        "work_execution",
-        "review_interpretation",
-        "closure_decisioning"
-      ],
-      "upstream_dependencies": [
-        "TLC"
-      ],
-      "downstream_consumers": [
-        "CDE",
-        "SEL"
-      ]
-    },
-    {
-      "acronym": "PQX",
-      "full_name": "Prompt Queue Execution",
-      "role": "Executes bounded authorized work slices.",
-      "owns": [
-        "execution",
-        "execution_state_transitions",
-        "execution_trace_emission"
-      ],
-      "consumes": [
-        "codex_pqx_task_wrapper",
-        "tpa_slice_artifact",
-        "top_level_conductor_run_artifact"
-      ],
-      "produces": [
-        "pqx_slice_execution_record",
-        "pqx_bundle_execution_record",
-        "pqx_execution_closure_record"
-      ],
-      "prohibited_behaviors": [
-        "trust_policy_adjudication",
-        "repair_plan_generation",
-        "closure_decisioning"
-      ],
-      "upstream_dependencies": [
-        "TLC",
-        "TPA"
-      ],
-      "downstream_consumers": [
-        "FRE",
-        "SEL"
-      ]
-    },
-    {
-      "acronym": "PRG",
-      "full_name": "Program Governance",
-      "role": "Owns program-level planning, drift management, and roadmap alignment.",
-      "owns": [
-        "program_governance",
-        "roadmap_alignment",
-        "program_drift_management"
-      ],
-      "consumes": [
-        "roadmap_signal_bundle",
-        "roadmap_review_view_artifact",
-        "batch_delivery_report"
-      ],
-      "produces": [
-        "program_brief",
-        "program_feedback_record",
-        "program_roadmap_alignment_result"
-      ],
-      "prohibited_behaviors": [
-        "work_execution",
-        "runtime_enforcement",
-        "review_interpretation"
-      ],
-      "upstream_dependencies": [
-        "TLC",
-        "RIL",
-        "FRE"
-      ],
-      "downstream_consumers": [
-        "TLC"
-      ]
-    },
-    {
-      "acronym": "PRM",
-      "full_name": "Prompt Registry Manager",
-      "role": "Owns canonical prompt/task registry and prompt version admissibility.",
-      "owns": [
-        "prompt_registry_authority",
-        "prompt_version_resolution",
-        "shadow_prompt_blocking"
-      ],
-      "consumes": [
-        "prompt_spec_artifacts",
-        "task_registry_artifacts",
-        "prompt_change_records"
-      ],
-      "produces": [
-        "prm_prompt_registry_record",
-        "prm_prompt_resolution_artifact",
-        "prm_shadow_prompt_block_record"
-      ],
-      "prohibited_behaviors": [
-        "work_execution",
-        "trust_policy_adjudication",
-        "closure_decisioning"
-      ],
-      "upstream_dependencies": [
-        "TLC"
-      ],
-      "downstream_consumers": [
-        "CDE",
-        "SEL"
-      ]
-    },
-    {
-      "acronym": "PRX",
-      "full_name": "Precedent Retrieval eXchange",
-      "role": "Owns structured precedent record retrieval and bounded relevance scoring.",
-      "owns": [
-        "precedent_record_storage_shape",
-        "precedent_retrieval",
-        "precedent_relevance_scoring"
-      ],
-      "consumes": [
-        "historical_decision_artifacts",
-        "historical_outcome_artifacts",
-        "evidence_bundles"
-      ],
-      "produces": [
-        "prx_precedent_record",
-        "prx_precedent_match_set",
-        "prx_precedent_score_report",
-        "prx_precedent_bundle"
-      ],
-      "prohibited_behaviors": [
-        "override_current_authority",
-        "auto_promote_historical_precedent"
-      ],
-      "upstream_dependencies": [
-        "TLC"
-      ],
-      "downstream_consumers": [
-        "CDE",
-        "SEL"
-      ]
-    },
-    {
-      "acronym": "REP",
-      "full_name": "Replay Enforcement Plane",
-      "role": "Owns replay integrity requirements and replay-gated promotion signals.",
-      "owns": [
-        "replay_integrity_validation",
-        "replay_required_promotion_gates",
-        "replay_failure_freeze_signals"
-      ],
-      "consumes": [
-        "replay_result_artifacts",
-        "baseline_replay_artifacts",
-        "promotion_gate_requests"
-      ],
-      "produces": [
-        "rep_replay_integrity_record",
-        "rep_replay_gate_decision",
-        "rep_replay_freeze_artifact"
-      ],
-      "prohibited_behaviors": [
-        "work_execution",
-        "closure_decisioning",
-        "runtime_enforcement"
-      ],
-      "upstream_dependencies": [
-        "TLC"
-      ],
-      "downstream_consumers": [
-        "CDE",
-        "SEL"
-      ]
-    },
-    {
-      "acronym": "RIL",
-      "full_name": "Review Integration Layer",
-      "role": "Interprets review outputs into deterministic integration payloads.",
-      "owns": [
-        "review_interpretation",
-        "review_integration",
-        "review_projection"
-      ],
-      "consumes": [
-        "review_artifact",
-        "review_signal_artifact",
-        "review_action_tracker_artifact"
-      ],
-      "produces": [
-        "review_integration_packet_artifact",
-        "review_projection_bundle_artifact",
-        "roadmap_review_projection_artifact"
-      ],
-      "prohibited_behaviors": [
-        "runtime_enforcement",
-        "work_execution",
-        "closure_decisioning"
-      ],
-      "upstream_dependencies": [
-        "TLC"
-      ],
-      "downstream_consumers": [
-        "CDE",
-        "PRG"
-      ]
-    },
-    {
-      "acronym": "ROU",
-      "full_name": "Routing Governance System",
-      "role": "Owns route candidate comparison, selection evidence, and route-governance records.",
-      "owns": [
-        "route_candidate_records",
-        "route_selection_evidence",
-        "route_change_governance"
-      ],
-      "consumes": [
-        "routing_candidates",
-        "cost_quality_signals",
-        "eval_and_canary_results"
-      ],
-      "produces": [
-        "rou_route_comparison_record",
-        "rou_route_selection_artifact",
-        "rou_route_change_control_record"
-      ],
-      "prohibited_behaviors": [
-        "work_execution",
-        "review_interpretation",
-        "closure_decisioning"
-      ],
-      "upstream_dependencies": [
-        "TLC"
-      ],
-      "downstream_consumers": [
-        "CDE",
-        "SEL"
-      ]
-    },
-    {
-      "acronym": "RSM",
-      "full_name": "Reconciliation State Manager",
-      "role": "Compares desired vs actual state and emits reconciliation artifacts.",
-      "owns": [
-        "desired_state_artifact",
-        "actual_state_artifact",
-        "state_delta_artifact",
-        "divergence_record",
-        "state_alignment_status",
-        "reconciliation_plan_artifact",
-        "portfolio_state_snapshot"
-      ],
-      "consumes": [
-        "review_integration_packet_artifact",
-        "module_posture",
-        "operator_posture",
-        "policy_judgment_override_state",
-        "portfolio_posture_signal"
-      ],
-      "produces": [
-        "rsm_reconciliation_debt_artifact",
-        "rsm_portfolio_state_snapshot"
-      ],
-      "prohibited_behaviors": [
-        "closure_decisioning",
-        "runtime_enforcement",
-        "work_execution",
-        "policy_adjudication",
-        "raw_evidence_reinterpretation"
-      ],
-      "upstream_dependencies": [
-        "RIL"
-      ],
-      "downstream_consumers": [
-        "PRG",
-        "CDE"
-      ]
-    },
-    {
-      "acronym": "SEC",
-      "full_name": "Security Guardrail Control",
-      "role": "Owns governed security guardrail event artifacts and control integration outputs.",
-      "owns": [
-        "security_guardrail_event_contracts",
-        "guardrail_control_integration",
-        "indeterminate_guardrail_freeze_signals"
-      ],
-      "consumes": [
-        "input_guardrail_events",
-        "output_guardrail_events",
-        "tool_guardrail_events"
-      ],
-      "produces": [
-        "sec_guardrail_event_record",
-        "sec_control_integration_signal",
-        "sec_indeterminate_freeze_record"
-      ],
-      "prohibited_behaviors": [
-        "work_execution",
-        "trust_policy_adjudication",
-        "closure_decisioning"
-      ],
-      "upstream_dependencies": [
-        "TLC"
-      ],
-      "downstream_consumers": [
-        "CDE",
-        "SEL"
-      ]
-    },
-    {
-      "acronym": "SEL",
-      "full_name": "System Enforcement Layer",
-      "role": "Applies fail-closed enforcement decisions across subsystem boundaries.",
-      "owns": [
-        "enforcement",
-        "fail_closed_blocking",
-        "promotion_guarding"
-      ],
-      "consumes": [
-        "tpa_slice_artifact",
-        "review_control_signal_artifact",
-        "closure_decision_artifact"
-      ],
-      "produces": [
-        "system_enforcement_result_artifact",
-        "enforcement_decision",
-        "action_trace_record"
-      ],
-      "prohibited_behaviors": [
-        "review_reinterpretation",
-        "repair_plan_generation",
-        "orchestration"
-      ],
-      "upstream_dependencies": [
-        "TLC",
-        "TPA",
-        "CDE"
-      ],
-      "downstream_consumers": [
-        "PQX",
-        "FRE",
-        "TLC"
-      ]
-    },
-    {
-      "acronym": "SIM",
-      "full_name": "Simulation eXecution Module",
-      "role": "Owns deterministic candidate policy and scenario simulation without live-state mutation.",
-      "owns": [
-        "candidate_policy_simulation",
-        "scenario_replay_execution",
-        "impact_diff_generation"
-      ],
-      "consumes": [
-        "candidate_policy_artifacts",
-        "baseline_artifacts",
-        "replayable_scenario_packs"
-      ],
-      "produces": [
-        "sim_scenario_record",
-        "sim_policy_impact_report",
-        "sim_diff_record",
-        "sim_simulation_bundle"
-      ],
-      "prohibited_behaviors": [
-        "modify_live_state",
-        "replace_tpa_cde_authority",
-        "promote_simulation_output_automatically"
-      ],
-      "upstream_dependencies": [
-        "TLC"
-      ],
-      "downstream_consumers": [
-        "CDE",
-        "SEL"
-      ]
-    },
-    {
-      "acronym": "SLO",
-      "full_name": "Service Level Objective Control",
-      "role": "Owns governed error-budget and burn-rate decision artifacts.",
-      "owns": [
-        "slo_error_budget_artifacts",
-        "burn_rate_decisioning",
-        "slo_freeze_block_signals"
-      ],
-      "consumes": [
-        "eval_replay_drift_latency_cost_signals",
-        "budget_threshold_policies",
-        "control_decision_inputs"
-      ],
-      "produces": [
-        "slo_budget_status_artifact",
-        "slo_burn_rate_record",
-        "slo_control_decision_signal"
-      ],
-      "prohibited_behaviors": [
-        "work_execution",
-        "trust_policy_adjudication",
-        "closure_decisioning"
-      ],
-      "upstream_dependencies": [
-        "TLC"
-      ],
-      "downstream_consumers": [
-        "CDE",
-        "SEL"
-      ]
-    },
-    {
-      "acronym": "TLC",
-      "full_name": "Top Level Conductor",
-      "role": "Orchestrates subsystem invocation order and interaction boundaries.",
-      "owns": [
-        "orchestration",
-        "subsystem_routing",
-        "bounded_cycle_coordination"
-      ],
-      "consumes": [
-        "tpa_slice_artifact",
-        "system_enforcement_result_artifact",
-        "closure_decision_artifact"
-      ],
-      "produces": [
-        "top_level_conductor_run_artifact"
-      ],
-      "prohibited_behaviors": [
-        "work_execution",
-        "repair_plan_generation",
-        "closure_decision_override"
-      ],
-      "upstream_dependencies": [
-        "AEX",
-        "PRG"
-      ],
-      "downstream_consumers": [
-        "PQX",
-        "TPA",
-        "FRE",
-        "RIL",
-        "CDE",
-        "PRG",
-        "SEL"
-      ]
-    },
-    {
-      "acronym": "TLX",
-      "full_name": "Tooling Layer eXecutor",
-      "role": "Owns tool registry, tool contracts, tool dispatch metadata, output normalization, permission metadata, and truncation/pagination rules.",
-      "owns": [
-        "tool_registry_entry",
-        "tool_contract",
-        "tool_output_envelope",
-        "tool_permission_profile",
-        "tool_dispatch_record"
-      ],
-      "consumes": [
-        "tool_requests",
-        "policy_permission_profile"
-      ],
-      "produces": [
-        "tool_output_envelope",
-        "tool_dispatch_record"
-      ],
-      "prohibited_behaviors": [
-        "allow_raw_unbounded_tool_outputs_into_runtime_context",
-        "treat_prompts_as_security_boundary",
-        "bypass_policy_permissions"
-      ],
-      "upstream_dependencies": [
-        "TPA"
-      ],
-      "downstream_consumers": [
-        "PQX",
-        "CTX"
-      ]
-    },
-    {
-      "acronym": "TPA",
-      "full_name": "Trust Policy Application",
-      "role": "Applies trust and policy gates to authorize execution scope.",
-      "owns": [
-        "trust_policy_application",
-        "scope_gating",
-        "complexity_budgeting"
-      ],
-      "consumes": [
-        "codex_pqx_task_wrapper",
-        "source_authority_refresh_receipt",
-        "complexity_trend"
-      ],
-      "produces": [
-        "tpa_scope_policy",
-        "tpa_slice_artifact",
-        "tpa_observability_summary"
-      ],
-      "prohibited_behaviors": [
-        "work_execution",
-        "runtime_enforcement",
-        "closure_decisioning"
-      ],
-      "upstream_dependencies": [
-        "TLC"
-      ],
-      "downstream_consumers": [
-        "PQX",
-        "SEL"
-      ]
-    },
-    {
-      "acronym": "XRL",
-      "full_name": "External Reality Loop",
-      "role": "Normalizes external outcomes and emits trust-weighted feedback bindings.",
-      "owns": [
-        "external_outcome_signal",
-        "outcome_normalization_record",
-        "outcome_trust_weight",
-        "external_feedback_binding_record",
-        "external_outcome_impact_artifact"
-      ],
-      "consumes": [
-        "external_outcome_feed",
-        "postmortem_record"
-      ],
-      "produces": [
-        "xrl_external_outcome_impact_artifact"
-      ],
-      "prohibited_behaviors": [
-        "policy_authority_decisioning",
-        "closure_decisioning",
-        "runtime_enforcement"
-      ],
-      "upstream_dependencies": [
-        "RIL"
-      ],
-      "downstream_consumers": [
-        "PRG",
-        "DEM"
-      ]
-    },
-    {
-      "acronym": "TRN",
-      "full_name": "Translation System",
-      "role": "Translation System governance authority.",
-      "owns": [
-        "source_translation_contracts"
-      ],
-      "consumes": [
-        "governed_inputs"
-      ],
-      "produces": [
-        "trn_governance_record"
-      ],
-      "prohibited_behaviors": [
-        "work_execution",
-        "closure_decisioning"
-      ],
-      "upstream_dependencies": [
-        "TLC"
-      ],
-      "downstream_consumers": [
-        "CDE",
-        "SEL"
-      ]
-    },
-    {
-      "acronym": "NRM",
-      "full_name": "Normalization System",
-      "role": "Normalization System governance authority.",
-      "owns": [
-        "deterministic_normalization_rules"
-      ],
-      "consumes": [
-        "governed_inputs"
-      ],
-      "produces": [
-        "nrm_governance_record"
-      ],
-      "prohibited_behaviors": [
-        "work_execution",
-        "closure_decisioning"
+        "execute_production_workflows",
+        "issue_closure_authority",
+        "issue_policy_authority",
+        "mutate_live_state_outside_controlled_injection",
+        "replace_pqx_execution"
       ],
       "upstream_dependencies": [
         "TLC"
@@ -1460,8 +256,8 @@
         "cmp_governance_record"
       ],
       "prohibited_behaviors": [
-        "work_execution",
-        "closure_decisioning"
+        "closure_decisioning",
+        "work_execution"
       ],
       "upstream_dependencies": [
         "TLC"
@@ -1472,46 +268,28 @@
       ]
     },
     {
-      "acronym": "RET",
-      "full_name": "Retirement System",
-      "role": "Retirement System governance authority.",
+      "acronym": "CON",
+      "full_name": "Contract Interface Governance",
+      "role": "Owns explicit interface contract hardening between systems.",
       "owns": [
-        "retirement_lifecycle_rules"
+        "contract_compatibility_gates",
+        "hidden_coupling_detection",
+        "interface_contract_registry"
       ],
       "consumes": [
-        "governed_inputs"
+        "compatibility_reports",
+        "orchestration_handoff_records",
+        "system_interface_contracts"
       ],
       "produces": [
-        "ret_governance_record"
+        "con_compatibility_gate_result",
+        "con_hidden_coupling_report",
+        "con_interface_contract_record"
       ],
       "prohibited_behaviors": [
-        "work_execution",
-        "closure_decisioning"
-      ],
-      "upstream_dependencies": [
-        "TLC"
-      ],
-      "downstream_consumers": [
-        "CDE",
-        "SEL"
-      ]
-    },
-    {
-      "acronym": "ABS",
-      "full_name": "Abstention System",
-      "role": "Abstention System governance authority.",
-      "owns": [
-        "abstention_taxonomy"
-      ],
-      "consumes": [
-        "governed_inputs"
-      ],
-      "produces": [
-        "abs_governance_record"
-      ],
-      "prohibited_behaviors": [
-        "work_execution",
-        "closure_decisioning"
+        "closure_decisioning",
+        "trust_policy_adjudication",
+        "work_execution"
       ],
       "upstream_dependencies": [
         "TLC"
@@ -1535,8 +313,8 @@
         "crs_governance_record"
       ],
       "prohibited_behaviors": [
-        "work_execution",
-        "closure_decisioning"
+        "closure_decisioning",
+        "work_execution"
       ],
       "upstream_dependencies": [
         "TLC"
@@ -1547,21 +325,62 @@
       ]
     },
     {
-      "acronym": "MIG",
-      "full_name": "Migration System",
-      "role": "Migration System governance authority.",
+      "acronym": "CTX",
+      "full_name": "Context eXchange",
+      "role": "Owns governed context assembly, bundling, manifest hashing, provenance, TTL/freshness, trust levels, conflict handling, and context preflight.",
       "owns": [
-        "migration_plan_contracts"
+        "context_bundle",
+        "context_conflict_record",
+        "context_manifest",
+        "context_preflight_result",
+        "context_recipe"
       ],
       "consumes": [
-        "governed_inputs"
+        "policy_admission_rules",
+        "source_context_artifacts"
       ],
       "produces": [
-        "mig_governance_record"
+        "context_bundle",
+        "context_manifest",
+        "context_preflight_result"
       ],
       "prohibited_behaviors": [
-        "work_execution",
-        "closure_decisioning"
+        "allow_untraceable_or_stale_context_through_strict_mode",
+        "bypass_policy_source_admission",
+        "emit_implicit_context"
+      ],
+      "upstream_dependencies": [
+        "TPA"
+      ],
+      "downstream_consumers": [
+        "CDE",
+        "PQX"
+      ]
+    },
+    {
+      "acronym": "CVX",
+      "full_name": "Consistency Validation eXchange",
+      "role": "Owns multi-run consistency comparison, divergence scoring, and instability classification.",
+      "owns": [
+        "divergence_scoring",
+        "instability_classification",
+        "multi_run_comparison"
+      ],
+      "consumes": [
+        "evidence_chain_artifacts",
+        "repeated_run_outputs",
+        "replay_bundles"
+      ],
+      "produces": [
+        "cvx_consistency_bundle",
+        "cvx_consistency_score",
+        "cvx_instability_report",
+        "cvx_run_comparison_record"
+      ],
+      "prohibited_behaviors": [
+        "alter_execution_outputs",
+        "override_decision_authority",
+        "replace_replay_engines"
       ],
       "upstream_dependencies": [
         "TLC"
@@ -1572,21 +391,28 @@
       ]
     },
     {
-      "acronym": "QRY",
-      "full_name": "Query/Index System",
-      "role": "Query/Index System governance authority.",
+      "acronym": "DAT",
+      "full_name": "Dataset Registry Authority",
+      "role": "Owns evaluation dataset registry lineage and version governance.",
       "owns": [
-        "query_index_manifest_authority"
+        "dataset_lineage_tracking",
+        "dataset_version_governance",
+        "eval_dataset_registry"
       ],
       "consumes": [
-        "governed_inputs"
+        "dataset_manifests",
+        "eval_case_manifests",
+        "failure_derived_dataset_inputs"
       ],
       "produces": [
-        "qry_governance_record"
+        "dat_dataset_lineage_record",
+        "dat_dataset_registry_record",
+        "dat_dataset_version_resolution"
       ],
       "prohibited_behaviors": [
-        "work_execution",
-        "closure_decisioning"
+        "closure_decisioning",
+        "runtime_enforcement",
+        "work_execution"
       ],
       "upstream_dependencies": [
         "TLC"
@@ -1597,21 +423,96 @@
       ]
     },
     {
-      "acronym": "TST",
-      "full_name": "Test Asset Governance System",
-      "role": "Test Asset Governance System governance authority.",
+      "acronym": "DCL",
+      "full_name": "Doctrine Compilation Layer",
+      "role": "Compiles institutional doctrine artifacts with conflict and lineage records.",
       "owns": [
-        "test_asset_registry"
+        "doctrine_artifact",
+        "doctrine_conflict_record",
+        "doctrine_lineage_record",
+        "doctrine_supersession_record",
+        "doctrine_update_candidate"
       ],
       "consumes": [
-        "governed_inputs"
+        "judgment_eval_result",
+        "policy_change_candidate",
+        "precedent_archive"
       ],
       "produces": [
-        "tst_governance_record"
+        "dcl_doctrine_artifact"
       ],
       "prohibited_behaviors": [
-        "work_execution",
-        "closure_decisioning"
+        "closure_decisioning",
+        "policy_authority_decisioning",
+        "runtime_enforcement"
+      ],
+      "upstream_dependencies": [
+        "PRG",
+        "RIL"
+      ],
+      "downstream_consumers": [
+        "PRG",
+        "TPA"
+      ]
+    },
+    {
+      "acronym": "DEM",
+      "full_name": "Decision Economics Modeler",
+      "role": "Produces recommendation-grade economics and tradeoff artifacts.",
+      "owns": [
+        "cost_of_delay_model",
+        "decision_economics_artifact",
+        "economic_decision_score",
+        "false_negative_cost_model",
+        "false_positive_cost_model",
+        "human_review_cost_model",
+        "tradeoff_surface_artifact"
+      ],
+      "consumes": [
+        "external_outcome_impact_artifact",
+        "portfolio_posture_signal"
+      ],
+      "produces": [
+        "dem_decision_economics_artifact"
+      ],
+      "prohibited_behaviors": [
+        "closure_decisioning",
+        "runtime_enforcement",
+        "work_execution"
+      ],
+      "upstream_dependencies": [
+        "RSM",
+        "XRL"
+      ],
+      "downstream_consumers": [
+        "PRG"
+      ]
+    },
+    {
+      "acronym": "DEX",
+      "full_name": "Decision Explainability eXchange",
+      "role": "Owns deterministic decision explanation reconstruction from governed evidence and prior decisions.",
+      "owns": [
+        "decision_explanation_reconstruction",
+        "explanation_compression_views",
+        "explanation_consistency_checking"
+      ],
+      "consumes": [
+        "control_eval_artifacts",
+        "decision_artifacts",
+        "evidence_chain_artifacts",
+        "provenance_replay_refs"
+      ],
+      "produces": [
+        "dex_explanation_bundle",
+        "dex_explanation_consistency_result",
+        "dex_explanation_record",
+        "dex_explanation_summary"
+      ],
+      "prohibited_behaviors": [
+        "make_decisions",
+        "override_authority_paths",
+        "reinterpret_upstream_semantics"
       ],
       "upstream_dependencies": [
         "TLC"
@@ -1622,21 +523,94 @@
       ]
     },
     {
-      "acronym": "RSK",
-      "full_name": "Risk Classification System",
-      "role": "Risk Classification System governance authority.",
+      "acronym": "DRT",
+      "full_name": "Drift Signal Runtime",
+      "role": "Owns deterministic drift signal artifacts for control consumption.",
       "owns": [
-        "risk_classification_taxonomy"
+        "drift_signal_aggregation",
+        "drift_signal_emission",
+        "drift_type_classification"
       ],
       "consumes": [
-        "governed_inputs"
+        "contradiction_artifacts",
+        "historical_baseline_artifacts",
+        "input_outcome_route_override_signals"
       ],
       "produces": [
-        "rsk_governance_record"
+        "drt_input_drift_artifact",
+        "drt_outcome_drift_artifact",
+        "drt_route_override_contradiction_bundle"
       ],
       "prohibited_behaviors": [
-        "work_execution",
-        "closure_decisioning"
+        "closure_decisioning",
+        "runtime_enforcement",
+        "work_execution"
+      ],
+      "upstream_dependencies": [
+        "TLC"
+      ],
+      "downstream_consumers": [
+        "CDE",
+        "SEL"
+      ]
+    },
+    {
+      "acronym": "DRX",
+      "full_name": "Drift Response eXecutor",
+      "role": "Owns recurring drift/entropy detection and governed maintain-stage responses.",
+      "owns": [
+        "drift_response_plan",
+        "drift_signal_record",
+        "eval_expansion_record",
+        "invariant_gap_record",
+        "maintain_cycle_record"
+      ],
+      "consumes": [
+        "eval_coverage_metrics",
+        "trace_drift_metrics"
+      ],
+      "produces": [
+        "drift_signal_record",
+        "eval_expansion_record",
+        "maintain_cycle_record"
+      ],
+      "prohibited_behaviors": [
+        "auto_fix_without_governed_artifacts",
+        "emit_drift_claims_without_trace_and_evidence_linkage",
+        "silently_mutate_governance"
+      ],
+      "upstream_dependencies": [
+        "OBS",
+        "PQX"
+      ],
+      "downstream_consumers": [
+        "CDE",
+        "PRG"
+      ]
+    },
+    {
+      "acronym": "ENT",
+      "full_name": "Entropy Management Loop",
+      "role": "Owns recurring drift/exception accumulation detection and correction-mining governance outputs.",
+      "owns": [
+        "correction_mining_outputs",
+        "entropy_accumulation_detection",
+        "override_backlog_reporting"
+      ],
+      "consumes": [
+        "architecture_lint_signals",
+        "drift_exception_history",
+        "override_backlog_artifacts"
+      ],
+      "produces": [
+        "ent_correction_mining_bundle",
+        "ent_entropy_report",
+        "ent_override_backlog_record"
+      ],
+      "prohibited_behaviors": [
+        "closure_decisioning",
+        "runtime_enforcement",
+        "work_execution"
       ],
       "upstream_dependencies": [
         "TLC"
@@ -1660,8 +634,8 @@
         "evd_governance_record"
       ],
       "prohibited_behaviors": [
-        "work_execution",
-        "closure_decisioning"
+        "closure_decisioning",
+        "work_execution"
       ],
       "upstream_dependencies": [
         "TLC"
@@ -1672,21 +646,127 @@
       ]
     },
     {
-      "acronym": "SUP",
-      "full_name": "Supersession Active-Set System",
-      "role": "Supersession Active-Set System governance authority.",
+      "acronym": "EVL",
+      "full_name": "Evaluation Registry Layer",
+      "role": "Owns required evaluation registry, required-case governance, and evaluation readiness gating signals.",
       "owns": [
-        "supersession_rules"
+        "eval_completion_blocking",
+        "required_eval_case_governance",
+        "required_eval_registry"
       ],
       "consumes": [
-        "governed_inputs"
+        "eval_registry_updates",
+        "eval_run_artifacts",
+        "required_case_policy"
       ],
       "produces": [
-        "sup_governance_record"
+        "evl_eval_block_signal",
+        "evl_eval_completion_record",
+        "evl_required_eval_set"
       ],
       "prohibited_behaviors": [
-        "work_execution",
-        "closure_decisioning"
+        "closure_decisioning",
+        "runtime_enforcement",
+        "work_execution"
+      ],
+      "upstream_dependencies": [
+        "TLC"
+      ],
+      "downstream_consumers": [
+        "CDE",
+        "SEL"
+      ]
+    },
+    {
+      "acronym": "FRE",
+      "full_name": "Failure Recovery Engine",
+      "role": "Diagnoses failures and emits bounded repair plans.",
+      "owns": [
+        "failure_diagnosis",
+        "recurrence_prevention_recommendation",
+        "repair_plan_generation"
+      ],
+      "consumes": [
+        "agent_failure_record",
+        "review_signal_artifact",
+        "system_enforcement_result_artifact"
+      ],
+      "produces": [
+        "failure_diagnosis_artifact",
+        "recurrence_prevention_record",
+        "repair_prompt_artifact"
+      ],
+      "prohibited_behaviors": [
+        "closure_decisioning",
+        "direct_enforcement_mutation",
+        "work_execution"
+      ],
+      "upstream_dependencies": [
+        "PQX",
+        "SEL",
+        "TLC"
+      ],
+      "downstream_consumers": [
+        "PRG",
+        "TLC"
+      ]
+    },
+    {
+      "acronym": "HIT",
+      "full_name": "Human Intervention Tracker",
+      "role": "Owns human review, override, correction diff, and downstream learning artifacts.",
+      "owns": [
+        "correction_diff_artifacts",
+        "human_override_artifacts",
+        "override_learning_linkage"
+      ],
+      "consumes": [
+        "downstream_learning_signals",
+        "human_review_records",
+        "override_requests"
+      ],
+      "produces": [
+        "hit_correction_diff",
+        "hit_learning_linkage_artifact",
+        "hit_override_record"
+      ],
+      "prohibited_behaviors": [
+        "closure_decisioning",
+        "runtime_enforcement",
+        "work_execution"
+      ],
+      "upstream_dependencies": [
+        "TLC"
+      ],
+      "downstream_consumers": [
+        "CDE",
+        "SEL"
+      ]
+    },
+    {
+      "acronym": "HIX",
+      "full_name": "Human Interaction eXchange",
+      "role": "Owns governed human interaction contracts, override auditing, and structured feedback exchange.",
+      "owns": [
+        "human_action_contracts",
+        "human_feedback_exchange_artifacts",
+        "override_audit_artifacts"
+      ],
+      "consumes": [
+        "hitl_checkpoints",
+        "override_requests",
+        "structured_human_feedback_inputs"
+      ],
+      "produces": [
+        "hix_feedback_exchange_record",
+        "hix_human_action_record",
+        "hix_human_interaction_bundle",
+        "hix_override_audit_record"
+      ],
+      "prohibited_behaviors": [
+        "bypass_governance_layers",
+        "mutate_state_outside_owner_flows",
+        "replace_cde_tpa_sel_authority"
       ],
       "upstream_dependencies": [
         "TLC"
@@ -1710,8 +790,747 @@
         "hnd_governance_record"
       ],
       "prohibited_behaviors": [
-        "work_execution",
-        "closure_decisioning"
+        "closure_decisioning",
+        "work_execution"
+      ],
+      "upstream_dependencies": [
+        "TLC"
+      ],
+      "downstream_consumers": [
+        "CDE",
+        "SEL"
+      ]
+    },
+    {
+      "acronym": "JDX",
+      "full_name": "Judgment Governance",
+      "role": "Owns high-impact governed judgment artifact requirements.",
+      "owns": [
+        "escalation_judgment_records",
+        "evidence_sufficiency_judgments",
+        "judgment_artifact_requirements"
+      ],
+      "consumes": [
+        "certification_evidence_bundles",
+        "escalation_context_artifacts",
+        "readiness_policy_evidence_artifacts"
+      ],
+      "produces": [
+        "jdg_escalation_decision_artifact",
+        "jdg_evidence_sufficiency_report",
+        "jdg_judgment_record"
+      ],
+      "prohibited_behaviors": [
+        "closure_decisioning",
+        "review_interpretation",
+        "work_execution"
+      ],
+      "upstream_dependencies": [
+        "TLC"
+      ],
+      "downstream_consumers": [
+        "CDE",
+        "SEL"
+      ]
+    },
+    {
+      "acronym": "JSX",
+      "full_name": "Judgment State eXchange",
+      "role": "Owns judgment lifecycle, active-set management, supersession, conflict records, and policy extraction handoff.",
+      "owns": [
+        "judgment_active_set_record",
+        "judgment_conflict_record",
+        "judgment_policy_extraction_record",
+        "judgment_status_record",
+        "judgment_supersession_record"
+      ],
+      "consumes": [
+        "judgment_artifacts"
+      ],
+      "produces": [
+        "judgment_active_set_record",
+        "judgment_policy_extraction_record"
+      ],
+      "prohibited_behaviors": [
+        "leave_conflict_resolution_implicit",
+        "replace_control_authority",
+        "treat_stale_judgments_as_active"
+      ],
+      "upstream_dependencies": [
+        "RIL"
+      ],
+      "downstream_consumers": [
+        "CDE",
+        "TPA"
+      ]
+    },
+    {
+      "acronym": "LIN",
+      "full_name": "Lineage Integrity Network",
+      "role": "Owns end-to-end lineage completeness requirements for promotion-relevant artifacts.",
+      "owns": [
+        "lineage_completeness_rules",
+        "lineage_graph_integrity_checks",
+        "lineage_promotion_gates"
+      ],
+      "consumes": [
+        "admission_lineage_artifacts",
+        "certification_lineage_artifacts",
+        "execution_lineage_artifacts"
+      ],
+      "produces": [
+        "lin_lineage_completeness_report",
+        "lin_lineage_graph_artifact",
+        "lin_lineage_promotion_block"
+      ],
+      "prohibited_behaviors": [
+        "closure_decisioning",
+        "trust_policy_adjudication",
+        "work_execution"
+      ],
+      "upstream_dependencies": [
+        "TLC"
+      ],
+      "downstream_consumers": [
+        "CDE",
+        "SEL"
+      ]
+    },
+    {
+      "acronym": "MCL",
+      "full_name": "Memory Compaction Layer",
+      "role": "Manages compaction/archive/retention artifacts for governed memory surfaces.",
+      "owns": [
+        "archival_tier_assignment",
+        "archive_prune_record",
+        "canonical_memory_promotion_candidate",
+        "memory_compaction_plan",
+        "memory_entropy_report",
+        "retention_policy_artifact"
+      ],
+      "consumes": [
+        "judgment_archive",
+        "policy_archive",
+        "precedent_archive"
+      ],
+      "produces": [
+        "mcl_memory_compaction_plan"
+      ],
+      "prohibited_behaviors": [
+        "closure_decisioning",
+        "runtime_enforcement",
+        "ungoverned_delete_execution"
+      ],
+      "upstream_dependencies": [
+        "RIL"
+      ],
+      "downstream_consumers": [
+        "PRG",
+        "RSM"
+      ]
+    },
+    {
+      "acronym": "MIG",
+      "full_name": "Migration System",
+      "role": "Migration System governance authority.",
+      "owns": [
+        "migration_plan_contracts"
+      ],
+      "consumes": [
+        "governed_inputs"
+      ],
+      "produces": [
+        "mig_governance_record"
+      ],
+      "prohibited_behaviors": [
+        "closure_decisioning",
+        "work_execution"
+      ],
+      "upstream_dependencies": [
+        "TLC"
+      ],
+      "downstream_consumers": [
+        "CDE",
+        "SEL"
+      ]
+    },
+    {
+      "acronym": "NRM",
+      "full_name": "Normalization System",
+      "role": "Normalization System governance authority.",
+      "owns": [
+        "deterministic_normalization_rules"
+      ],
+      "consumes": [
+        "governed_inputs"
+      ],
+      "produces": [
+        "nrm_governance_record"
+      ],
+      "prohibited_behaviors": [
+        "closure_decisioning",
+        "work_execution"
+      ],
+      "upstream_dependencies": [
+        "TLC"
+      ],
+      "downstream_consumers": [
+        "CDE",
+        "SEL"
+      ]
+    },
+    {
+      "acronym": "OBS",
+      "full_name": "Observability Contract System",
+      "role": "Owns cross-system observability contracts for trace/span/correlation completeness.",
+      "owns": [
+        "observability_completeness_checks",
+        "observability_contracts",
+        "trace_span_correlation_requirements"
+      ],
+      "consumes": [
+        "control_trace_artifacts",
+        "review_trace_artifacts",
+        "runtime_trace_artifacts"
+      ],
+      "produces": [
+        "obs_completeness_report",
+        "obs_correlation_validation_record",
+        "obs_observability_contract_record"
+      ],
+      "prohibited_behaviors": [
+        "closure_decisioning",
+        "review_interpretation",
+        "work_execution"
+      ],
+      "upstream_dependencies": [
+        "TLC"
+      ],
+      "downstream_consumers": [
+        "CDE",
+        "SEL"
+      ]
+    },
+    {
+      "acronym": "PQX",
+      "full_name": "Prompt Queue Execution",
+      "role": "Executes bounded authorized work slices.",
+      "owns": [
+        "execution",
+        "execution_state_transitions",
+        "execution_trace_emission"
+      ],
+      "consumes": [
+        "codex_pqx_task_wrapper",
+        "top_level_conductor_run_artifact",
+        "tpa_slice_artifact"
+      ],
+      "produces": [
+        "pqx_bundle_execution_record",
+        "pqx_execution_closure_record",
+        "pqx_slice_execution_record"
+      ],
+      "prohibited_behaviors": [
+        "closure_decisioning",
+        "repair_plan_generation",
+        "trust_policy_adjudication"
+      ],
+      "upstream_dependencies": [
+        "TLC",
+        "TPA"
+      ],
+      "downstream_consumers": [
+        "FRE",
+        "SEL"
+      ]
+    },
+    {
+      "acronym": "PRG",
+      "full_name": "Program Governance",
+      "role": "Owns program-level planning, drift management, and roadmap alignment.",
+      "owns": [
+        "program_drift_management",
+        "program_governance",
+        "roadmap_alignment"
+      ],
+      "consumes": [
+        "batch_delivery_report",
+        "roadmap_review_view_artifact",
+        "roadmap_signal_bundle"
+      ],
+      "produces": [
+        "program_brief",
+        "program_feedback_record",
+        "program_roadmap_alignment_result"
+      ],
+      "prohibited_behaviors": [
+        "review_interpretation",
+        "runtime_enforcement",
+        "work_execution"
+      ],
+      "upstream_dependencies": [
+        "FRE",
+        "RIL",
+        "TLC"
+      ],
+      "downstream_consumers": [
+        "TLC"
+      ]
+    },
+    {
+      "acronym": "PRM",
+      "full_name": "Prompt Registry Manager",
+      "role": "Owns canonical prompt/task registry and prompt version admissibility.",
+      "owns": [
+        "prompt_registry_authority",
+        "prompt_version_resolution",
+        "shadow_prompt_blocking"
+      ],
+      "consumes": [
+        "prompt_change_records",
+        "prompt_spec_artifacts",
+        "task_registry_artifacts"
+      ],
+      "produces": [
+        "prm_prompt_registry_record",
+        "prm_prompt_resolution_artifact",
+        "prm_shadow_prompt_block_record"
+      ],
+      "prohibited_behaviors": [
+        "closure_decisioning",
+        "trust_policy_adjudication",
+        "work_execution"
+      ],
+      "upstream_dependencies": [
+        "TLC"
+      ],
+      "downstream_consumers": [
+        "CDE",
+        "SEL"
+      ]
+    },
+    {
+      "acronym": "PRX",
+      "full_name": "Precedent Retrieval eXchange",
+      "role": "Owns structured precedent record retrieval and bounded relevance scoring.",
+      "owns": [
+        "precedent_record_storage_shape",
+        "precedent_relevance_scoring",
+        "precedent_retrieval"
+      ],
+      "consumes": [
+        "evidence_bundles",
+        "historical_decision_artifacts",
+        "historical_outcome_artifacts"
+      ],
+      "produces": [
+        "prx_precedent_bundle",
+        "prx_precedent_match_set",
+        "prx_precedent_record",
+        "prx_precedent_score_report"
+      ],
+      "prohibited_behaviors": [
+        "auto_promote_historical_precedent",
+        "override_current_authority"
+      ],
+      "upstream_dependencies": [
+        "TLC"
+      ],
+      "downstream_consumers": [
+        "CDE",
+        "SEL"
+      ]
+    },
+    {
+      "acronym": "QRY",
+      "full_name": "Query/Index System",
+      "role": "Query/Index System governance authority.",
+      "owns": [
+        "query_index_manifest_authority"
+      ],
+      "consumes": [
+        "governed_inputs"
+      ],
+      "produces": [
+        "qry_governance_record"
+      ],
+      "prohibited_behaviors": [
+        "closure_decisioning",
+        "work_execution"
+      ],
+      "upstream_dependencies": [
+        "TLC"
+      ],
+      "downstream_consumers": [
+        "CDE",
+        "SEL"
+      ]
+    },
+    {
+      "acronym": "REL",
+      "full_name": "Canary Rollout Governance",
+      "role": "Owns staged rollout, canary evidence, and rollback governance artifacts.",
+      "owns": [
+        "canary_rollout_artifacts",
+        "rollback_decision_artifacts",
+        "staged_release_guardrails"
+      ],
+      "consumes": [
+        "prompt_policy_route_judge_change_sets",
+        "rollback_trigger_signals",
+        "rollout_eval_records"
+      ],
+      "produces": [
+        "can_canary_outcome_record",
+        "can_rollback_action_record",
+        "can_rollout_plan_artifact"
+      ],
+      "prohibited_behaviors": [
+        "closure_decisioning",
+        "trust_policy_adjudication",
+        "work_execution"
+      ],
+      "upstream_dependencies": [
+        "TLC"
+      ],
+      "downstream_consumers": [
+        "CDE",
+        "SEL"
+      ]
+    },
+    {
+      "acronym": "REP",
+      "full_name": "Replay Enforcement Plane",
+      "role": "Owns replay integrity requirements and replay-gated promotion signals.",
+      "owns": [
+        "replay_failure_freeze_signals",
+        "replay_integrity_validation",
+        "replay_required_promotion_gates"
+      ],
+      "consumes": [
+        "baseline_replay_artifacts",
+        "promotion_gate_requests",
+        "replay_result_artifacts"
+      ],
+      "produces": [
+        "rep_replay_freeze_artifact",
+        "rep_replay_gate_decision",
+        "rep_replay_integrity_record"
+      ],
+      "prohibited_behaviors": [
+        "closure_decisioning",
+        "runtime_enforcement",
+        "work_execution"
+      ],
+      "upstream_dependencies": [
+        "TLC"
+      ],
+      "downstream_consumers": [
+        "CDE",
+        "SEL"
+      ]
+    },
+    {
+      "acronym": "RET",
+      "full_name": "Retirement System",
+      "role": "Retirement System governance authority.",
+      "owns": [
+        "retirement_lifecycle_rules"
+      ],
+      "consumes": [
+        "governed_inputs"
+      ],
+      "produces": [
+        "ret_governance_record"
+      ],
+      "prohibited_behaviors": [
+        "closure_decisioning",
+        "work_execution"
+      ],
+      "upstream_dependencies": [
+        "TLC"
+      ],
+      "downstream_consumers": [
+        "CDE",
+        "SEL"
+      ]
+    },
+    {
+      "acronym": "RIL",
+      "full_name": "Review Integration Layer",
+      "role": "Interprets review outputs into deterministic integration payloads.",
+      "owns": [
+        "review_integration",
+        "review_interpretation",
+        "review_projection"
+      ],
+      "consumes": [
+        "review_action_tracker_artifact",
+        "review_artifact",
+        "review_signal_artifact"
+      ],
+      "produces": [
+        "review_integration_packet_artifact",
+        "review_projection_bundle_artifact",
+        "roadmap_review_projection_artifact"
+      ],
+      "prohibited_behaviors": [
+        "closure_decisioning",
+        "runtime_enforcement",
+        "work_execution"
+      ],
+      "upstream_dependencies": [
+        "TLC"
+      ],
+      "downstream_consumers": [
+        "CDE",
+        "PRG"
+      ]
+    },
+    {
+      "acronym": "ROU",
+      "full_name": "Routing Governance System",
+      "role": "Owns route candidate comparison, selection evidence, and route-governance records.",
+      "owns": [
+        "route_candidate_records",
+        "route_change_governance",
+        "route_selection_evidence"
+      ],
+      "consumes": [
+        "cost_quality_signals",
+        "eval_and_canary_results",
+        "routing_candidates"
+      ],
+      "produces": [
+        "rou_route_change_control_record",
+        "rou_route_comparison_record",
+        "rou_route_selection_artifact"
+      ],
+      "prohibited_behaviors": [
+        "closure_decisioning",
+        "review_interpretation",
+        "work_execution"
+      ],
+      "upstream_dependencies": [
+        "TLC"
+      ],
+      "downstream_consumers": [
+        "CDE",
+        "SEL"
+      ]
+    },
+    {
+      "acronym": "RSK",
+      "full_name": "Risk Classification System",
+      "role": "Risk Classification System governance authority.",
+      "owns": [
+        "risk_classification_taxonomy"
+      ],
+      "consumes": [
+        "governed_inputs"
+      ],
+      "produces": [
+        "rsk_governance_record"
+      ],
+      "prohibited_behaviors": [
+        "closure_decisioning",
+        "work_execution"
+      ],
+      "upstream_dependencies": [
+        "TLC"
+      ],
+      "downstream_consumers": [
+        "CDE",
+        "SEL"
+      ]
+    },
+    {
+      "acronym": "RSM",
+      "full_name": "Reconciliation State Manager",
+      "role": "Compares desired vs actual state and emits reconciliation artifacts.",
+      "owns": [
+        "actual_state_artifact",
+        "desired_state_artifact",
+        "divergence_record",
+        "portfolio_state_snapshot",
+        "reconciliation_plan_artifact",
+        "state_alignment_status",
+        "state_delta_artifact"
+      ],
+      "consumes": [
+        "module_posture",
+        "operator_posture",
+        "policy_judgment_override_state",
+        "portfolio_posture_signal",
+        "review_integration_packet_artifact"
+      ],
+      "produces": [
+        "rsm_portfolio_state_snapshot",
+        "rsm_reconciliation_debt_artifact"
+      ],
+      "prohibited_behaviors": [
+        "closure_decisioning",
+        "policy_adjudication",
+        "raw_evidence_reinterpretation",
+        "runtime_enforcement",
+        "work_execution"
+      ],
+      "upstream_dependencies": [
+        "RIL"
+      ],
+      "downstream_consumers": [
+        "CDE",
+        "PRG"
+      ]
+    },
+    {
+      "acronym": "SEC",
+      "full_name": "Security Guardrail Control",
+      "role": "Owns governed security guardrail event artifacts and control integration outputs.",
+      "owns": [
+        "guardrail_control_integration",
+        "indeterminate_guardrail_freeze_signals",
+        "security_guardrail_event_contracts"
+      ],
+      "consumes": [
+        "input_guardrail_events",
+        "output_guardrail_events",
+        "tool_guardrail_events"
+      ],
+      "produces": [
+        "sec_control_integration_signal",
+        "sec_guardrail_event_record",
+        "sec_indeterminate_freeze_record"
+      ],
+      "prohibited_behaviors": [
+        "closure_decisioning",
+        "trust_policy_adjudication",
+        "work_execution"
+      ],
+      "upstream_dependencies": [
+        "TLC"
+      ],
+      "downstream_consumers": [
+        "CDE",
+        "SEL"
+      ]
+    },
+    {
+      "acronym": "SEL",
+      "full_name": "System Enforcement Layer",
+      "role": "Applies fail-closed enforcement decisions across subsystem boundaries.",
+      "owns": [
+        "enforcement",
+        "fail_closed_blocking",
+        "promotion_guarding"
+      ],
+      "consumes": [
+        "closure_decision_artifact",
+        "review_control_signal_artifact",
+        "tpa_slice_artifact"
+      ],
+      "produces": [
+        "action_trace_record",
+        "enforcement_decision",
+        "system_enforcement_result_artifact"
+      ],
+      "prohibited_behaviors": [
+        "orchestration",
+        "repair_plan_generation",
+        "review_reinterpretation"
+      ],
+      "upstream_dependencies": [
+        "CDE",
+        "TLC",
+        "TPA"
+      ],
+      "downstream_consumers": [
+        "FRE",
+        "PQX",
+        "TLC"
+      ]
+    },
+    {
+      "acronym": "SIM",
+      "full_name": "Simulation eXecution Module",
+      "role": "Owns deterministic candidate policy and scenario simulation without live-state mutation.",
+      "owns": [
+        "candidate_policy_simulation",
+        "impact_diff_generation",
+        "scenario_replay_execution"
+      ],
+      "consumes": [
+        "baseline_artifacts",
+        "candidate_policy_artifacts",
+        "replayable_scenario_packs"
+      ],
+      "produces": [
+        "sim_diff_record",
+        "sim_policy_impact_report",
+        "sim_scenario_record",
+        "sim_simulation_bundle"
+      ],
+      "prohibited_behaviors": [
+        "modify_live_state",
+        "promote_simulation_output_automatically",
+        "replace_tpa_cde_authority"
+      ],
+      "upstream_dependencies": [
+        "TLC"
+      ],
+      "downstream_consumers": [
+        "CDE",
+        "SEL"
+      ]
+    },
+    {
+      "acronym": "SLO",
+      "full_name": "Service Level Objective Control",
+      "role": "Owns governed error-budget and burn-rate decision artifacts.",
+      "owns": [
+        "burn_rate_decisioning",
+        "slo_error_budget_artifacts",
+        "slo_freeze_block_signals"
+      ],
+      "consumes": [
+        "budget_threshold_policies",
+        "control_decision_inputs",
+        "eval_replay_drift_latency_cost_signals"
+      ],
+      "produces": [
+        "slo_budget_status_artifact",
+        "slo_burn_rate_record",
+        "slo_control_decision_signal"
+      ],
+      "prohibited_behaviors": [
+        "closure_decisioning",
+        "trust_policy_adjudication",
+        "work_execution"
+      ],
+      "upstream_dependencies": [
+        "TLC"
+      ],
+      "downstream_consumers": [
+        "CDE",
+        "SEL"
+      ]
+    },
+    {
+      "acronym": "SUP",
+      "full_name": "Supersession Active-Set System",
+      "role": "Supersession Active-Set System governance authority.",
+      "owns": [
+        "supersession_rules"
+      ],
+      "consumes": [
+        "governed_inputs"
+      ],
+      "produces": [
+        "sup_governance_record"
+      ],
+      "prohibited_behaviors": [
+        "closure_decisioning",
+        "work_execution"
       ],
       "upstream_dependencies": [
         "TLC"
@@ -1735,8 +1554,8 @@
         "syn_governance_record"
       ],
       "prohibited_behaviors": [
-        "work_execution",
-        "closure_decisioning"
+        "closure_decisioning",
+        "work_execution"
       ],
       "upstream_dependencies": [
         "TLC"
@@ -1744,6 +1563,187 @@
       "downstream_consumers": [
         "CDE",
         "SEL"
+      ]
+    },
+    {
+      "acronym": "TLC",
+      "full_name": "Top Level Conductor",
+      "role": "Orchestrates subsystem invocation order and interaction boundaries.",
+      "owns": [
+        "bounded_cycle_coordination",
+        "orchestration",
+        "subsystem_routing"
+      ],
+      "consumes": [
+        "closure_decision_artifact",
+        "system_enforcement_result_artifact",
+        "tpa_slice_artifact"
+      ],
+      "produces": [
+        "top_level_conductor_run_artifact"
+      ],
+      "prohibited_behaviors": [
+        "closure_decision_override",
+        "repair_plan_generation",
+        "work_execution"
+      ],
+      "upstream_dependencies": [
+        "AEX",
+        "PRG"
+      ],
+      "downstream_consumers": [
+        "CDE",
+        "FRE",
+        "PQX",
+        "PRG",
+        "RIL",
+        "SEL",
+        "TPA"
+      ]
+    },
+    {
+      "acronym": "TLX",
+      "full_name": "Tooling Layer eXecutor",
+      "role": "Owns tool registry, tool contracts, tool dispatch metadata, output normalization, permission metadata, and truncation/pagination rules.",
+      "owns": [
+        "tool_contract",
+        "tool_dispatch_record",
+        "tool_output_envelope",
+        "tool_permission_profile",
+        "tool_registry_entry"
+      ],
+      "consumes": [
+        "policy_permission_profile",
+        "tool_requests"
+      ],
+      "produces": [
+        "tool_dispatch_record",
+        "tool_output_envelope"
+      ],
+      "prohibited_behaviors": [
+        "allow_raw_unbounded_tool_outputs_into_runtime_context",
+        "bypass_policy_permissions",
+        "treat_prompts_as_security_boundary"
+      ],
+      "upstream_dependencies": [
+        "TPA"
+      ],
+      "downstream_consumers": [
+        "CTX",
+        "PQX"
+      ]
+    },
+    {
+      "acronym": "TPA",
+      "full_name": "Trust Policy Application",
+      "role": "Applies trust and policy gates to authorize execution scope.",
+      "owns": [
+        "complexity_budgeting",
+        "scope_gating",
+        "trust_policy_application"
+      ],
+      "consumes": [
+        "codex_pqx_task_wrapper",
+        "complexity_trend",
+        "source_authority_refresh_receipt"
+      ],
+      "produces": [
+        "tpa_observability_summary",
+        "tpa_scope_policy",
+        "tpa_slice_artifact"
+      ],
+      "prohibited_behaviors": [
+        "closure_decisioning",
+        "runtime_enforcement",
+        "work_execution"
+      ],
+      "upstream_dependencies": [
+        "TLC"
+      ],
+      "downstream_consumers": [
+        "PQX",
+        "SEL"
+      ]
+    },
+    {
+      "acronym": "TRN",
+      "full_name": "Translation System",
+      "role": "Translation System governance authority.",
+      "owns": [
+        "source_translation_contracts"
+      ],
+      "consumes": [
+        "governed_inputs"
+      ],
+      "produces": [
+        "trn_governance_record"
+      ],
+      "prohibited_behaviors": [
+        "closure_decisioning",
+        "work_execution"
+      ],
+      "upstream_dependencies": [
+        "TLC"
+      ],
+      "downstream_consumers": [
+        "CDE",
+        "SEL"
+      ]
+    },
+    {
+      "acronym": "TST",
+      "full_name": "Test Asset Governance System",
+      "role": "Test Asset Governance System governance authority.",
+      "owns": [
+        "test_asset_registry"
+      ],
+      "consumes": [
+        "governed_inputs"
+      ],
+      "produces": [
+        "tst_governance_record"
+      ],
+      "prohibited_behaviors": [
+        "closure_decisioning",
+        "work_execution"
+      ],
+      "upstream_dependencies": [
+        "TLC"
+      ],
+      "downstream_consumers": [
+        "CDE",
+        "SEL"
+      ]
+    },
+    {
+      "acronym": "XRL",
+      "full_name": "External Reality Loop",
+      "role": "Normalizes external outcomes and emits trust-weighted feedback bindings.",
+      "owns": [
+        "external_feedback_binding_record",
+        "external_outcome_impact_artifact",
+        "external_outcome_signal",
+        "outcome_normalization_record",
+        "outcome_trust_weight"
+      ],
+      "consumes": [
+        "external_outcome_feed",
+        "postmortem_record"
+      ],
+      "produces": [
+        "xrl_external_outcome_impact_artifact"
+      ],
+      "prohibited_behaviors": [
+        "closure_decisioning",
+        "policy_authority_decisioning",
+        "runtime_enforcement"
+      ],
+      "upstream_dependencies": [
+        "RIL"
+      ],
+      "downstream_consumers": [
+        "DEM",
+        "PRG"
       ]
     }
   ],
@@ -1765,40 +1765,136 @@
       "to": "TLC"
     },
     {
-      "from": "TLC",
-      "to": "PQX"
-    },
-    {
-      "from": "TLC",
-      "to": "TPA"
-    },
-    {
-      "from": "TLC",
-      "to": "FRE"
-    },
-    {
-      "from": "TLC",
-      "to": "RIL"
-    },
-    {
-      "from": "TLC",
+      "from": "BAX",
       "to": "CDE"
     },
     {
-      "from": "TLC",
+      "from": "BRM",
+      "to": "CDE"
+    },
+    {
+      "from": "CAP",
+      "to": "SEL"
+    },
+    {
+      "from": "CDE",
+      "to": "CDE"
+    },
+    {
+      "from": "CHX",
+      "to": "CVX"
+    },
+    {
+      "from": "CON",
+      "to": "SEL"
+    },
+    {
+      "from": "CTX",
+      "to": "PQX"
+    },
+    {
+      "from": "CTX",
+      "to": "SEL"
+    },
+    {
+      "from": "DAT",
+      "to": "SEL"
+    },
+    {
+      "from": "DCL",
+      "to": "TPA"
+    },
+    {
+      "from": "DEM",
       "to": "PRG"
+    },
+    {
+      "from": "DRT",
+      "to": "SEL"
+    },
+    {
+      "from": "DRX",
+      "to": "CDE"
+    },
+    {
+      "from": "ENT",
+      "to": "SEL"
+    },
+    {
+      "from": "EVL",
+      "to": "SEL"
+    },
+    {
+      "from": "HIT",
+      "to": "SEL"
+    },
+    {
+      "from": "HIX",
+      "to": "DEX"
+    },
+    {
+      "from": "JDX",
+      "to": "SEL"
+    },
+    {
+      "from": "JSX",
+      "to": "CDE"
+    },
+    {
+      "from": "LIN",
+      "to": "SEL"
+    },
+    {
+      "from": "MCL",
+      "to": "RSM"
+    },
+    {
+      "from": "OBS",
+      "to": "SEL"
+    },
+    {
+      "from": "PRM",
+      "to": "SEL"
+    },
+    {
+      "from": "PRX",
+      "to": "DEX"
+    },
+    {
+      "from": "REL",
+      "to": "SEL"
+    },
+    {
+      "from": "REP",
+      "to": "SEL"
     },
     {
       "from": "RIL",
       "to": "CDE"
     },
     {
-      "from": "SEL",
-      "to": "PQX"
+      "from": "RIL",
+      "to": "RSM"
+    },
+    {
+      "from": "ROU",
+      "to": "SEL"
+    },
+    {
+      "from": "RSM",
+      "to": "CDE"
+    },
+    {
+      "from": "RSM",
+      "to": "PRG"
+    },
+    {
+      "from": "SEC",
+      "to": "SEL"
     },
     {
       "from": "SEL",
-      "to": "TPA"
+      "to": "CDE"
     },
     {
       "from": "SEL",
@@ -1806,11 +1902,15 @@
     },
     {
       "from": "SEL",
-      "to": "RIL"
+      "to": "PQX"
     },
     {
       "from": "SEL",
-      "to": "CDE"
+      "to": "PRG"
+    },
+    {
+      "from": "SEL",
+      "to": "RIL"
     },
     {
       "from": "SEL",
@@ -1818,22 +1918,22 @@
     },
     {
       "from": "SEL",
-      "to": "PRG"
+      "to": "TPA"
     },
     {
-      "from": "TPA",
-      "to": "BAX"
+      "from": "SIM",
+      "to": "CVX"
     },
     {
-      "from": "BAX",
-      "to": "CDE"
+      "from": "SLO",
+      "to": "SEL"
     },
     {
-      "from": "CDE",
-      "to": "CDE"
+      "from": "TLC",
+      "to": "CAP"
     },
     {
-      "from": "CDE",
+      "from": "TLC",
       "to": "CDE"
     },
     {
@@ -1842,7 +1942,19 @@
     },
     {
       "from": "TLC",
+      "to": "CON"
+    },
+    {
+      "from": "TLC",
+      "to": "CTX"
+    },
+    {
+      "from": "TLC",
       "to": "CVX"
+    },
+    {
+      "from": "TLC",
+      "to": "DAT"
     },
     {
       "from": "TLC",
@@ -1850,7 +1962,51 @@
     },
     {
       "from": "TLC",
-      "to": "SIM"
+      "to": "DRT"
+    },
+    {
+      "from": "TLC",
+      "to": "ENT"
+    },
+    {
+      "from": "TLC",
+      "to": "EVL"
+    },
+    {
+      "from": "TLC",
+      "to": "FRE"
+    },
+    {
+      "from": "TLC",
+      "to": "HIT"
+    },
+    {
+      "from": "TLC",
+      "to": "HIX"
+    },
+    {
+      "from": "TLC",
+      "to": "JDX"
+    },
+    {
+      "from": "TLC",
+      "to": "LIN"
+    },
+    {
+      "from": "TLC",
+      "to": "OBS"
+    },
+    {
+      "from": "TLC",
+      "to": "PQX"
+    },
+    {
+      "from": "TLC",
+      "to": "PRG"
+    },
+    {
+      "from": "TLC",
+      "to": "PRM"
     },
     {
       "from": "TLC",
@@ -1858,211 +2014,51 @@
     },
     {
       "from": "TLC",
-      "to": "HIX"
-    },
-    {
-      "from": "CHX",
-      "to": "CVX"
-    },
-    {
-      "from": "SIM",
-      "to": "CVX"
-    },
-    {
-      "from": "PRX",
-      "to": "DEX"
-    },
-    {
-      "from": "HIX",
-      "to": "DEX"
-    },
-    {
-      "from": "TLC",
-      "to": "CTX"
-    },
-    {
-      "from": "CTX",
-      "to": "SEL"
-    },
-    {
-      "from": "TLC",
-      "to": "EVL"
-    },
-    {
-      "from": "EVL",
-      "to": "SEL"
-    },
-    {
-      "from": "TLC",
-      "to": "OBS"
-    },
-    {
-      "from": "OBS",
-      "to": "SEL"
-    },
-    {
-      "from": "TLC",
-      "to": "LIN"
-    },
-    {
-      "from": "LIN",
-      "to": "SEL"
-    },
-    {
-      "from": "TLC",
-      "to": "DRT"
-    },
-    {
-      "from": "DRT",
-      "to": "SEL"
-    },
-    {
-      "from": "TLC",
-      "to": "SLO"
-    },
-    {
-      "from": "SLO",
-      "to": "SEL"
-    },
-    {
-      "from": "TLC",
       "to": "REL"
-    },
-    {
-      "from": "REL",
-      "to": "SEL"
-    },
-    {
-      "from": "TLC",
-      "to": "DAT"
-    },
-    {
-      "from": "DAT",
-      "to": "SEL"
-    },
-    {
-      "from": "TLC",
-      "to": "JDX"
-    },
-    {
-      "from": "JDX",
-      "to": "SEL"
-    },
-    {
-      "from": "TLC",
-      "to": "PRM"
-    },
-    {
-      "from": "PRM",
-      "to": "SEL"
-    },
-    {
-      "from": "TLC",
-      "to": "ROU"
-    },
-    {
-      "from": "ROU",
-      "to": "SEL"
-    },
-    {
-      "from": "TLC",
-      "to": "HIT"
-    },
-    {
-      "from": "HIT",
-      "to": "SEL"
-    },
-    {
-      "from": "TLC",
-      "to": "CAP"
-    },
-    {
-      "from": "CAP",
-      "to": "SEL"
-    },
-    {
-      "from": "TLC",
-      "to": "SEC"
-    },
-    {
-      "from": "SEC",
-      "to": "SEL"
     },
     {
       "from": "TLC",
       "to": "REP"
     },
     {
-      "from": "REP",
-      "to": "SEL"
-    },
-    {
       "from": "TLC",
-      "to": "ENT"
-    },
-    {
-      "from": "ENT",
-      "to": "SEL"
-    },
-    {
-      "from": "TLC",
-      "to": "CON"
-    },
-    {
-      "from": "CON",
-      "to": "SEL"
-    },
-    {
-      "from": "RIL",
-      "to": "RSM"
-    },
-    {
-      "from": "RSM",
-      "to": "PRG"
-    },
-    {
-      "from": "RSM",
-      "to": "CDE"
-    },
-    {
-      "from": "DEM",
-      "to": "PRG"
-    },
-    {
-      "from": "BRM",
-      "to": "CDE"
-    },
-    {
-      "from": "DCL",
-      "to": "TPA"
-    },
-    {
-      "from": "XRL",
       "to": "RIL"
     },
     {
-      "from": "XRL",
-      "to": "PRG"
+      "from": "TLC",
+      "to": "ROU"
     },
     {
-      "from": "MCL",
-      "to": "RSM"
+      "from": "TLC",
+      "to": "SEC"
     },
     {
-      "from": "CTX",
-      "to": "PQX"
+      "from": "TLC",
+      "to": "SIM"
+    },
+    {
+      "from": "TLC",
+      "to": "SLO"
+    },
+    {
+      "from": "TLC",
+      "to": "TPA"
     },
     {
       "from": "TLX",
       "to": "CTX"
     },
     {
-      "from": "JSX",
-      "to": "CDE"
+      "from": "TPA",
+      "to": "BAX"
     },
     {
-      "from": "DRX",
-      "to": "CDE"
+      "from": "XRL",
+      "to": "PRG"
+    },
+    {
+      "from": "XRL",
+      "to": "RIL"
     }
   ]
 }

--- a/contracts/schemas/system_registry_artifact.schema.json
+++ b/contracts/schemas/system_registry_artifact.schema.json
@@ -34,6 +34,7 @@
     "systems": {
       "type": "array",
       "minItems": 8,
+      "description": "Canonicalized by scripts/build_system_registry_artifact.py; each governed action maps to exactly one owner.",
       "items": {
         "$ref": "#/$defs/system_entry"
       }
@@ -87,6 +88,7 @@
           "type": "array",
           "minItems": 1,
           "uniqueItems": true,
+          "description": "Set-like ownership responsibilities; duplicates are invalid and canonical builder repair is required.",
           "items": {
             "type": "string",
             "pattern": "^[a-z][a-z0-9_]*$"

--- a/docs/architecture/system_registry.md
+++ b/docs/architecture/system_registry.md
@@ -3,6 +3,8 @@
 ## Core Rule
 1. **Single-responsibility ownership:** each governed responsibility has exactly one owning system.
 2. **No-duplication rule:** no system may implement, enforce, or silently shadow a responsibility owned by another system.
+3. **Canonical artifact rule:** runtime enforcement MUST consume the normalized `contracts/examples/system_registry_artifact.json` produced by `scripts/build_system_registry_artifact.py`.
+4. **Support-only rule:** support code may assist governed runtime execution but MUST NOT become an authority surface.
 
 These rules are hard boundaries for architecture, contracts, and validation.
 

--- a/docs/governance/governed_runtime_ownership_map.json
+++ b/docs/governance/governed_runtime_ownership_map.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": "1.0.0",
+  "policy": "three_letter_governed_runtime_ownership",
+  "governed_path_prefixes": [
+    {
+      "path": "spectrum_systems/modules/runtime/",
+      "classification": "authority_bearing",
+      "owner": "TLC"
+    },
+    {
+      "path": "scripts/run_contract_preflight.py",
+      "classification": "authority_bearing",
+      "owner": "TPA"
+    },
+    {
+      "path": "scripts/build_preflight_pqx_wrapper.py",
+      "classification": "authority_bearing",
+      "owner": "PQX"
+    },
+    {
+      "path": "scripts/",
+      "classification": "support_only",
+      "owner": null
+    },
+    {
+      "path": "tests/",
+      "classification": "support_only",
+      "owner": null
+    },
+    {
+      "path": "docs/",
+      "classification": "support_only",
+      "owner": null
+    },
+    {
+      "path": "contracts/examples/",
+      "classification": "support_only",
+      "owner": null
+    }
+  ],
+  "waivers": [
+    {
+      "path": "spectrum_systems/modules/runtime/__init__.py",
+      "classification": "support_only",
+      "expires_on": "2026-12-31",
+      "reason": "legacy module init shim; no authority behavior"
+    }
+  ]
+}

--- a/docs/governance/three_letter_ownership_policy.md
+++ b/docs/governance/three_letter_ownership_policy.md
@@ -1,0 +1,21 @@
+# Three-Letter Ownership Policy (Canonical Governed Runtime)
+
+## Purpose
+Enforce explicit 3-letter ownership over governed runtime behavior while allowing support-only code.
+
+## Policy
+1. Every governed behavior must map to exactly one owning 3-letter system.
+2. Support-only code is allowed, but support-only code must not emit authority-bearing artifacts or decisions.
+3. Shared utilities may assist owners but do not inherit authority.
+4. New governed runtime code must declare one of:
+   - explicit owning 3-letter system, or
+   - explicit `support_only` / non-authority classification.
+5. Docs/tests/examples/templates are non-authority by default unless they execute governed runtime behavior.
+
+## Canonical sources
+- Runtime ownership authority: `docs/architecture/system_registry.md`.
+- Runtime source of truth artifact: `contracts/examples/system_registry_artifact.json` (rebuilt through `scripts/build_system_registry_artifact.py`).
+- Governed path admission map: `docs/governance/governed_runtime_ownership_map.json`.
+
+## Admission enforcement
+Use `scripts/validate_governed_runtime_ownership.py` in CI and local preflight to fail closed on unclassified governed runtime additions.

--- a/docs/review-actions/PLAN-3LS-50-2026-04-14.md
+++ b/docs/review-actions/PLAN-3LS-50-2026-04-14.md
@@ -1,0 +1,10 @@
+# Plan — 3LS-50 — 2026-04-14
+
+## Prompt type
+BUILD
+
+## Roadmap item
+3LS-50 — Wire full 3-letter system governance policy into the current Spectrum Systems repo
+
+## Objective
+Enforce explicit single-owner 3-letter governance across registry, runtime enforcement, preflight remediation, and governed code admission while keeping existing canonical registry seams.

--- a/docs/reviews/REVIEW-3LS-50-2026-04-14.md
+++ b/docs/reviews/REVIEW-3LS-50-2026-04-14.md
@@ -1,0 +1,21 @@
+# REVIEW — 3LS-50 — 2026-04-14
+
+## Summary
+Implemented repo-native 3-letter ownership governance hardening through canonical registry build normalization, runtime enforcement violation precision, preflight failure classification, and governed runtime ownership admission checks.
+
+## Root causes fixed
+1. Malformed registry state entering runtime now routes through deterministic builder normalization and protected-owner invariants.
+2. Drift detection now checks doc registry against canonical artifact ownership sets.
+3. Duplicate/ambiguous ownership remains fail-closed with explicit violation codes.
+4. Preflight BLOCK classification now labels canonicalizable mismatch classes before escalation.
+5. Push/PR ref ambiguity now emits structured GitHub SHA context in preflight wrapper sidecar.
+6. Runtime/preflight dependence on malformed manual registry state now uses canonical rebuild path.
+7. New governed code admission policy enforces owner/support-only declarations via map + validator.
+8. Shadow authority risk is reduced through explicit closure artifact authority checks.
+
+## Remaining risks
+- The governed runtime ownership map is prefix-based and requires disciplined updates for new slices.
+- Full-repo rollout should wire `scripts/validate_governed_runtime_ownership.py` into all CI entrypoints.
+
+## Readiness
+READY

--- a/docs/roadmaps/system_roadmap.md
+++ b/docs/roadmaps/system_roadmap.md
@@ -51,3 +51,15 @@
 | BATCH-CL-03 | CL | Recurrence Prevention Enforcement | not_started | BATCH-CL-02 | true | Roadmap authority + deterministic dependency-gated progression | policy authority | pytest tests/test_batch_cl_03.py | Replayable ordered batch evaluation with trace anchor trace-system-roadmap-mvp-2026-04-04 and batch_id BATCH-CL-03 | hard gate; fail-closed on: missing_required_artifact, failed_required_test, hard_gate_failed |
 
 Execution automation must read the governed JSON artifact, validate against schema before selection, and fail closed on invalid roadmap state.
+
+## Ownership Governance Failure Tracking (3LS-50)
+
+Ownership violations are first-class failures in roadmap execution and must be tracked as recurrence-class failures:
+- `registry_malformed`
+- `ownership_mismatch`
+- `prohibited_behavior`
+- `interaction_edge_violation`
+- `preflight_auto_repaired`
+- `preflight_escalated`
+
+Operational reporting must emit structured artifacts before human-readable summaries.

--- a/scripts/build_preflight_pqx_wrapper.py
+++ b/scripts/build_preflight_pqx_wrapper.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import sys
 from copy import deepcopy
 from datetime import datetime, timezone
@@ -97,6 +98,22 @@ def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def _github_ref_context() -> dict[str, object]:
+    event_name = (os.environ.get("GITHUB_EVENT_NAME") or "").strip()
+    payload = {
+        "event_name": event_name or "unspecified",
+        "has_base_head_sha": bool((os.environ.get("GITHUB_BASE_SHA") or "").strip() and (os.environ.get("GITHUB_HEAD_SHA") or "").strip()),
+        "has_push_before_sha": bool((os.environ.get("GITHUB_BEFORE_SHA") or "").strip() and (os.environ.get("GITHUB_SHA") or "").strip()),
+    }
+    if event_name == "pull_request" and not payload["has_base_head_sha"]:
+        payload["failure_class"] = "missing_pr_sha_context"
+    elif event_name == "push" and not payload["has_push_before_sha"]:
+        payload["failure_class"] = "missing_push_sha_context"
+    else:
+        payload["failure_class"] = "none"
+    return payload
+
+
 def main(argv: Optional[list[str]] = None) -> int:
     args = _parse_args(argv)
     template_path = _REPO_ROOT / args.template
@@ -148,6 +165,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         "refs_attempted": resolution.refs_attempted,
         "warnings": resolution.warnings,
         "hardening_artifact_refs": hardening_refs,
+        "github_ref_context": _github_ref_context(),
     }
 
     output_path = _REPO_ROOT / args.output

--- a/scripts/build_system_registry_artifact.py
+++ b/scripts/build_system_registry_artifact.py
@@ -52,22 +52,18 @@ class BuildResult:
     normalized_system_count: int
 
 
-def _dedupe_ordered_strings(values: Any, *, field: str, acronym: str) -> list[str]:
+def _dedupe_sorted_strings(values: Any, *, field: str, acronym: str) -> list[str]:
     if not isinstance(values, list):
         raise SystemRegistryBuildError(f"registry_build_invalid:{acronym}.{field}:expected_list")
-    out: list[str] = []
-    seen: set[str] = set()
+    out: set[str] = set()
     for idx, raw in enumerate(values):
         if not isinstance(raw, str):
             raise SystemRegistryBuildError(f"registry_build_invalid:{acronym}.{field}[{idx}]:expected_string")
         value = raw.strip()
         if not value:
             raise SystemRegistryBuildError(f"registry_build_invalid:{acronym}.{field}[{idx}]:empty_string")
-        if value in seen:
-            continue
-        seen.add(value)
-        out.append(value)
-    return out
+        out.add(value)
+    return sorted(out)
 
 
 def _normalize_registry(payload: dict[str, Any]) -> dict[str, Any]:
@@ -91,10 +87,22 @@ def _normalize_registry(payload: dict[str, Any]) -> dict[str, Any]:
         record = dict(entry)
         record["acronym"] = acronym
         for field in _SET_LIKE_SYSTEM_FIELDS:
-            record[field] = _dedupe_ordered_strings(record.get(field, []), field=field, acronym=acronym)
+            record[field] = _dedupe_sorted_strings(record.get(field, []), field=field, acronym=acronym)
         normalized_systems.append(record)
 
-    normalized["systems"] = normalized_systems
+    normalized["systems"] = sorted(normalized_systems, key=lambda item: str(item.get("acronym", "")))
+    interaction_edges = payload.get("interaction_edges")
+    if isinstance(interaction_edges, list):
+        deduped_edges: set[tuple[str, str]] = set()
+        for edge in interaction_edges:
+            if not isinstance(edge, dict):
+                raise SystemRegistryBuildError("registry_build_invalid:interaction_edges:expected_object_entries")
+            source = str(edge.get("from") or "").strip().upper()
+            target = str(edge.get("to") or "").strip().upper()
+            if not source or not target:
+                raise SystemRegistryBuildError("registry_build_invalid:interaction_edges:from_to_required")
+            deduped_edges.add((source, target))
+        normalized["interaction_edges"] = [{"from": source, "to": target} for source, target in sorted(deduped_edges)]
     return normalized
 
 

--- a/scripts/run_contract_preflight.py
+++ b/scripts/run_contract_preflight.py
@@ -109,6 +109,7 @@ _CONTROL_SURFACE_GAP_PACKET_REQUIRED_TESTS = [
     "tests/test_pqx_slice_runner.py",
 ]
 _GOVERNED_PROMPT_SURFACE_REGISTRY = REPO_ROOT / "docs" / "governance" / "governed_prompt_surfaces.json"
+_GOVERNED_RUNTIME_OWNERSHIP_MAP = REPO_ROOT / "docs" / "governance" / "governed_runtime_ownership_map.json"
 
 _REQUIRED_SURFACE_TEST_OVERRIDES: dict[str, list[str]] = {
     "scripts/run_autonomous_validation_run.py": ["tests/test_run_autonomous_validation_run.py"],
@@ -419,6 +420,65 @@ def classify_changed_contracts(changed_paths: list[str]) -> dict[str, list[str]]
         "changed_example_paths": changed_examples,
         "changed_governed_definitions": governed_defs,
     }
+
+
+def classify_preflight_failure(report: dict[str, Any]) -> str:
+    if report.get("schema_example_failures"):
+        return "canonicalizable_registry_or_schema_mismatch"
+    if report.get("missing_required_surface"):
+        return "required_surface_mapping_mismatch"
+    pqx_ctx = (report.get("changed_path_detection") or {}).get("pqx_required_context_enforcement")
+    if isinstance(pqx_ctx, dict) and str(pqx_ctx.get("status")) == "block":
+        return "pqx_required_context_block"
+    if report.get("control_surface_gap_blocking"):
+        return "control_surface_gap_blocking"
+    if report.get("consumer_failures") or report.get("producer_failures") or report.get("fixture_failures"):
+        return "contract_or_runtime_validation_failure"
+    if str(report.get("status")) == "failed":
+        return "unknown_preflight_failure"
+    return "none"
+
+
+def validate_governed_runtime_ownership(changed_paths: list[str]) -> list[dict[str, str]]:
+    if not _GOVERNED_RUNTIME_OWNERSHIP_MAP.is_file():
+        return [{"path": "docs/governance/governed_runtime_ownership_map.json", "reason": "missing_ownership_map"}]
+    try:
+        payload = json.loads(_GOVERNED_RUNTIME_OWNERSHIP_MAP.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return [{"path": "docs/governance/governed_runtime_ownership_map.json", "reason": "invalid_ownership_map"}]
+    prefixes = payload.get("governed_path_prefixes", []) if isinstance(payload, dict) else []
+    known_exact = {
+        str(entry.get("path") or "")
+        for entry in prefixes
+        if isinstance(entry, dict) and str(entry.get("path") or "").endswith(".py")
+    }
+    waivers = {str(item.get("path") or "") for item in payload.get("waivers", []) if isinstance(item, dict)} if isinstance(payload, dict) else set()
+    failures: list[dict[str, str]] = []
+    for path in changed_paths:
+        if not path.startswith(("spectrum_systems/modules/runtime/", "scripts/")):
+            continue
+        if not (REPO_ROOT / path).exists() and path not in known_exact:
+            failures.append({"path": path, "reason": "missing_governed_runtime_ownership_classification"})
+            continue
+        if path in waivers:
+            continue
+        matched = False
+        for entry in prefixes:
+            if not isinstance(entry, dict):
+                continue
+            prefix = str(entry.get("path") or "")
+            if path.startswith(prefix):
+                matched = True
+                classification = str(entry.get("classification") or "")
+                owner = entry.get("owner")
+                if classification == "authority_bearing" and (not isinstance(owner, str) or len(owner) != 3):
+                    failures.append({"path": path, "reason": "authority_bearing_requires_three_letter_owner"})
+                if classification == "support_only" and owner is not None:
+                    failures.append({"path": path, "reason": "support_only_must_not_set_owner"})
+                break
+        if not matched:
+            failures.append({"path": path, "reason": "missing_governed_runtime_ownership_classification"})
+    return failures
 
 
 
@@ -1490,6 +1550,7 @@ def main() -> int:
                 resolved_targets_by_path=forced_eval_targets_by_path,
             )
         )
+        missing_required_surface.extend(validate_governed_runtime_ownership(detection.changed_paths))
         forced_targets = sorted({target for targets in forced_eval_targets_by_path.values() for target in targets})
 
         producer_eval_targets = sorted(set(producer_targets + forced_targets))
@@ -1592,6 +1653,7 @@ def main() -> int:
     control_signal = map_preflight_control_signal(report=report, hardening_flow=bool(args.hardening_flow))
     decision = str(control_signal.get("strategy_gate_decision", "BLOCK"))
     report["status"] = "failed" if decision in {"BLOCK", "FREEZE"} else "passed"
+    report["failure_classification"] = classify_preflight_failure(report)
 
     json_path = output_dir / "contract_preflight_report.json"
     md_path = output_dir / "contract_preflight_report.md"

--- a/scripts/validate_governed_runtime_ownership.py
+++ b/scripts/validate_governed_runtime_ownership.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Fail-closed validation for governed runtime ownership assignment."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MAP_PATH = REPO_ROOT / "docs" / "governance" / "governed_runtime_ownership_map.json"
+
+
+def _git_changed_paths(base_ref: str, head_ref: str) -> list[str]:
+    result = subprocess.run(
+        ["git", "diff", "--name-only", f"{base_ref}..{head_ref}"],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "failed to diff paths")
+    return sorted({line.strip() for line in result.stdout.splitlines() if line.strip()})
+
+
+def _load_map() -> dict:
+    payload = json.loads(MAP_PATH.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise RuntimeError("governed runtime ownership map must be a JSON object")
+    return payload
+
+
+def _classify(path: str, payload: dict) -> tuple[str | None, str | None]:
+    prefixes = payload.get("governed_path_prefixes", [])
+    for entry in prefixes:
+        if not isinstance(entry, dict):
+            continue
+        prefix = str(entry.get("path") or "")
+        if path.startswith(prefix):
+            return str(entry.get("classification") or ""), entry.get("owner") if isinstance(entry.get("owner"), str) else None
+    return None, None
+
+
+def _is_waived(path: str, payload: dict) -> bool:
+    waivers = payload.get("waivers", [])
+    for waiver in waivers:
+        if isinstance(waiver, dict) and str(waiver.get("path") or "") == path:
+            return True
+    return False
+
+
+def validate_paths(paths: list[str]) -> list[str]:
+    payload = _load_map()
+    known_exact = {
+        str(entry.get("path") or "")
+        for entry in payload.get("governed_path_prefixes", [])
+        if isinstance(entry, dict) and str(entry.get("path") or "").endswith(".py")
+    }
+    failures: list[str] = []
+    for path in paths:
+        if not path.startswith(("spectrum_systems/modules/runtime/", "scripts/")):
+            continue
+        file_exists = (REPO_ROOT / path).exists()
+        classification, owner = _classify(path, payload)
+        if not file_exists and path not in known_exact:
+            failures.append(f"ownership_classification_missing:{path}")
+            continue
+        if classification is None:
+            failures.append(f"ownership_classification_missing:{path}")
+            continue
+        if classification == "authority_bearing" and (owner is None or len(owner) != 3):
+            failures.append(f"authority_owner_invalid:{path}:{owner}")
+        if classification == "support_only" and owner is not None:
+            failures.append(f"support_only_must_not_have_owner:{path}:{owner}")
+        if _is_waived(path, payload):
+            continue
+    return failures
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate governed runtime ownership declarations")
+    parser.add_argument("--base-ref", default="HEAD~1")
+    parser.add_argument("--head-ref", default="HEAD")
+    parser.add_argument("--path", action="append", default=[])
+    args = parser.parse_args(argv)
+
+    changed = sorted(set(args.path)) if args.path else _git_changed_paths(args.base_ref, args.head_ref)
+    failures = validate_paths(changed)
+    if failures:
+        for failure in failures:
+            print(f"ERROR: {failure}")
+        return 2
+    print(json.dumps({"status": "ok", "validated_paths": changed}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_system_registry_boundaries.py
+++ b/scripts/validate_system_registry_boundaries.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import sys
 from dataclasses import dataclass
@@ -11,6 +12,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 REGISTRY_PATH = REPO_ROOT / "docs" / "architecture" / "system_registry.md"
+REGISTRY_ARTIFACT_PATH = REPO_ROOT / "contracts" / "examples" / "system_registry_artifact.json"
 
 SYSTEM_HEADER_RE = re.compile(r"^\s*###\s+([A-Z0-9]+)\s*$")
 FIELD_RE = re.compile(r"^\s*-\s+\*\*(role|owns|consumes|produces|must_not_do):\*\*\s*(.*)$")
@@ -337,6 +339,42 @@ def check_next_phase_presence_and_io(systems: dict[str, SystemDefinition]) -> li
             errors.append(f"{name} must declare produces list")
     return errors
 
+
+def check_doc_artifact_drift(systems: dict[str, SystemDefinition]) -> list[str]:
+    errors: list[str] = []
+    if not REGISTRY_ARTIFACT_PATH.is_file():
+        return ["registry artifact missing for drift validation"]
+    payload = json.loads(REGISTRY_ARTIFACT_PATH.read_text(encoding="utf-8"))
+    artifact_systems = payload.get("systems", [])
+    artifact_by_name = {
+        str(entry.get("acronym") or "").strip().upper(): entry
+        for entry in artifact_systems
+        if isinstance(entry, dict)
+    }
+    doc_names = set(systems.keys())
+    artifact_names = set(artifact_by_name.keys())
+    artifact_only = sorted(artifact_names - doc_names)
+    if artifact_only:
+        errors.append(f"registry_doc_artifact_drift:artifact_only={artifact_only}")
+    protected = {
+        "execution": "PQX",
+        "execution_admission": "AEX",
+        "failure_diagnosis": "FRE",
+        "review_interpretation": "RIL",
+        "closure_decisions": "CDE",
+        "enforcement": "SEL",
+        "orchestration": "TLC",
+    }
+    for responsibility, owner in protected.items():
+        artifact_owner = sorted(
+            name
+            for name, entry in artifact_by_name.items()
+            if responsibility in (entry.get("owns") if isinstance(entry.get("owns"), list) else [])
+        )
+        if artifact_owner != [owner]:
+            errors.append(f"registry_artifact_protected_owner_drift:{responsibility}:expected={owner}:actual={artifact_owner}")
+    return errors
+
 def run_all_checks(registry_path: Path = REGISTRY_PATH) -> list[str]:
     systems, full_text = parse_registry(registry_path)
 
@@ -355,6 +393,7 @@ def run_all_checks(registry_path: Path = REGISTRY_PATH) -> list[str]:
     errors.extend(check_extended_hardening_ownership(systems))
     errors.extend(check_next_wave_boundaries(systems))
     errors.extend(check_next_phase_presence_and_io(systems))
+    errors.extend(check_doc_artifact_drift(systems))
     return errors
 
 

--- a/spectrum_systems/modules/runtime/github_closure_continuation.py
+++ b/spectrum_systems/modules/runtime/github_closure_continuation.py
@@ -23,6 +23,7 @@ from spectrum_systems.modules.runtime.closure_decision_engine import (
     build_closure_decision_artifact,
     maybe_build_next_step_prompt_artifact,
 )
+from spectrum_systems.modules.runtime.system_registry_enforcer import validate_artifact_authority
 from spectrum_systems.modules.runtime.top_level_conductor import run_top_level_conductor
 from spectrum_systems.utils.deterministic_id import deterministic_id
 
@@ -602,6 +603,11 @@ def run_github_closure_continuation(
     }
 
     decision_artifact = build_closure_decision_artifact(cde_request)
+    authority = validate_artifact_authority(emitting_system="CDE", artifact_type="closure_decision_artifact")
+    if not authority["allow"]:
+        raise GithubClosureContinuationError(
+            "closure_decision_artifact authority violation: " + ",".join(authority["violation_codes"])
+        )
     validate_artifact(decision_artifact, "closure_decision_artifact")
     _write_json(artifact_paths.closure_decision_artifact_path, decision_artifact)
 

--- a/spectrum_systems/modules/runtime/github_pr_autofix_contract_preflight.py
+++ b/spectrum_systems/modules/runtime/github_pr_autofix_contract_preflight.py
@@ -313,6 +313,21 @@ def _repair_system_registry_reserved_entries(*, repo_root: Path) -> list[str]:
     return [str(path.relative_to(repo_root))]
 
 
+def _canonical_rebuild_system_registry(*, repo_root: Path, command_runner: Callable[[list[str], Path], CommandResult]) -> list[str]:
+    cmd = [
+        sys.executable,
+        "scripts/build_system_registry_artifact.py",
+        "--input",
+        "contracts/examples/system_registry_artifact.json",
+        "--output",
+        "contracts/examples/system_registry_artifact.json",
+    ]
+    result = command_runner(cmd, repo_root)
+    if result.returncode != 0:
+        raise ContractPreflightAutofixError("system_registry_canonical_rebuild_failed")
+    return ["contracts/examples/system_registry_artifact.json"]
+
+
 def _run(command: list[str], cwd: Path) -> CommandResult:
     completed = subprocess.run(command, cwd=str(cwd), check=False)
     return CommandResult(command=command, returncode=completed.returncode)
@@ -379,7 +394,9 @@ def run_preflight_block_autorepair(
         elif category == "contract_mismatch":
             attempt["mutated_paths"] = _repair_required_surface_mapping(repo_root=repo_root, report=report)
         elif category == "schema_violation":
-            attempt["mutated_paths"] = _repair_system_registry_reserved_entries(repo_root=repo_root)
+            repaired = _repair_system_registry_reserved_entries(repo_root=repo_root)
+            rebuilt = _canonical_rebuild_system_registry(repo_root=repo_root, command_runner=command_runner)
+            attempt["mutated_paths"] = sorted(set(repaired + rebuilt))
         else:
             raise ContractPreflightAutofixError("unsupported_auto_repair_category")
         if len(attempt["mutated_paths"]) > 5:

--- a/spectrum_systems/modules/runtime/system_registry_enforcer.py
+++ b/spectrum_systems/modules/runtime/system_registry_enforcer.py
@@ -18,6 +18,7 @@ class SystemRegistryEnforcerError(ValueError):
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _REGISTRY_EXAMPLE_PATH = _REPO_ROOT / "contracts" / "examples" / "system_registry_artifact.json"
+_OWNERSHIP_MAP_PATH = _REPO_ROOT / "docs" / "governance" / "governed_runtime_ownership_map.json"
 _CANONICAL_HANDOFF_PATH: set[tuple[str, str]] = {
     ("PQX", "TPA"),
     ("TPA", "FRE"),
@@ -60,6 +61,25 @@ def _load_registry() -> dict[str, Any]:
             f"{path}: {exc.message}. Rebuild with scripts/build_system_registry_artifact.py."
         ) from exc
     return registry
+
+
+@lru_cache(maxsize=1)
+def _load_ownership_map() -> dict[str, Any]:
+    if not _OWNERSHIP_MAP_PATH.is_file():
+        return {}
+    try:
+        payload = json.loads(_OWNERSHIP_MAP_PATH.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SystemRegistryEnforcerError(f"governed runtime ownership map invalid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise SystemRegistryEnforcerError("governed runtime ownership map must be JSON object")
+    return payload
+
+
+def clear_registry_enforcer_caches() -> None:
+    _load_registry.cache_clear()
+    _registry_indexes.cache_clear()
+    _load_ownership_map.cache_clear()
 
 
 @lru_cache(maxsize=1)
@@ -118,22 +138,41 @@ def validate_system_action(system_name: str, action_type: str, target_system: st
     source_system = systems.get(source)
     target_exists = target in systems
     if source_system is None:
-        violations.append("unknown_source_system")
+        violations.append("E_UNKNOWN_SOURCE_SYSTEM")
     if not target_exists:
-        violations.append("unknown_target_system")
+        violations.append("E_UNKNOWN_TARGET_SYSTEM")
+    if not action:
+        violations.append("E_EMPTY_ACTION_TYPE")
 
     owners = owners_by_action.get(action, [])
     if len(owners) > 1:
-        violations.append("duplicate_action_ownership")
+        violations.append("E_DUPLICATE_ACTION_OWNERSHIP")
     if source_system is not None:
         if action not in source_system.get("owns", []):
-            violations.append("action_not_owned_by_system")
+            violations.append("E_ACTION_NOT_OWNED_BY_SYSTEM")
         if action in source_system.get("prohibited_behaviors", []):
-            violations.append("prohibited_behavior")
+            violations.append("E_PROHIBITED_BEHAVIOR")
+    for system, entry in systems.items():
+        classification = str(entry.get("classification") or "")
+        if classification == "support_only" and action in entry.get("owns", []):
+            violations.append(f"E_SUPPORT_ONLY_OWNS_ACTION:{system}:{action}")
 
     allowed_interaction = (source, target) in allowed_edges or (source, target) in _CANONICAL_HANDOFF_PATH
     if source_system is not None and target_exists and not allowed_interaction:
-        violations.append("interaction_not_allowed")
+        violations.append("E_INTERACTION_NOT_ALLOWED")
+
+    legacy_aliases = {
+        "E_UNKNOWN_SOURCE_SYSTEM": "unknown_source_system",
+        "E_UNKNOWN_TARGET_SYSTEM": "unknown_target_system",
+        "E_DUPLICATE_ACTION_OWNERSHIP": "duplicate_action_ownership",
+        "E_ACTION_NOT_OWNED_BY_SYSTEM": "action_not_owned_by_system",
+        "E_PROHIBITED_BEHAVIOR": "prohibited_behavior",
+        "E_INTERACTION_NOT_ALLOWED": "interaction_not_allowed",
+    }
+    for code in list(violations):
+        alias = legacy_aliases.get(code)
+        if alias:
+            violations.append(alias)
 
     return {
         "allow": len(violations) == 0,
@@ -169,18 +208,18 @@ def validate_system_handoff(from_system: str, to_system: str, artifact: dict[str
     violations.extend(action_check["violation_codes"])
 
     if not isinstance(schema_name, str) or not schema_name.strip():
-        violations.append("missing_schema_name")
+            violations.append("E_MISSING_SCHEMA_NAME")
     else:
         try:
             validate_artifact(payload, schema_name.strip())
         except (ValidationError, FileNotFoundError, TypeError, ValueError):
-            violations.append("artifact_schema_validation_failed")
+            violations.append("E_ARTIFACT_SCHEMA_VALIDATION_FAILED")
 
     missing_required = [
         str(field) for field in required_fields if isinstance(field, str) and field.strip() and not _is_present(payload.get(field))
     ]
     if missing_required:
-        violations.append("missing_required_fields")
+        violations.append("E_MISSING_REQUIRED_FIELDS")
 
     trace_refs = payload.get("trace_refs", [])
     artifact_level_trace_refs = artifact.get("trace_refs", [])
@@ -197,11 +236,23 @@ def validate_system_handoff(from_system: str, to_system: str, artifact: dict[str
         normalized_trace_refs.append(trace_id.strip())
 
     if not normalized_trace_refs:
-        violations.append("missing_trace_continuity")
+        violations.append("E_MISSING_TRACE_CONTINUITY")
     elif expected_trace_refs:
         expected = {str(item).strip() for item in expected_trace_refs if str(item).strip()}
         if expected and expected.isdisjoint(set(normalized_trace_refs)):
-            violations.append("broken_trace_continuity")
+            violations.append("E_BROKEN_TRACE_CONTINUITY")
+
+    legacy_aliases = {
+        "E_MISSING_SCHEMA_NAME": "missing_schema_name",
+        "E_ARTIFACT_SCHEMA_VALIDATION_FAILED": "artifact_schema_validation_failed",
+        "E_MISSING_REQUIRED_FIELDS": "missing_required_fields",
+        "E_MISSING_TRACE_CONTINUITY": "missing_trace_continuity",
+        "E_BROKEN_TRACE_CONTINUITY": "broken_trace_continuity",
+    }
+    for code in list(violations):
+        alias = legacy_aliases.get(code)
+        if alias:
+            violations.append(alias)
 
     return {
         "allow": len(set(violations)) == 0,
@@ -210,4 +261,25 @@ def validate_system_handoff(from_system: str, to_system: str, artifact: dict[str
         "from_system": str(from_system or "").strip().upper(),
         "to_system": str(to_system or "").strip().upper(),
         "schema_name": schema_name,
+    }
+
+
+def validate_artifact_authority(*, emitting_system: str, artifact_type: str) -> dict[str, Any]:
+    source = str(emitting_system or "").strip().upper()
+    artifact = str(artifact_type or "").strip()
+    violations: list[str] = []
+    if not source:
+        violations.append("E_UNKNOWN_SOURCE_SYSTEM")
+    if not artifact:
+        violations.append("E_EMPTY_ARTIFACT_TYPE")
+    if artifact == "closure_decision_artifact" and source != "CDE":
+        violations.append("E_ARTIFACT_AUTHORITY_VIOLATION_CLOSURE_DECISION_CDE_ONLY")
+    if artifact in {"system_registry_artifact", "preflight_block_diagnosis_record"} and source not in {"SEL", "TPA"}:
+        violations.append("E_ARTIFACT_AUTHORITY_VIOLATION_REGISTRY_PREFLIGHT_PATH")
+    return {
+        "allow": len(violations) == 0,
+        "block": len(violations) > 0,
+        "violation_codes": sorted(set(violations)),
+        "system": source,
+        "artifact_type": artifact,
     }

--- a/spectrum_systems/modules/runtime/top_level_conductor.py
+++ b/spectrum_systems/modules/runtime/top_level_conductor.py
@@ -41,7 +41,11 @@ from spectrum_systems.modules.runtime.review_parsing_engine import parse_review_
 from spectrum_systems.modules.runtime.review_projection_adapter import build_review_projection_bundle
 from spectrum_systems.modules.runtime.review_signal_classifier import classify_review_signal
 from spectrum_systems.modules.runtime.review_signal_consumer import build_review_integration_packet
-from spectrum_systems.modules.runtime.system_registry_enforcer import validate_system_action, validate_system_handoff
+from spectrum_systems.modules.runtime.system_registry_enforcer import (
+    validate_artifact_authority,
+    validate_system_action,
+    validate_system_handoff,
+)
 from spectrum_systems.modules.runtime.system_enforcement_layer import enforce_system_boundaries
 from spectrum_systems.modules.runtime.tlc_hardening import (
     build_tlc_orchestration_readiness,
@@ -446,9 +450,13 @@ def _enforce_handoff(
 
 
 def _validate_handoff_output(subsystem: str, result: dict[str, Any]) -> None:
+    if isinstance(result.get("closure_decision_artifact"), dict):
+        authority = validate_artifact_authority(emitting_system=subsystem, artifact_type="closure_decision_artifact")
+        if not authority["allow"]:
+            codes = ",".join(authority["violation_codes"])
+            raise TopLevelConductorError(f"{subsystem} must not emit closure_decision_artifact; authority_violation={codes}")
+
     if subsystem != "CDE":
-        if isinstance(result.get("closure_decision_artifact"), dict):
-            raise TopLevelConductorError(f"{subsystem} must not emit closure_decision_artifact; route closure signals to CDE")
         if isinstance(result.get("decision_type"), str) and result.get("decision_type"):
             raise TopLevelConductorError(f"{subsystem} must not emit decision_type; closure authority is CDE-only")
         if isinstance(result.get("next_step_class"), str) and result.get("next_step_class"):

--- a/tests/test_build_preflight_pqx_wrapper.py
+++ b/tests/test_build_preflight_pqx_wrapper.py
@@ -64,6 +64,7 @@ def test_wrapper_builder_writes_changed_paths_and_resolution(tmp_path: Path, mon
     assert "changed_path_resolution" not in payload
     sidecar = json.loads((tmp_path / "preflight_changed_path_resolution.json").read_text(encoding="utf-8"))
     assert sidecar["trust_level"] == "authoritative"
+    assert sidecar["github_ref_context"]["failure_class"] == "none"
 
 
 def test_wrapper_builder_blocks_on_insufficient_context(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_contract_preflight.py
+++ b/tests/test_contract_preflight.py
@@ -74,6 +74,29 @@ def test_classify_changed_contracts_detects_governed_surfaces() -> None:
     assert classified["changed_governed_definitions"] == ["contracts/review-output.schema.json"]
 
 
+def test_classify_preflight_failure_marks_registry_schema_as_canonicalizable() -> None:
+    failure_class = preflight.classify_preflight_failure(
+        {
+            "status": "failed",
+            "schema_example_failures": [{"path": "contracts/examples/system_registry_artifact.json"}],
+            "missing_required_surface": [],
+        }
+    )
+    assert failure_class == "canonicalizable_registry_or_schema_mismatch"
+
+
+def test_validate_governed_runtime_ownership_flags_unclassified_runtime_paths() -> None:
+    failures = preflight.validate_governed_runtime_ownership(
+        ["spectrum_systems/modules/runtime/new_ownerless_surface.py"]
+    )
+    assert failures == [
+        {
+            "path": "spectrum_systems/modules/runtime/new_ownerless_surface.py",
+            "reason": "missing_governed_runtime_ownership_classification",
+        }
+    ]
+
+
 def test_build_impact_map_includes_required_roadmap_smoke_tests(monkeypatch) -> None:
     def _fake_analyze_contract_impact(**_: object) -> dict[str, object]:
         return {

--- a/tests/test_system_registry_boundary_enforcement.py
+++ b/tests/test_system_registry_boundary_enforcement.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from scripts import validate_system_registry_boundaries as validator
@@ -109,3 +110,19 @@ def test_extended_hardening_unique_owners_enforced(tmp_path: Path) -> None:
 
     errors = validator.run_all_checks(mutated_path)
     assert any("context_bundle_contracts" in error for error in errors)
+
+
+def test_validator_detects_doc_artifact_drift(tmp_path: Path, monkeypatch) -> None:
+    artifact = {
+        "systems": [
+            {
+                "acronym": "ZZZ",
+                "owns": ["execution_admission"],
+            }
+        ]
+    }
+    artifact_path = tmp_path / "system_registry_artifact.json"
+    artifact_path.write_text(json.dumps(artifact), encoding="utf-8")
+    monkeypatch.setattr(validator, "REGISTRY_ARTIFACT_PATH", artifact_path)
+    errors = validator.run_all_checks(REGISTRY_PATH)
+    assert any("registry_doc_artifact_drift" in error for error in errors)

--- a/tests/test_system_registry_enforcer.py
+++ b/tests/test_system_registry_enforcer.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from spectrum_systems.modules.runtime.system_registry_enforcer import (
+    clear_registry_enforcer_caches,
+    validate_artifact_authority,
+    validate_system_action,
+    validate_system_handoff,
+)
+
+
+def test_validate_system_action_allows_valid_owned_edge() -> None:
+    clear_registry_enforcer_caches()
+    result = validate_system_action("TLC", "orchestration", "PQX")
+    assert result["allow"] is True
+    assert result["violation_codes"] == []
+
+
+def test_validate_system_action_blocks_invalid_actor_and_target() -> None:
+    clear_registry_enforcer_caches()
+    result = validate_system_action("BAD", "orchestration", "NOPE")
+    assert result["allow"] is False
+    assert "E_UNKNOWN_SOURCE_SYSTEM" in result["violation_codes"]
+    assert "E_UNKNOWN_TARGET_SYSTEM" in result["violation_codes"]
+
+
+def test_validate_system_handoff_requires_trace_continuity() -> None:
+    clear_registry_enforcer_caches()
+    result = validate_system_handoff(
+        "TLC",
+        "PQX",
+        {
+            "schema_name": "codex_pqx_task_wrapper",
+            "action_type": "orchestration",
+            "payload": {},
+            "required_fields": [],
+            "expected_trace_refs": ["trace:required"],
+        },
+    )
+    assert result["allow"] is False
+    assert "E_MISSING_TRACE_CONTINUITY" in result["violation_codes"]
+
+
+def test_validate_artifact_authority_blocks_non_cde_closure_decision() -> None:
+    result = validate_artifact_authority(emitting_system="PQX", artifact_type="closure_decision_artifact")
+    assert result["allow"] is False
+    assert "E_ARTIFACT_AUTHORITY_VIOLATION_CLOSURE_DECISION_CDE_ONLY" in result["violation_codes"]

--- a/tests/test_validate_governed_runtime_ownership.py
+++ b/tests/test_validate_governed_runtime_ownership.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from scripts import validate_governed_runtime_ownership as validator
+
+
+def test_validate_paths_fails_for_unclassified_governed_runtime_path() -> None:
+    failures = validator.validate_paths(["spectrum_systems/modules/runtime/new_governed_surface.py"])
+    assert failures
+    assert failures[0].startswith("ownership_classification_missing:")
+
+
+def test_validate_paths_allows_classified_paths() -> None:
+    failures = validator.validate_paths(
+        [
+            "spectrum_systems/modules/runtime/system_registry_enforcer.py",
+            "scripts/run_contract_preflight.py",
+            "docs/architecture/system_registry.md",
+        ]
+    )
+    assert failures == []


### PR DESCRIPTION
### Motivation
- Ensure every governed runtime behavior maps to exactly one 3-letter owning system and prevent helpers/support code from silently becoming authorities. 
- Strengthen the existing canonical registry seam (doc + artifact + builder + schema) so malformed registry state is canonicalized, validated, and fail-closed before runtime use. 
- Move preflight from immediate escalation to a classify → bounded repair → rerun → escalate flow for canonicalizable failures. 
- Make artifact-authority boundaries explicit (CDE-only closure decisions, registry/prefight artifact emission paths) and add admission checks for new governed runtime code.

### Description
- Canonical registry hardening: `scripts/build_system_registry_artifact.py` now deterministically dedupes/sorts set-like fields and interaction edges and writes a canonical artifact used at runtime; schema text updated to document these constraints. 
- Doc ↔ artifact drift and protected-owner validation: `scripts/validate_system_registry_boundaries.py` now detects doc/artifact drift and enforces protected ownership invariants (PQX/AEX/FRE/RIL/CDE/SEL/TLC). 
- Runtime enforcement: `spectrum_systems/modules/runtime/system_registry_enforcer.py` gained stricter, machine-readable violation codes, legacy aliases for compatibility, cache-clear helper, and a `validate_artifact_authority()` guard for high-risk artifacts. 
- Orchestration/closure hardening: `top_level_conductor.py` and `github_closure_continuation.py` now consult artifact-authority checks and fail-closed if non-authoritative subsystems attempt to emit closure artifacts. 
- Preflight and autofix improvements: `scripts/run_contract_preflight.py` adds structured failure classification and calls a governed-runtime ownership validator; `scripts/build_preflight_pqx_wrapper.py` emits GitHub ref-context in its sidecar; `github_pr_autofix_contract_preflight.py` bounds the schema-violation repair path to run a canonical registry rebuild before rerun. 
- New admission policy: added `docs/governance/three_letter_ownership_policy.md` and a machine-readable `docs/governance/governed_runtime_ownership_map.json` plus `scripts/validate_governed_runtime_ownership.py` to fail-closed on new governed runtime/script paths that lack a 3-letter owner or explicit `support_only` classification. 
- Docs, plan, and review artifacts: updated `docs/architecture/system_registry.md`, `docs/roadmaps/system_roadmap.md`, `AGENTS.md`, and added `docs/review-actions/PLAN-3LS-50-2026-04-14.md` and `docs/reviews/REVIEW-3LS-50-2026-04-14.md`. 
- Tests: new and updated tests were added/modified to exercise builder canonicalization, drift detection, runtime enforcement, artifact-authority blocking, preflight classification, wrapper sidecar context, and the admission validator. Files added include `scripts/validate_governed_runtime_ownership.py`, `docs/governance/*`, and tests `tests/test_system_registry_enforcer.py` and `tests/test_validate_governed_runtime_ownership.py`.

### Testing
- Ran targeted suites during development: `pytest tests/test_system_registry_boundaries.py tests/test_system_registry_boundary_enforcement.py tests/test_system_registry_enforcer.py` (all passed). 
- Ran preflight/autofix/wrapper targeted tests: `pytest tests/test_contract_preflight.py tests/test_build_preflight_pqx_wrapper.py tests/test_github_pr_autofix_contract_preflight.py tests/test_validate_governed_runtime_ownership.py` (all passed). 
- Verified runtime handoff and authority tests: `pytest tests/test_system_handoff_integrity.py::test_registry_enforcement_duplicate_ownership_and_prohibited_behavior` and enforcer tests (passed). 
- Full test suite: `pytest` executed and completed successfully with `6584 passed, 1 skipped`.
- Canonical builder executed: `python scripts/build_system_registry_artifact.py --input contracts/examples/system_registry_artifact.json --output contracts/examples/system_registry_artifact.json` returned success and produced a normalized artifact used by runtime enforcement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dde00a650083299fdaaebf1fae7597)