### PR TITLE
PRF-07: deterministic preflight failure normalization and repair routing

### DIFF
--- a/.github/workflows/artifact-boundary.yml
+++ b/.github/workflows/artifact-boundary.yml
@@ -147,6 +147,23 @@ PY
             --authority-evidence-ref artifacts/pqx_runs/preflight.pqx_slice_execution_record.json \
             --same-repo-write-allowed
 
+          # Preflight is the canonical authority for PR pytest execution truth.
+          python - <<'PY'
+import json
+import os
+from pathlib import Path
+
+artifact = Path("outputs/contract_preflight/contract_preflight_result_artifact.json")
+if not artifact.is_file():
+    raise SystemExit("missing contract_preflight_result_artifact.json")
+payload = json.loads(artifact.read_text(encoding="utf-8"))
+decision = str((payload.get("control_signal") or {}).get("strategy_gate_decision") or "BLOCK")
+execution = payload.get("pytest_execution") or {}
+count = int(execution.get("pytest_execution_count") or 0)
+if os.environ.get("GITHUB_EVENT_NAME") == "pull_request" and decision in {"ALLOW", "WARN"} and count < 1:
+    raise SystemExit("workflow/preflight trust mismatch: PR allow without preflight-owned pytest execution")
+PY
+
       - name: Upload contract preflight outputs
         if: always()
         uses: actions/upload-artifact@v4
@@ -225,4 +242,6 @@ PY
         run: python -m pip install -r requirements-dev.txt
 
       - name: Run pytest
+        # Non-authoritative redundancy signal only.
+        # PR gating execution truth is owned by contract-preflight artifacts.
         run: pytest

--- a/.github/workflows/pr-autofix-contract-preflight.yml
+++ b/.github/workflows/pr-autofix-contract-preflight.yml
@@ -134,6 +134,9 @@ jobs:
               raise SystemExit("missing contract_preflight_result_artifact.json")
           payload = json.loads(result.read_text(encoding="utf-8"))
           initial = payload.get("control_signal", {}).get("strategy_gate_decision", "BLOCK")
+          pytest_count = int(((payload.get("pytest_execution") or {}).get("pytest_execution_count") or 0))
+          if initial in {"ALLOW", "WARN"} and pytest_count < 1:
+              raise SystemExit("workflow/preflight trust mismatch: allow decision missing preflight-owned pytest execution")
           if initial != "BLOCK":
               raise SystemExit(0 if initial in {"ALLOW", "WARN"} else 2)
           outcome_path = out / "preflight_recovery_outcome_record.json"

--- a/contracts/examples/contract_preflight_result_artifact.json
+++ b/contracts/examples/contract_preflight_result_artifact.json
@@ -51,7 +51,8 @@
     ],
     "fallback_used": false,
     "targeted_selection_empty": false,
-    "fallback_selection_empty": false
+    "fallback_selection_empty": false,
+    "selection_reason_codes": []
   },
   "pqx_required_context_enforcement": {
     "classification": "governed_pqx_required",

--- a/contracts/examples/contract_preflight_result_artifact.json
+++ b/contracts/examples/contract_preflight_result_artifact.json
@@ -35,6 +35,24 @@
   "control_surface_gap_result_ref": "outputs/contract_preflight/control_surface_gap_result.json",
   "pqx_gap_work_items_ref": "outputs/contract_preflight/control_surface_gap_pqx_work_items.json",
   "control_surface_gap_blocking": false,
+  "pytest_execution": {
+    "event_name": "pull_request",
+    "pytest_execution_count": 2,
+    "pytest_commands": [
+      "/usr/bin/python3 -m pytest -q tests/test_run_github_pr_autofix_contract_preflight.py"
+    ],
+    "selected_targets": [
+      "tests/test_run_github_pr_autofix_contract_preflight.py"
+    ],
+    "fallback_targets": [
+      "tests/test_run_github_pr_autofix_contract_preflight.py",
+      "tests/test_eval_dataset_registry.py",
+      "tests/test_contracts.py"
+    ],
+    "fallback_used": false,
+    "targeted_selection_empty": false,
+    "fallback_selection_empty": false
+  },
   "pqx_required_context_enforcement": {
     "classification": "governed_pqx_required",
     "execution_context": "pqx_governed",

--- a/contracts/schemas/contract_preflight_result_artifact.schema.json
+++ b/contracts/schemas/contract_preflight_result_artifact.schema.json
@@ -21,6 +21,7 @@
     "control_surface_gap_result_ref",
     "pqx_gap_work_items_ref",
     "control_surface_gap_blocking",
+    "pytest_execution",
     "pqx_required_context_enforcement",
     "control_signal",
     "trace"
@@ -131,6 +132,41 @@
     },
     "control_surface_gap_blocking": {
       "type": "boolean"
+    },
+    "pytest_execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "event_name",
+        "pytest_execution_count",
+        "pytest_commands",
+        "selected_targets",
+        "fallback_targets",
+        "fallback_used",
+        "targeted_selection_empty",
+        "fallback_selection_empty"
+      ],
+      "properties": {
+        "event_name": {"type": "string"},
+        "pytest_execution_count": {"type": "integer", "minimum": 0},
+        "pytest_commands": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1}
+        },
+        "selected_targets": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true
+        },
+        "fallback_targets": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true
+        },
+        "fallback_used": {"type": "boolean"},
+        "targeted_selection_empty": {"type": "boolean"},
+        "fallback_selection_empty": {"type": "boolean"}
+      }
     },
     "pqx_required_context_enforcement": {
       "type": "object",

--- a/contracts/schemas/contract_preflight_result_artifact.schema.json
+++ b/contracts/schemas/contract_preflight_result_artifact.schema.json
@@ -144,7 +144,8 @@
         "fallback_targets",
         "fallback_used",
         "targeted_selection_empty",
-        "fallback_selection_empty"
+        "fallback_selection_empty",
+        "selection_reason_codes"
       ],
       "properties": {
         "event_name": {"type": "string"},
@@ -165,7 +166,12 @@
         },
         "fallback_used": {"type": "boolean"},
         "targeted_selection_empty": {"type": "boolean"},
-        "fallback_selection_empty": {"type": "boolean"}
+        "fallback_selection_empty": {"type": "boolean"},
+        "selection_reason_codes": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true
+        }
       }
     },
     "pqx_required_context_enforcement": {

--- a/contracts/schemas/failure_repair_candidate_artifact.schema.json
+++ b/contracts/schemas/failure_repair_candidate_artifact.schema.json
@@ -68,7 +68,9 @@
         "accidental_filtering_detected",
         "non_repairable_policy_violation",
         "internal_preflight_error",
-        "unknown_preflight_failure"
+        "test_inventory_regression",
+        "control_surface_gap",
+        "downstream_test_failure"
       ]
     },
     "safe_to_repair": {

--- a/contracts/schemas/preflight_block_diagnosis_record.schema.json
+++ b/contracts/schemas/preflight_block_diagnosis_record.schema.json
@@ -11,7 +11,8 @@
     "strategy_gate_decision",
     "failure_class",
     "reason_codes",
-    "root_cause_summary"
+    "root_cause_summary",
+    "normalized_failure"
   ],
   "properties": {
     "artifact_type": {
@@ -55,7 +56,9 @@
         "accidental_filtering_detected",
         "non_repairable_policy_violation",
         "internal_preflight_error",
-        "unknown_preflight_failure"
+        "test_inventory_regression",
+        "control_surface_gap",
+        "downstream_test_failure"
       ]
     },
     "reason_codes": {
@@ -68,6 +71,15 @@
     "root_cause_summary": {
       "type": "string",
       "minLength": 1
+    },
+    "normalized_failure": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["failure_class", "repairable"],
+      "properties": {
+        "failure_class": {"type": "string", "minLength": 1},
+        "repairable": {"type": "boolean"}
+      }
     }
   }
 }

--- a/docs/review-actions/PLAN-PRF-07-2026-04-14.md
+++ b/docs/review-actions/PLAN-PRF-07-2026-04-14.md
@@ -1,0 +1,15 @@
+# PLAN-PRF-07-2026-04-14
+
+## Primary prompt type
+BUILD
+
+## Scope
+Implement deterministic preflight failure normalization, remove unknown failure classification paths, and wire repair eligibility to normalized repairability.
+
+## Execution steps
+1. Add `spectrum_systems/modules/runtime/preflight_failure_normalizer.py` with deterministic signal mapping and fail-closed fallback class.
+2. Update `scripts/run_contract_preflight.py` to use normalized failure output, persist `report["normalized_failure"]`, and assert unknown failure classes are never emitted.
+3. Update `spectrum_systems/modules/runtime/github_pr_autofix_contract_preflight.py` to consume normalized classification and gate auto-repair via `normalized_failure["repairable"]`.
+4. Replace all repository occurrences of the legacy unknown preflight class token with `internal_preflight_error`.
+5. Add targeted unit tests in `tests/test_preflight_failure_normalizer.py` and adjust affected preflight/autofix tests.
+6. Run deterministic test surface for changed areas.

--- a/docs/review-actions/PLAN-PRF-07-FIX-2026-04-14.md
+++ b/docs/review-actions/PLAN-PRF-07-FIX-2026-04-14.md
@@ -1,0 +1,16 @@
+# PLAN-PRF-07-FIX-2026-04-14
+
+## Primary prompt type
+BUILD
+
+## Scope
+Fail-closed hardening for contract preflight so pull_request preflight can never pass without real pytest execution.
+
+## Execution steps
+1. Trace preflight execution paths to identify why `pull_request` can return passed without executing pytest.
+2. Add deterministic pytest execution accounting in `scripts/run_contract_preflight.py` and enforce PR-only invariant (`pytest_execution_count >= 1` for pass).
+3. Add governed fallback pytest suite for empty targeted selection; block with deterministic invariant codes when fallback cannot execute.
+4. Propagate execution accounting into report/artifact surfaces and deterministic failure normalization/classification.
+5. Update autofix classification/repair planning for deterministic pytest selection/inventory failures.
+6. Add and restore tests in preflight/autofix seams to prove end-to-end invariant behavior.
+7. Run required and targeted test suites.

--- a/docs/review-actions/PLAN-PYX-01-2026-04-14.md
+++ b/docs/review-actions/PLAN-PYX-01-2026-04-14.md
@@ -1,0 +1,16 @@
+# PLAN-PYX-01-2026-04-14
+
+## Primary prompt type
+BUILD
+
+## Scope
+Architectural hardening so governed contract preflight is the canonical authority for PR pytest execution truth and CI workflows cannot imply equivalent gating authority.
+
+## Execution steps
+1. Inspect current preflight/autofix/workflow seams to identify remaining authority split between decision and execution.
+2. Harden `scripts/run_contract_preflight.py` invariants and execution accounting reason codes for PR gating truth.
+3. Align autofix classification/normalization to preserve deterministic execution-truth failure classes.
+4. Update workflow files to explicitly declare preflight as PR gating execution authority and keep any broad pytest jobs as non-authoritative redundancy.
+5. Add/update tests for preflight invariants, artifact accounting fields, autofix classification, and workflow-facing block behavior.
+6. Write review artifact at `docs/reviews/PYX-01-preflight-pytest-authority-hardening.md`.
+7. Run required targeted tests and validate contracts/schemas impacted by artifact changes.

--- a/docs/reviews/PYX-01-preflight-pytest-authority-hardening.md
+++ b/docs/reviews/PYX-01-preflight-pytest-authority-hardening.md
@@ -1,0 +1,42 @@
+# PYX-01 — Preflight Pytest Authority Hardening
+
+## Problem statement
+Governed contract preflight previously allowed architectural ambiguity between decision authority (preflight status/control signal) and execution authority (pytest runs in separate CI jobs). This could make PR trust signals appear stronger than preflight-owned execution truth.
+
+## Root cause
+1. Preflight and workflows both executed test-related logic, but only preflight should own PR gating execution truth.
+2. Workflow topology allowed interpretation that downstream `run-pytest` evidence was equivalent to preflight execution evidence.
+3. Trust-critical invariant language was not explicit enough about authority ownership boundaries.
+
+## Before vs after authority model
+
+### Before
+- `run_contract_preflight.py` made allow/block decisions.
+- Separate CI jobs could run pytest later.
+- Authority seam was ambiguous: downstream pytest looked like gating evidence.
+
+### After
+- `run_contract_preflight.py` is the canonical owner of governed PR pytest execution truth.
+- Preflight artifacts persist structured execution accounting (`pytest_execution`).
+- PR allow/warn paths require preflight-owned execution count >= 1.
+- Workflow checks explicitly validate preflight-owned execution accounting and fail closed on mismatch.
+- `run-pytest` remains only a redundancy/health signal, not gating authority.
+
+## Invariants
+- `PR_PYTEST_EXECUTION_REQUIRED`
+- `PR_PYTEST_FALLBACK_TARGETS_EMPTY`
+- `PR_PYTEST_SELECTED_TARGETS_EMPTY` (selection reason code)
+- `PREFLIGHT_PASS_WITHOUT_PYTEST_EXECUTION`
+
+## Failure modes blocked
+- PR allow/pass without any preflight-owned pytest execution.
+- Empty targeted selection silently passing without governed fallback attempt.
+- Empty fallback selection allowing ambiguous pass behavior.
+- Workflow acceptance of allow/warn without preflight-owned execution accounting.
+
+## Remaining risks
+- Governance fallback target files can drift (rename/remove), which now fails closed (desired) and requires maintenance updates.
+- Future workflow edits must preserve explicit authority comments and checks to avoid reintroducing trust seams.
+
+## Recommended next follow-on step
+Add a CI policy/lint check that enforces presence of workflow comments + trust-check script snippets where contract preflight jobs are defined, preventing accidental removal of authority-boundary checks.

--- a/scripts/run_contract_preflight.py
+++ b/scripts/run_contract_preflight.py
@@ -128,6 +128,11 @@ _SYSTEM_REGISTRY_PATH = REPO_ROOT / "docs" / "architecture" / "system_registry.m
 _SYSTEM_REGISTRY_GUARD_POLICY_PATH = REPO_ROOT / "contracts" / "governance" / "system_registry_guard_policy.json"
 _TEST_INVENTORY_BASELINE_PATH = REPO_ROOT / "docs" / "governance" / "pytest_pr_inventory_baseline.json"
 _DEFAULT_PR_INVENTORY_TARGETS = ["tests/test_eval_dataset_registry.py"]
+_GOVERNED_PR_FALLBACK_PYTEST_TARGETS = [
+    "tests/test_run_github_pr_autofix_contract_preflight.py",
+    "tests/test_eval_dataset_registry.py",
+    "tests/test_contracts.py",
+]
 
 _REQUIRED_SURFACE_TEST_OVERRIDES: dict[str, list[str]] = {
     "scripts/run_autonomous_validation_run.py": ["tests/test_run_autonomous_validation_run.py"],
@@ -698,11 +703,17 @@ def validate_examples(changed_example_paths: list[str]) -> list[dict[str, Any]]:
     return failures
 
 
-def run_targeted_pytests(paths: list[str]) -> list[dict[str, Any]]:
+def _resolve_existing_pytest_targets(paths: list[str]) -> list[str]:
+    return sorted({path for path in paths if (REPO_ROOT / path).is_file()})
+
+
+def run_targeted_pytests(paths: list[str], *, execution_log: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
     failures: list[dict[str, Any]] = []
     for path in paths:
         cmd = [sys.executable, "-m", "pytest", "-q", path]
         result = _run(cmd, cwd=REPO_ROOT)
+        if execution_log is not None:
+            execution_log.append({"target": path, "command": " ".join(cmd), "returncode": result.returncode})
         if result.returncode != 0:
             failures.append(
                 {
@@ -772,6 +783,11 @@ def render_markdown(report: dict[str, Any]) -> str:
         lines.append(f"- **test_inventory_failure_class**: {test_inventory.get('failure_class', 'unknown')}")
         lines.append(f"- **test_inventory_selected_count**: {test_inventory.get('selected_count', 0)}")
         lines.append(f"- **test_inventory_baseline_expected_count**: {test_inventory.get('baseline_expected_count', 0)}")
+    pytest_execution = report.get("pytest_execution")
+    if isinstance(pytest_execution, dict):
+        lines.append(f"- **pytest_execution_count**: {pytest_execution.get('pytest_execution_count', 0)}")
+        lines.append(f"- **pytest_fallback_used**: {pytest_execution.get('fallback_used', False)}")
+        lines.append(f"- **pytest_selected_target_count**: {len(pytest_execution.get('selected_targets', []))}")
 
     lines.append("")
     pqx_execution_policy = report.get("pqx_execution_policy")
@@ -1233,6 +1249,7 @@ def build_preflight_result_artifact(
         "control_surface_gap_result_ref": report.get("control_surface_gap_result_ref"),
         "pqx_gap_work_items_ref": report.get("pqx_gap_work_items_ref"),
         "control_surface_gap_blocking": bool(report.get("control_surface_gap_blocking", False)),
+        "pytest_execution": report.get("pytest_execution", {}),
         "pqx_required_context_enforcement": {
             "classification": str(required_context.get("classification", "exploration_only_or_non_governed")),
             "execution_context": str(required_context.get("execution_context", "unspecified")),
@@ -1315,6 +1332,16 @@ def main() -> int:
             "pqx_required_context_enforcement": {"status": "block", "blocking_reasons": [str(ref_context.reason_code or "malformed_ref_context")]},
             "system_registry_guard_result": {"artifact_type": "system_registry_guard_result", "status": "pass", "normalized_reason_codes": []},
             "system_registry_guard_result_ref": None,
+            "pytest_execution": {
+                "event_name": str(ref_context.event_name or ""),
+                "pytest_execution_count": 0,
+                "pytest_commands": [],
+                "selected_targets": [],
+                "fallback_targets": [],
+                "fallback_used": False,
+                "targeted_selection_empty": True,
+                "fallback_selection_empty": False,
+            },
             "ref_context": ref_context.as_dict(),
             "root_cause_classification": {"failure_class": "missing_required_artifact", "reason_codes": [str(ref_context.reason_code or "malformed_ref_context")]},
             "repair_eligibility_rationale": "auto_repair_allowed: normalized ref context unavailable and must be reconstructed with bounded inputs",
@@ -1529,6 +1556,13 @@ def main() -> int:
     test_inventory_artifact_path = output_dir / "test_inventory_integrity_result.json"
     test_inventory_artifact_path.parent.mkdir(parents=True, exist_ok=True)
     test_inventory_artifact_path.write_text(json.dumps(test_inventory_payload, indent=2) + "\n", encoding="utf-8")
+    is_pull_request_event = str(ref_context.event_name or "").strip() == "pull_request"
+    pytest_execution_log: list[dict[str, Any]] = []
+    selected_pytest_targets: list[str] = []
+    fallback_pytest_targets: list[str] = []
+    fallback_pytest_used = False
+    targeted_selection_empty = False
+    fallback_selection_empty = False
 
     if detection.changed_path_detection_mode == "detection_failed_no_governed_paths":
         detection_invariants = ["changed-path detection failed before evaluation"]
@@ -1645,9 +1679,11 @@ def main() -> int:
         forced_targets = sorted({target for targets in forced_eval_targets_by_path.values() for target in targets})
 
         producer_eval_targets = sorted(set(producer_targets + forced_targets))
-        producer_failures = run_targeted_pytests(producer_eval_targets) if producer_eval_targets else []
-        fixture_failures = run_targeted_pytests(fixture_targets) if fixture_targets else []
-        consumer_failures = run_targeted_pytests(smoke_targets) if smoke_targets else []
+        selected_pytest_targets = sorted(set(producer_eval_targets + fixture_targets + smoke_targets))
+        targeted_selection_empty = len(selected_pytest_targets) == 0
+        producer_failures = run_targeted_pytests(producer_eval_targets, execution_log=pytest_execution_log) if producer_eval_targets else []
+        fixture_failures = run_targeted_pytests(fixture_targets, execution_log=pytest_execution_log) if fixture_targets else []
+        consumer_failures = run_targeted_pytests(smoke_targets, execution_log=pytest_execution_log) if smoke_targets else []
 
         masked_failures = detect_masked_failures(producer_failures + fixture_failures + consumer_failures)
 
@@ -1699,17 +1735,51 @@ def main() -> int:
             "test_inventory_integrity": test_inventory_payload,
             "test_inventory_integrity_result_ref": str(test_inventory_artifact_path),
         }
-        if report["control_surface_enforcement"] and report["control_surface_enforcement"].get("enforcement_status") == "BLOCK":
+    if is_pull_request_event and report.get("status") == "passed" and not pytest_execution_log:
+        fallback_pytest_targets = _resolve_existing_pytest_targets(_GOVERNED_PR_FALLBACK_PYTEST_TARGETS)
+        fallback_pytest_used = True
+        fallback_selection_empty = len(fallback_pytest_targets) == 0
+        if fallback_pytest_targets:
+            fallback_failures = run_targeted_pytests(fallback_pytest_targets, execution_log=pytest_execution_log)
+            if fallback_failures:
+                report["status"] = "failed"
+                report["consumer_failures"] = sorted(
+                    list(report.get("consumer_failures", [])) + fallback_failures,
+                    key=lambda entry: str(entry.get("path", "")) if isinstance(entry, dict) else str(entry),
+                )
+                report["recommended_repair_areas"] = sorted(
+                    set(report.get("recommended_repair_areas", []) + ["governed fallback PR pytest suite"])
+                )
+        else:
             report["status"] = "failed"
             report["invariant_violations"] = sorted(
-                set(
-                    report.get("invariant_violations", [])
-                    + report["control_surface_enforcement"].get("blocking_reasons", [])
-                )
+                set(report.get("invariant_violations", []) + ["PR_PYTEST_FALLBACK_TARGETS_EMPTY"])
             )
             report["recommended_repair_areas"] = sorted(
-                set(report["recommended_repair_areas"] + ["control surface manifest required coverage mappings"])
+                set(report.get("recommended_repair_areas", []) + ["restore governed PR fallback pytest suite"])
             )
+
+    report["pytest_execution"] = {
+        "event_name": str(ref_context.event_name or ""),
+        "pytest_execution_count": len(pytest_execution_log),
+        "pytest_commands": [str(entry.get("command", "")) for entry in pytest_execution_log],
+        "selected_targets": selected_pytest_targets,
+        "fallback_targets": fallback_pytest_targets,
+        "fallback_used": fallback_pytest_used,
+        "targeted_selection_empty": targeted_selection_empty,
+        "fallback_selection_empty": fallback_selection_empty,
+    }
+    if report["control_surface_enforcement"] and report["control_surface_enforcement"].get("enforcement_status") == "BLOCK":
+        report["status"] = "failed"
+        report["invariant_violations"] = sorted(
+            set(
+                report.get("invariant_violations", [])
+                + report["control_surface_enforcement"].get("blocking_reasons", [])
+            )
+        )
+        report["recommended_repair_areas"] = sorted(
+            set(report["recommended_repair_areas"] + ["control surface manifest required coverage mappings"])
+        )
     report["control_surface_gap_status"] = control_surface_gap_bridge["status"]
     report["control_surface_gap_result_ref"] = control_surface_gap_bridge["gap_result_path"]
     report["pqx_gap_work_items_ref"] = control_surface_gap_bridge["pqx_work_items_path"]
@@ -1759,6 +1829,16 @@ def main() -> int:
         )
         report["recommended_repair_areas"] = sorted(
             set(report.get("recommended_repair_areas", []) + ["trust-spine evidence cohesion"])
+        )
+    pytest_execution = report.get("pytest_execution", {})
+    pytest_execution_count = int(pytest_execution.get("pytest_execution_count", 0)) if isinstance(pytest_execution, dict) else 0
+    if is_pull_request_event and report.get("status") == "passed" and pytest_execution_count < 1:
+        report["status"] = "failed"
+        report["invariant_violations"] = sorted(
+            set(report.get("invariant_violations", []) + ["PR_PYTEST_EXECUTION_REQUIRED"])
+        )
+        report["recommended_repair_areas"] = sorted(
+            set(report.get("recommended_repair_areas", []) + ["run governed PR pytest execution before ALLOW"])
         )
 
     control_signal = map_preflight_control_signal(report=report, hardening_flow=bool(args.hardening_flow))

--- a/scripts/run_contract_preflight.py
+++ b/scripts/run_contract_preflight.py
@@ -53,8 +53,10 @@ from spectrum_systems.modules.runtime.trust_spine_evidence_cohesion import (  # 
     evaluate_trust_spine_evidence_cohesion,
 )
 from spectrum_systems.modules.runtime.github_pr_autofix_contract_preflight import (  # noqa: E402
-    classify_preflight_block,
     emit_preflight_block_bundle,
+)
+from spectrum_systems.modules.runtime.preflight_failure_normalizer import (  # noqa: E402
+    normalize_preflight_failure,
 )
 from spectrum_systems.modules.governance.system_registry_guard import (  # noqa: E402
     evaluate_system_registry_guard,
@@ -1765,15 +1767,32 @@ def main() -> int:
     classification_exception: str | None = None
     if report["status"] == "failed":
         try:
-            failure_class, reason_codes = classify_preflight_block(report=report)
+            normalized = normalize_preflight_failure(report)
+            failure_class = normalized["failure_class"]
+            reason_codes = list(report.get("invariant_violations", []))
+            report["normalized_failure"] = normalized
         except Exception as exc:  # defensive fail-closed annotation only
+            normalized = {
+                "failure_class": "internal_preflight_error",
+                "signals": {},
+                "repairable": False,
+            }
             failure_class, reason_codes = "internal_preflight_error", ["preflight_runtime_exception"]
+            report["normalized_failure"] = normalized
             classification_exception = str(exc)
         report["root_cause_classification"] = {
             "failure_class": failure_class,
             "reason_codes": reason_codes,
         }
-        if failure_class in {"missing_required_artifact", "contract_mismatch", "schema_violation", "invalid_wrapper", "authority_evidence_missing"}:
+        assert report["root_cause_classification"]["failure_class"] in {
+            "schema_violation",
+            "contract_mismatch",
+            "test_inventory_regression",
+            "control_surface_gap",
+            "downstream_test_failure",
+            "internal_preflight_error",
+        }
+        if report["normalized_failure"]["repairable"]:
             report["repair_eligibility_rationale"] = "auto_repair_allowed: deterministic bounded failure classification"
         else:
             report["repair_eligibility_rationale"] = "escalation_required: non-repairable policy or unbounded runtime failure"

--- a/scripts/run_contract_preflight.py
+++ b/scripts/run_contract_preflight.py
@@ -1341,6 +1341,7 @@ def main() -> int:
                 "fallback_used": False,
                 "targeted_selection_empty": True,
                 "fallback_selection_empty": False,
+                "selection_reason_codes": [],
             },
             "ref_context": ref_context.as_dict(),
             "root_cause_classification": {"failure_class": "missing_required_artifact", "reason_codes": [str(ref_context.reason_code or "malformed_ref_context")]},
@@ -1563,6 +1564,7 @@ def main() -> int:
     fallback_pytest_used = False
     targeted_selection_empty = False
     fallback_selection_empty = False
+    pytest_selection_reason_codes: list[str] = []
 
     if detection.changed_path_detection_mode == "detection_failed_no_governed_paths":
         detection_invariants = ["changed-path detection failed before evaluation"]
@@ -1681,6 +1683,8 @@ def main() -> int:
         producer_eval_targets = sorted(set(producer_targets + forced_targets))
         selected_pytest_targets = sorted(set(producer_eval_targets + fixture_targets + smoke_targets))
         targeted_selection_empty = len(selected_pytest_targets) == 0
+        if is_pull_request_event and targeted_selection_empty:
+            pytest_selection_reason_codes.append("PR_PYTEST_SELECTED_TARGETS_EMPTY")
         producer_failures = run_targeted_pytests(producer_eval_targets, execution_log=pytest_execution_log) if producer_eval_targets else []
         fixture_failures = run_targeted_pytests(fixture_targets, execution_log=pytest_execution_log) if fixture_targets else []
         consumer_failures = run_targeted_pytests(smoke_targets, execution_log=pytest_execution_log) if smoke_targets else []
@@ -1738,6 +1742,8 @@ def main() -> int:
     if is_pull_request_event and report.get("status") == "passed" and not pytest_execution_log:
         fallback_pytest_targets = _resolve_existing_pytest_targets(_GOVERNED_PR_FALLBACK_PYTEST_TARGETS)
         fallback_pytest_used = True
+        if "PR_PYTEST_SELECTED_TARGETS_EMPTY" not in pytest_selection_reason_codes:
+            pytest_selection_reason_codes.append("PR_PYTEST_SELECTED_TARGETS_EMPTY")
         fallback_selection_empty = len(fallback_pytest_targets) == 0
         if fallback_pytest_targets:
             fallback_failures = run_targeted_pytests(fallback_pytest_targets, execution_log=pytest_execution_log)
@@ -1768,6 +1774,7 @@ def main() -> int:
         "fallback_used": fallback_pytest_used,
         "targeted_selection_empty": targeted_selection_empty,
         "fallback_selection_empty": fallback_selection_empty,
+        "selection_reason_codes": sorted(set(pytest_selection_reason_codes)),
     }
     if report["control_surface_enforcement"] and report["control_surface_enforcement"].get("enforcement_status") == "BLOCK":
         report["status"] = "failed"
@@ -1835,7 +1842,10 @@ def main() -> int:
     if is_pull_request_event and report.get("status") == "passed" and pytest_execution_count < 1:
         report["status"] = "failed"
         report["invariant_violations"] = sorted(
-            set(report.get("invariant_violations", []) + ["PR_PYTEST_EXECUTION_REQUIRED"])
+            set(
+                report.get("invariant_violations", [])
+                + ["PR_PYTEST_EXECUTION_REQUIRED", "PREFLIGHT_PASS_WITHOUT_PYTEST_EXECUTION"]
+            )
         )
         report["recommended_repair_areas"] = sorted(
             set(report.get("recommended_repair_areas", []) + ["run governed PR pytest execution before ALLOW"])

--- a/spectrum_systems/modules/runtime/github_pr_autofix_contract_preflight.py
+++ b/spectrum_systems/modules/runtime/github_pr_autofix_contract_preflight.py
@@ -207,6 +207,10 @@ def classify_preflight_block(*, report: dict[str, Any]) -> tuple[str, list[str]]
     if invariant_violations:
         if "PR_PYTEST_EXECUTION_REQUIRED" in invariant_violations:
             return "no_tests_discovered", ["PR_PYTEST_EXECUTION_REQUIRED"]
+        if "PREFLIGHT_PASS_WITHOUT_PYTEST_EXECUTION" in invariant_violations:
+            return "no_tests_discovered", ["PREFLIGHT_PASS_WITHOUT_PYTEST_EXECUTION"]
+        if "PR_PYTEST_SELECTED_TARGETS_EMPTY" in invariant_violations:
+            return "no_tests_discovered", ["PR_PYTEST_SELECTED_TARGETS_EMPTY"]
         if "PR_PYTEST_FALLBACK_TARGETS_EMPTY" in invariant_violations:
             return "no_tests_discovered", ["PR_PYTEST_FALLBACK_TARGETS_EMPTY"]
         if "artifact_validation_failure" in invariant_violations:

--- a/spectrum_systems/modules/runtime/github_pr_autofix_contract_preflight.py
+++ b/spectrum_systems/modules/runtime/github_pr_autofix_contract_preflight.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from spectrum_systems.contracts import validate_artifact
+from spectrum_systems.modules.runtime.preflight_failure_normalizer import normalize_preflight_failure
 
 
 class ContractPreflightAutofixError(RuntimeError):
@@ -25,7 +26,6 @@ KNOWN_REPAIR_CATEGORIES = {
     "invalid_wrapper",
     "non_repairable_policy_violation",
     "internal_preflight_error",
-    "unknown_preflight_failure",
     "pytest_config_missing",
     "pytest_config_mismatch",
     "testpaths_missing",
@@ -35,6 +35,9 @@ KNOWN_REPAIR_CATEGORIES = {
     "collection_failure",
     "working_directory_mismatch",
     "accidental_filtering_detected",
+    "test_inventory_regression",
+    "control_surface_gap",
+    "downstream_test_failure",
 }
 
 TERMINAL_STATES = {
@@ -86,7 +89,7 @@ def _write_recovery_outcome(
         "artifact_type": "preflight_recovery_outcome_record",
         "schema_version": "1.1.0",
         "initial_preflight_status": str(result_artifact.get("preflight_status") or "failed"),
-        "failure_class": str(diagnosis.get("failure_class") or "unknown_preflight_failure"),
+        "failure_class": str(diagnosis.get("failure_class") or "internal_preflight_error"),
         "eligibility_decision": str(plan.get("eligibility_decision") or "escalation_required"),
         "repair_invoked": bool(repair_invoked),
         "repair_execution_status": repair_execution_status,
@@ -210,13 +213,15 @@ def classify_preflight_block(*, report: dict[str, Any]) -> tuple[str, list[str]]
             return "internal_preflight_error", ["preflight_runtime_exception"]
         return "contract_mismatch", invariant_violations[:3]
 
-    return "unknown_preflight_failure", ["UNCLASSIFIED_BLOCK_REASON"]
+    return "internal_preflight_error", ["UNCLASSIFIED_BLOCK_REASON"]
 
 
 def _repair_policy(failure_class: str) -> tuple[str, bool, bool]:
     if failure_class in {
         "schema_violation",
         "contract_mismatch",
+        "test_inventory_regression",
+        "control_surface_gap",
         "invalid_wrapper",
         "authority_evidence_missing",
         "missing_required_artifact",
@@ -231,17 +236,21 @@ def _repair_policy(failure_class: str) -> tuple[str, bool, bool]:
         "accidental_filtering_detected",
     }:
         return "auto_repair_allowed", True, False
-    if failure_class in {"non_repairable_policy_violation", "lineage_missing"}:
+    if failure_class in {"non_repairable_policy_violation", "lineage_missing", "downstream_test_failure"}:
         return "auto_repair_forbidden", False, True
-    if failure_class in {"internal_preflight_error", "unknown_preflight_failure"}:
+    if failure_class in {"internal_preflight_error"}:
         return "escalation_required", False, True
     return "escalation_required", False, True
 
 
 def build_preflight_block_diagnosis_record(*, report: dict[str, Any], preflight_artifact: dict[str, Any]) -> dict[str, Any]:
     try:
+        normalized_failure = report.get("normalized_failure")
+        if not isinstance(normalized_failure, dict):
+            normalized_failure = normalize_preflight_failure(report)
         category, reasons = classify_preflight_block(report=report)
     except Exception:
+        normalized_failure = {"failure_class": "internal_preflight_error", "repairable": False}
         category, reasons = "internal_preflight_error", ["preflight_runtime_exception"]
     return {
         "artifact_type": "preflight_block_diagnosis_record",
@@ -251,6 +260,10 @@ def build_preflight_block_diagnosis_record(*, report: dict[str, Any], preflight_
         "strategy_gate_decision": str(((preflight_artifact.get("control_signal") or {}).get("strategy_gate_decision")) or "BLOCK"),
         "failure_class": category,
         "reason_codes": reasons,
+        "normalized_failure": {
+            "failure_class": category,
+            "repairable": bool(normalized_failure.get("repairable", False)),
+        },
         "root_cause_summary": str((preflight_artifact.get("control_signal") or {}).get("rationale") or "preflight block"),
     }
 
@@ -259,7 +272,11 @@ def build_preflight_repair_plan_record(*, diagnosis_record: dict[str, Any]) -> d
     category = diagnosis_record["failure_class"]
     if category not in KNOWN_REPAIR_CATEGORIES:
         raise ContractPreflightAutofixError("unknown_repair_category")
-    eligibility_decision, auto_repair_allowed, escalation_required = _repair_policy(category)
+    normalized_failure = diagnosis_record.get("normalized_failure")
+    if isinstance(normalized_failure, dict) and bool(normalized_failure.get("repairable", False)):
+        eligibility_decision, auto_repair_allowed, escalation_required = "auto_repair_allowed", True, False
+    else:
+        eligibility_decision, auto_repair_allowed, escalation_required = _repair_policy(category)
 
     allowed_paths = {
         "invalid_wrapper": [
@@ -275,17 +292,19 @@ def build_preflight_repair_plan_record(*, diagnosis_record: dict[str, Any]) -> d
         "missing_required_artifact": ["outputs/contract_preflight", "contracts/examples"],
         "lineage_missing": ["outputs/contract_preflight", "scripts/run_contract_preflight.py"],
         "non_repairable_policy_violation": ["docs/reviews"],
-        "internal_preflight_error": ["scripts/run_contract_preflight.py"],
-        "unknown_preflight_failure": ["docs/reviews"],
+        "internal_preflight_error": ["scripts/run_contract_preflight.py", "docs/reviews"],
         "pytest_config_missing": ["pytest.ini"],
         "pytest_config_mismatch": ["pytest.ini", "docs/governance/pytest_pr_inventory_baseline.json"],
         "testpaths_missing": ["pytest.ini", "tests/"],
         "no_tests_discovered": ["tests/", "pytest.ini"],
         "unexpected_test_inventory_regression": ["tests/", "docs/governance/pytest_pr_inventory_baseline.json"],
+        "test_inventory_regression": ["tests/", "docs/governance/pytest_pr_inventory_baseline.json"],
         "import_resolution_failure": ["tests/", "spectrum_systems/", "pytest.ini"],
         "collection_failure": ["tests/", "pytest.ini"],
         "working_directory_mismatch": [".github/workflows/", "scripts/run_contract_preflight.py"],
         "accidental_filtering_detected": ["pytest.ini", ".github/workflows/"],
+        "control_surface_gap": ["outputs/contract_preflight", "scripts/run_contract_preflight.py"],
+        "downstream_test_failure": ["tests/", "scripts/run_contract_preflight.py"],
     }[category]
 
     return {

--- a/spectrum_systems/modules/runtime/github_pr_autofix_contract_preflight.py
+++ b/spectrum_systems/modules/runtime/github_pr_autofix_contract_preflight.py
@@ -205,6 +205,10 @@ def classify_preflight_block(*, report: dict[str, Any]) -> tuple[str, list[str]]
         return "contract_mismatch", reasons
 
     if invariant_violations:
+        if "PR_PYTEST_EXECUTION_REQUIRED" in invariant_violations:
+            return "no_tests_discovered", ["PR_PYTEST_EXECUTION_REQUIRED"]
+        if "PR_PYTEST_FALLBACK_TARGETS_EMPTY" in invariant_violations:
+            return "no_tests_discovered", ["PR_PYTEST_FALLBACK_TARGETS_EMPTY"]
         if "artifact_validation_failure" in invariant_violations:
             return "schema_violation", ["artifact_validation_failure"]
         if "repair_pipeline_failure" in invariant_violations:

--- a/spectrum_systems/modules/runtime/preflight_failure_normalizer.py
+++ b/spectrum_systems/modules/runtime/preflight_failure_normalizer.py
@@ -18,6 +18,7 @@ def normalize_preflight_failure(report: dict[str, Any]) -> dict[str, Any]:
         "has_missing_surface": bool(report.get("missing_required_surface")),
         "has_invariant_violations": bool(report.get("invariant_violations")),
         "has_control_surface_gap": bool(report.get("control_surface_gap_blocking")),
+        "has_pytest_execution_gap": "PR_PYTEST_EXECUTION_REQUIRED" in set(report.get("invariant_violations", [])),
         "has_test_inventory_failure": (
             report.get("test_inventory_integrity", {}).get("failure_class") not in {None, "success"}
         ),
@@ -31,6 +32,8 @@ def normalize_preflight_failure(report: dict[str, Any]) -> dict[str, Any]:
         failure_class = "test_inventory_regression"
     elif signals["has_control_surface_gap"]:
         failure_class = "control_surface_gap"
+    elif signals["has_pytest_execution_gap"]:
+        failure_class = "test_inventory_regression"
     elif signals["has_test_failures"]:
         failure_class = "downstream_test_failure"
     elif signals["has_invariant_violations"]:

--- a/spectrum_systems/modules/runtime/preflight_failure_normalizer.py
+++ b/spectrum_systems/modules/runtime/preflight_failure_normalizer.py
@@ -18,7 +18,10 @@ def normalize_preflight_failure(report: dict[str, Any]) -> dict[str, Any]:
         "has_missing_surface": bool(report.get("missing_required_surface")),
         "has_invariant_violations": bool(report.get("invariant_violations")),
         "has_control_surface_gap": bool(report.get("control_surface_gap_blocking")),
-        "has_pytest_execution_gap": "PR_PYTEST_EXECUTION_REQUIRED" in set(report.get("invariant_violations", [])),
+        "has_pytest_execution_gap": bool(
+            {"PR_PYTEST_EXECUTION_REQUIRED", "PREFLIGHT_PASS_WITHOUT_PYTEST_EXECUTION"}
+            & set(report.get("invariant_violations", []))
+        ),
         "has_test_inventory_failure": (
             report.get("test_inventory_integrity", {}).get("failure_class") not in {None, "success"}
         ),

--- a/spectrum_systems/modules/runtime/preflight_failure_normalizer.py
+++ b/spectrum_systems/modules/runtime/preflight_failure_normalizer.py
@@ -1,0 +1,54 @@
+"""Deterministic normalization for contract preflight failures."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def normalize_preflight_failure(report: dict[str, Any]) -> dict[str, Any]:
+    """Convert raw preflight report into deterministic failure signal."""
+
+    signals = {
+        "has_schema_failures": bool(report.get("schema_example_failures")),
+        "has_test_failures": bool(
+            report.get("producer_failures")
+            or report.get("consumer_failures")
+            or report.get("fixture_failures")
+        ),
+        "has_missing_surface": bool(report.get("missing_required_surface")),
+        "has_invariant_violations": bool(report.get("invariant_violations")),
+        "has_control_surface_gap": bool(report.get("control_surface_gap_blocking")),
+        "has_test_inventory_failure": (
+            report.get("test_inventory_integrity", {}).get("failure_class") not in {None, "success"}
+        ),
+    }
+
+    if signals["has_schema_failures"]:
+        failure_class = "schema_violation"
+    elif signals["has_missing_surface"]:
+        failure_class = "contract_mismatch"
+    elif signals["has_test_inventory_failure"]:
+        failure_class = "test_inventory_regression"
+    elif signals["has_control_surface_gap"]:
+        failure_class = "control_surface_gap"
+    elif signals["has_test_failures"]:
+        failure_class = "downstream_test_failure"
+    elif signals["has_invariant_violations"]:
+        failure_class = "internal_preflight_error"
+    else:
+        failure_class = "internal_preflight_error"
+
+    return {
+        "failure_class": failure_class,
+        "signals": signals,
+        "repairable": failure_class
+        in {
+            "schema_violation",
+            "contract_mismatch",
+            "test_inventory_regression",
+            "control_surface_gap",
+        },
+    }
+
+
+__all__ = ["normalize_preflight_failure"]

--- a/tests/test_contract_preflight.py
+++ b/tests/test_contract_preflight.py
@@ -1625,7 +1625,6 @@ def test_main_contract_preflight_blocks_con035_when_required_test_mapping_missin
         "invalid_wrapper",
         "non_repairable_policy_violation",
         "internal_preflight_error",
-        "unknown_preflight_failure",
     }
     assert "eligibility_decision" in plan
     assert "rerun_allowed" in rerun
@@ -1834,15 +1833,15 @@ def test_push_context_exact_failure_regression_no_unknown_and_no_escalation(tmp_
     assert code == 2
 
     report = json.loads((output_dir / "contract_preflight_report.json").read_text(encoding="utf-8"))
-    assert report["root_cause_classification"]["failure_class"] != "unknown_preflight_failure"
-    assert report["root_cause_classification"]["reason_codes"] == ["changed_path_resolution_failure"]
+    assert report["root_cause_classification"]["failure_class"] == "internal_preflight_error"
+    assert report["root_cause_classification"]["reason_codes"] == ["changed-path detection failed before evaluation"]
     ref_context = report["changed_path_detection"]["ref_context"]
     assert ref_context["base_ref"] == "cafecb6682f83c47134a7d01ae818643d1136811"
     assert ref_context["head_ref"] == "a91128736a3706718cb0d32910503cfe056d3d1f"
 
     diagnosis = json.loads((output_dir / "preflight_block_diagnosis_record.json").read_text(encoding="utf-8"))
     plan = json.loads((output_dir / "preflight_repair_plan_record.json").read_text(encoding="utf-8"))
-    assert diagnosis["failure_class"] != "unknown_preflight_failure"
+    assert diagnosis["failure_class"] != "internal_preflight_error"
     assert plan["eligibility_decision"] == "auto_repair_allowed"
     assert not (output_dir / "preflight_human_escalation_record.json").exists()
 
@@ -1935,5 +1934,5 @@ def test_main_preflight_emits_classified_test_inventory_failure(tmp_path: Path, 
     assert exit_code == 2
 
     report = json.loads((output_dir / "contract_preflight_report.json").read_text(encoding="utf-8"))
-    assert report["root_cause_classification"]["failure_class"] == "unexpected_test_inventory_regression"
+    assert report["root_cause_classification"]["failure_class"] == "test_inventory_regression"
     assert "unexpected_test_inventory_regression" in report["invariant_violations"]

--- a/tests/test_contract_preflight.py
+++ b/tests/test_contract_preflight.py
@@ -1936,3 +1936,110 @@ def test_main_preflight_emits_classified_test_inventory_failure(tmp_path: Path, 
     report = json.loads((output_dir / "contract_preflight_report.json").read_text(encoding="utf-8"))
     assert report["root_cause_classification"]["failure_class"] == "test_inventory_regression"
     assert "unexpected_test_inventory_regression" in report["invariant_violations"]
+
+
+def test_pull_request_blocks_when_no_pytest_execution_and_no_fallback_targets(tmp_path: Path, monkeypatch) -> None:
+    output_dir = tmp_path / "out"
+    monkeypatch.setattr(
+        preflight,
+        "_parse_args",
+        lambda: type(
+            "Args",
+            (),
+            {
+                "base_ref": "origin/main",
+                "head_ref": "HEAD",
+                "event_name": "pull_request",
+                "changed_path": ["README.md"],
+                "output_dir": str(output_dir),
+                "hardening_flow": False,
+                "execution_context": "pqx_governed",
+                "pqx_wrapper_path": None,
+                "authority_evidence_ref": None,
+            },
+        )(),
+    )
+    monkeypatch.setattr(preflight, "_resolve_existing_pytest_targets", lambda _paths: [])
+
+    code = preflight.main()
+    assert code == 2
+    report = json.loads((output_dir / "contract_preflight_report.json").read_text(encoding="utf-8"))
+    assert "PR_PYTEST_FALLBACK_TARGETS_EMPTY" in report["invariant_violations"]
+    assert report["pytest_execution"]["pytest_execution_count"] == 0
+    assert report["pytest_execution"]["fallback_used"] is True
+
+
+def test_pull_request_no_targeted_tests_uses_governed_fallback(tmp_path: Path, monkeypatch) -> None:
+    output_dir = tmp_path / "out"
+    monkeypatch.setattr(
+        preflight,
+        "_parse_args",
+        lambda: type(
+            "Args",
+            (),
+            {
+                "base_ref": "origin/main",
+                "head_ref": "HEAD",
+                "event_name": "pull_request",
+                "changed_path": ["README.md"],
+                "output_dir": str(output_dir),
+                "hardening_flow": False,
+                "execution_context": "pqx_governed",
+                "pqx_wrapper_path": None,
+                "authority_evidence_ref": None,
+            },
+        )(),
+    )
+
+    def _fake_pytest(paths: list[str], *, execution_log: list[dict[str, object]] | None = None) -> list[dict[str, object]]:
+        if execution_log is not None:
+            for target in paths:
+                execution_log.append(
+                    {
+                        "target": target,
+                        "command": f"python -m pytest -q {target}",
+                        "returncode": 0,
+                    }
+                )
+        return []
+
+    monkeypatch.setattr(preflight, "run_targeted_pytests", _fake_pytest)
+    monkeypatch.setattr(preflight, "_resolve_existing_pytest_targets", lambda paths: [str(paths[0])])
+
+    code = preflight.main()
+    assert code == 0
+    report = json.loads((output_dir / "contract_preflight_report.json").read_text(encoding="utf-8"))
+    assert report["status"] == "passed"
+    assert report["pytest_execution"]["fallback_used"] is True
+    assert report["pytest_execution"]["pytest_execution_count"] == 1
+    assert report["pytest_execution"]["selected_targets"] == []
+    assert report["pytest_execution"]["fallback_targets"] == ["tests/test_run_github_pr_autofix_contract_preflight.py"]
+
+
+def test_push_noop_does_not_require_pull_request_pytest_invariant(tmp_path: Path, monkeypatch) -> None:
+    output_dir = tmp_path / "out"
+    monkeypatch.setattr(
+        preflight,
+        "_parse_args",
+        lambda: type(
+            "Args",
+            (),
+            {
+                "base_ref": "origin/main",
+                "head_ref": "HEAD",
+                "event_name": "push",
+                "changed_path": ["README.md"],
+                "output_dir": str(output_dir),
+                "hardening_flow": False,
+                "execution_context": "pqx_governed",
+                "pqx_wrapper_path": None,
+                "authority_evidence_ref": None,
+            },
+        )(),
+    )
+
+    code = preflight.main()
+    assert code == 0
+    report = json.loads((output_dir / "contract_preflight_report.json").read_text(encoding="utf-8"))
+    assert "PR_PYTEST_EXECUTION_REQUIRED" not in report["invariant_violations"]
+    assert report["status"] == "passed"

--- a/tests/test_contract_preflight.py
+++ b/tests/test_contract_preflight.py
@@ -2014,6 +2014,10 @@ def test_pull_request_no_targeted_tests_uses_governed_fallback(tmp_path: Path, m
     assert report["pytest_execution"]["pytest_execution_count"] == 1
     assert report["pytest_execution"]["selected_targets"] == []
     assert report["pytest_execution"]["fallback_targets"] == ["tests/test_run_github_pr_autofix_contract_preflight.py"]
+    assert report["pytest_execution"]["selection_reason_codes"] == ["PR_PYTEST_SELECTED_TARGETS_EMPTY"]
+    artifact = json.loads((output_dir / "contract_preflight_result_artifact.json").read_text(encoding="utf-8"))
+    assert artifact["pytest_execution"]["pytest_execution_count"] == 1
+    assert "selection_reason_codes" in artifact["pytest_execution"]
 
 
 def test_push_noop_does_not_require_pull_request_pytest_invariant(tmp_path: Path, monkeypatch) -> None:
@@ -2043,3 +2047,34 @@ def test_push_noop_does_not_require_pull_request_pytest_invariant(tmp_path: Path
     report = json.loads((output_dir / "contract_preflight_report.json").read_text(encoding="utf-8"))
     assert "PR_PYTEST_EXECUTION_REQUIRED" not in report["invariant_violations"]
     assert report["status"] == "passed"
+
+
+def test_pull_request_fails_closed_when_fallback_reports_success_without_execution_log(tmp_path: Path, monkeypatch) -> None:
+    output_dir = tmp_path / "out"
+    monkeypatch.setattr(
+        preflight,
+        "_parse_args",
+        lambda: type(
+            "Args",
+            (),
+            {
+                "base_ref": "origin/main",
+                "head_ref": "HEAD",
+                "event_name": "pull_request",
+                "changed_path": ["README.md"],
+                "output_dir": str(output_dir),
+                "hardening_flow": False,
+                "execution_context": "pqx_governed",
+                "pqx_wrapper_path": None,
+                "authority_evidence_ref": None,
+            },
+        )(),
+    )
+    monkeypatch.setattr(preflight, "_resolve_existing_pytest_targets", lambda _paths: ["tests/test_contracts.py"])
+    monkeypatch.setattr(preflight, "run_targeted_pytests", lambda *_args, **_kwargs: [])
+
+    code = preflight.main()
+    assert code == 2
+    report = json.loads((output_dir / "contract_preflight_report.json").read_text(encoding="utf-8"))
+    assert "PR_PYTEST_EXECUTION_REQUIRED" in report["invariant_violations"]
+    assert "PREFLIGHT_PASS_WITHOUT_PYTEST_EXECUTION" in report["invariant_violations"]

--- a/tests/test_github_pr_autofix_contract_preflight.py
+++ b/tests/test_github_pr_autofix_contract_preflight.py
@@ -87,6 +87,18 @@ def test_pr_pytest_execution_invariant_is_classified_for_repair(tmp_path: Path) 
     assert plan["eligibility_decision"] == "auto_repair_allowed"
 
 
+def test_preflight_pass_without_execution_invariant_is_classified_for_repair() -> None:
+    diagnosis = build_preflight_block_diagnosis_record(
+        report={
+            "invariant_violations": ["PREFLIGHT_PASS_WITHOUT_PYTEST_EXECUTION"],
+            "normalized_failure": {"failure_class": "test_inventory_regression", "repairable": True},
+        },
+        preflight_artifact={"control_signal": {"strategy_gate_decision": "BLOCK"}, "generated_at": "2026"},
+    )
+    assert diagnosis["failure_class"] == "no_tests_discovered"
+    assert diagnosis["reason_codes"] == ["PREFLIGHT_PASS_WITHOUT_PYTEST_EXECUTION"]
+
+
 def test_bounded_repair_plan_creation_known_category() -> None:
     diagnosis = build_preflight_block_diagnosis_record(
         report={"missing_required_surface": ["x"]},

--- a/tests/test_github_pr_autofix_contract_preflight.py
+++ b/tests/test_github_pr_autofix_contract_preflight.py
@@ -70,7 +70,7 @@ def test_diagnosis_fails_closed_when_block_reason_unknown(tmp_path: Path) -> Non
     assert (out / "preflight_repair_result_record.json").exists()
     assert (out / "preflight_recovery_outcome_record.json").exists()
     diagnosis = json.loads((out / "preflight_block_diagnosis_record.json").read_text(encoding="utf-8"))
-    assert diagnosis["failure_class"] == "unknown_preflight_failure"
+    assert diagnosis["failure_class"] == "internal_preflight_error"
 
 
 def test_bounded_repair_plan_creation_known_category() -> None:

--- a/tests/test_github_pr_autofix_contract_preflight.py
+++ b/tests/test_github_pr_autofix_contract_preflight.py
@@ -73,6 +73,20 @@ def test_diagnosis_fails_closed_when_block_reason_unknown(tmp_path: Path) -> Non
     assert diagnosis["failure_class"] == "internal_preflight_error"
 
 
+def test_pr_pytest_execution_invariant_is_classified_for_repair(tmp_path: Path) -> None:
+    diagnosis = build_preflight_block_diagnosis_record(
+        report={
+            "invariant_violations": ["PR_PYTEST_EXECUTION_REQUIRED"],
+            "normalized_failure": {"failure_class": "test_inventory_regression", "repairable": True},
+        },
+        preflight_artifact={"control_signal": {"strategy_gate_decision": "BLOCK"}, "generated_at": "2026"},
+    )
+    assert diagnosis["failure_class"] == "no_tests_discovered"
+    assert diagnosis["normalized_failure"]["repairable"] is True
+    plan = build_preflight_repair_plan_record(diagnosis_record=diagnosis)
+    assert plan["eligibility_decision"] == "auto_repair_allowed"
+
+
 def test_bounded_repair_plan_creation_known_category() -> None:
     diagnosis = build_preflight_block_diagnosis_record(
         report={"missing_required_surface": ["x"]},

--- a/tests/test_preflight_failure_normalizer.py
+++ b/tests/test_preflight_failure_normalizer.py
@@ -17,3 +17,9 @@ def test_missing_surface_maps_to_contract_mismatch() -> None:
     report = {"missing_required_surface": ["x"]}
     result = normalize_preflight_failure(report)
     assert result["failure_class"] == "contract_mismatch"
+
+
+def test_pr_pytest_execution_gap_maps_to_inventory_regression() -> None:
+    report = {"invariant_violations": ["PR_PYTEST_EXECUTION_REQUIRED"]}
+    result = normalize_preflight_failure(report)
+    assert result["failure_class"] == "test_inventory_regression"

--- a/tests/test_preflight_failure_normalizer.py
+++ b/tests/test_preflight_failure_normalizer.py
@@ -1,0 +1,19 @@
+from spectrum_systems.modules.runtime.preflight_failure_normalizer import normalize_preflight_failure
+
+
+def test_no_unknown_failure() -> None:
+    report = {}
+    result = normalize_preflight_failure(report)
+    assert result["failure_class"] == "internal_preflight_error"
+
+
+def test_schema_maps_correctly() -> None:
+    report = {"schema_example_failures": ["x"]}
+    result = normalize_preflight_failure(report)
+    assert result["failure_class"] == "schema_violation"
+
+
+def test_missing_surface_maps_to_contract_mismatch() -> None:
+    report = {"missing_required_surface": ["x"]}
+    result = normalize_preflight_failure(report)
+    assert result["failure_class"] == "contract_mismatch"

--- a/tests/test_preflight_failure_normalizer.py
+++ b/tests/test_preflight_failure_normalizer.py
@@ -23,3 +23,9 @@ def test_pr_pytest_execution_gap_maps_to_inventory_regression() -> None:
     report = {"invariant_violations": ["PR_PYTEST_EXECUTION_REQUIRED"]}
     result = normalize_preflight_failure(report)
     assert result["failure_class"] == "test_inventory_regression"
+
+
+def test_preflight_pass_without_execution_maps_to_inventory_regression() -> None:
+    report = {"invariant_violations": ["PREFLIGHT_PASS_WITHOUT_PYTEST_EXECUTION"]}
+    result = normalize_preflight_failure(report)
+    assert result["failure_class"] == "test_inventory_regression"


### PR DESCRIPTION
### Motivation
- Preflight BLOCK outcomes were sometimes unclassifiable which caused non-deterministic escalation and flaky preflight autofix behavior. 
- Introduce a deterministic normalization layer so every preflight failure maps to a bounded failure class and repair routing can be consistently decided. 

### Description
- Add a new normalization module `spectrum_systems/modules/runtime/preflight_failure_normalizer.py` that extracts deterministic signals, maps them to a small set of failure classes, and exposes a `repairable` flag. 
- Update `scripts/run_contract_preflight.py` to call `normalize_preflight_failure`, persist `report["normalized_failure"]`, derive `root_cause_classification` from the normalized output, and set repair eligibility from `normalized_failure["repairable"]` with a fail-closed fallback. 
- Update the autofix routing in `spectrum_systems/modules/runtime/github_pr_autofix_contract_preflight.py` to include normalized failure data in diagnosis records and to allow automatic repair when `normalized_failure["repairable"]` is true while removing the legacy unknown failure path. 
- Extend and align contract schemas to require `normalized_failure` metadata in diagnosis artifacts and add the new deterministic classes to affected enums. 
- Add unit tests `tests/test_preflight_failure_normalizer.py` and update affected preflight/autofix tests to reflect deterministic classification behavior. 
- Add a build plan document `docs/review-actions/PLAN-PRF-07-2026-04-14.md` to record multi-file change rationale per repository governance. 

### Testing
- Ran targeted unit and integration tests with `pytest -q tests/test_preflight_failure_normalizer.py tests/test_github_pr_autofix_contract_preflight.py tests/test_contract_preflight.py tests/test_contracts.py tests/test_module_architecture.py`. 
- Result: all tests passed (`224 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de1f6daf8083298df2022577bbe1de)