### PR TITLE
AUD-01: Add retroactive pytest integrity audit and bounded remediation queue

### DIFF
--- a/.github/workflows/artifact-boundary.yml
+++ b/.github/workflows/artifact-boundary.yml
@@ -160,8 +160,22 @@ payload = json.loads(artifact.read_text(encoding="utf-8"))
 decision = str((payload.get("control_signal") or {}).get("strategy_gate_decision") or "BLOCK")
 execution = payload.get("pytest_execution") or {}
 count = int(execution.get("pytest_execution_count") or 0)
-if os.environ.get("GITHUB_EVENT_NAME") == "pull_request" and decision in {"ALLOW", "WARN"} and count < 1:
-    raise SystemExit("workflow/preflight trust mismatch: PR allow without preflight-owned pytest execution")
+record_ref = str(payload.get("pytest_execution_record_ref") or "").strip()
+if os.environ.get("GITHUB_EVENT_NAME") == "pull_request":
+    if not record_ref:
+        raise SystemExit("workflow/preflight trust mismatch: missing pytest_execution_record_ref")
+    record_path = Path(record_ref)
+    if not record_path.is_file():
+        raise SystemExit(f"workflow/preflight trust mismatch: missing pytest_execution_record artifact at {record_ref}")
+    record = json.loads(record_path.read_text(encoding="utf-8"))
+    executed = bool(record.get("executed", False))
+    selected_targets = record.get("selected_targets") or []
+    if decision in {"ALLOW", "WARN"} and count < 1:
+        raise SystemExit("workflow/preflight trust mismatch: PR allow without preflight-owned pytest execution")
+    if decision in {"ALLOW", "WARN"} and not executed:
+        raise SystemExit("workflow/preflight trust mismatch: PR allow with executed=false")
+    if decision in {"ALLOW", "WARN"} and not selected_targets:
+        raise SystemExit("workflow/preflight trust mismatch: PR allow with empty selected_targets")
 PY
 
       - name: Upload contract preflight outputs

--- a/.github/workflows/pr-autofix-contract-preflight.yml
+++ b/.github/workflows/pr-autofix-contract-preflight.yml
@@ -135,8 +135,21 @@ jobs:
           payload = json.loads(result.read_text(encoding="utf-8"))
           initial = payload.get("control_signal", {}).get("strategy_gate_decision", "BLOCK")
           pytest_count = int(((payload.get("pytest_execution") or {}).get("pytest_execution_count") or 0))
+          record_ref = str(payload.get("pytest_execution_record_ref") or "").strip()
+          if not record_ref:
+              raise SystemExit("workflow/preflight trust mismatch: missing pytest_execution_record_ref")
+          record_path = Path(record_ref)
+          if not record_path.exists():
+              raise SystemExit(f"workflow/preflight trust mismatch: missing pytest_execution_record artifact at {record_ref}")
+          record = json.loads(record_path.read_text(encoding="utf-8"))
+          executed = bool(record.get("executed", False))
+          selected_targets = record.get("selected_targets") or []
           if initial in {"ALLOW", "WARN"} and pytest_count < 1:
               raise SystemExit("workflow/preflight trust mismatch: allow decision missing preflight-owned pytest execution")
+          if initial in {"ALLOW", "WARN"} and not executed:
+              raise SystemExit("workflow/preflight trust mismatch: allow decision with executed=false")
+          if initial in {"ALLOW", "WARN"} and not selected_targets:
+              raise SystemExit("workflow/preflight trust mismatch: allow decision with empty selected_targets")
           if initial != "BLOCK":
               raise SystemExit(0 if initial in {"ALLOW", "WARN"} else 2)
           outcome_path = out / "preflight_recovery_outcome_record.json"

--- a/contracts/examples/contract_preflight_result_artifact.example.json
+++ b/contracts/examples/contract_preflight_result_artifact.example.json
@@ -1,6 +1,6 @@
 {
   "artifact_type": "contract_preflight_result_artifact",
-  "schema_version": "1.2.0",
+  "schema_version": "1.3.0",
   "preflight_status": "passed",
   "changed_contracts": [
     "contracts/schemas/roadmap_eligibility_artifact.schema.json"
@@ -69,5 +69,6 @@
       "contract_surface"
     ],
     "provenance_ref": "contracts/standards-manifest.json"
-  }
+  },
+  "pytest_execution_record_ref": "outputs/contract_preflight/pytest_execution_record.json"
 }

--- a/contracts/examples/contract_preflight_result_artifact.json
+++ b/contracts/examples/contract_preflight_result_artifact.json
@@ -1,6 +1,6 @@
 {
   "artifact_type": "contract_preflight_result_artifact",
-  "schema_version": "1.2.0",
+  "schema_version": "1.3.0",
   "preflight_status": "passed",
   "changed_contracts": [
     "contracts/schemas/roadmap_eligibility_artifact.schema.json"
@@ -88,5 +88,6 @@
       "contract_surface"
     ],
     "provenance_ref": "contracts/standards-manifest.json"
-  }
+  },
+  "pytest_execution_record_ref": "outputs/contract_preflight/pytest_execution_record.json"
 }

--- a/contracts/examples/pytest_execution_record.json
+++ b/contracts/examples/pytest_execution_record.json
@@ -1,0 +1,32 @@
+{
+  "artifact_type": "pytest_execution_record",
+  "schema_version": "1.0.0",
+  "event_name": "pull_request",
+  "workflow_name": "artifact-boundary",
+  "workflow_job": "contract-preflight",
+  "executed": true,
+  "pytest_command": "python -m pytest -q tests/test_contract_preflight.py",
+  "selected_targets": [
+    "tests/test_contract_preflight.py"
+  ],
+  "configured_selected_targets": [
+    "tests/test_contract_preflight.py"
+  ],
+  "fallback_targets": [],
+  "fallback_used": false,
+  "targeted_selection_empty": false,
+  "fallback_selection_empty": true,
+  "selection_reason_codes": [],
+  "collection_count": null,
+  "exit_code": 0,
+  "execution_count": 1,
+  "execution_entries": [
+    {
+      "target": "tests/test_contract_preflight.py",
+      "command": "python -m pytest -q tests/test_contract_preflight.py",
+      "exit_code": 0
+    }
+  ],
+  "timestamp": "2026-04-14T00:00:00Z",
+  "failure_reason": null
+}

--- a/contracts/examples/retroactive_pytest_integrity_audit_result.json
+++ b/contracts/examples/retroactive_pytest_integrity_audit_result.json
@@ -1,0 +1,57 @@
+{
+  "artifact_type": "retroactive_pytest_integrity_audit_result",
+  "schema_version": "1.0.0",
+  "audit_scope": {
+    "roots": [
+      "outputs",
+      "artifacts",
+      "data"
+    ],
+    "artifact_globs": [
+      "**/contract_preflight_result_artifact.json",
+      "**/contract_preflight_report.json"
+    ],
+    "repo_root": "/workspace/spectrum-systems"
+  },
+  "scanned_run_count": 3,
+  "trusted_count": 1,
+  "suspect_count": 1,
+  "unable_to_evaluate_count": 1,
+  "suspect_runs": [
+    {
+      "artifact_path": "outputs/history/run-001/contract_preflight_result_artifact.json",
+      "classification": "suspect_missing_pytest_execution",
+      "reason_codes": [
+        "HISTORICAL_ARTIFACT_SHAPE_PRE_PYX01",
+        "HISTORICAL_PR_ALLOW_WITHOUT_PYTEST_EXECUTION"
+      ],
+      "trusting_outcome": true,
+      "context": "pr",
+      "remediation_recommendation": "re_run_governed_preflight_if_commit_pair_reconstructable"
+    }
+  ],
+  "remediation_queue": [
+    {
+      "artifact_path": "outputs/history/run-001/contract_preflight_result_artifact.json",
+      "classification": "suspect_missing_pytest_execution",
+      "reason_codes": [
+        "HISTORICAL_ARTIFACT_SHAPE_PRE_PYX01",
+        "HISTORICAL_PR_ALLOW_WITHOUT_PYTEST_EXECUTION"
+      ],
+      "recommended_action": "re_run_governed_preflight_if_commit_pair_reconstructable",
+      "quarantine_recommendation": "quarantine_from_trusted_baseline_metrics_until_revalidated"
+    }
+  ],
+  "summary_reason_codes": [
+    "HISTORICAL_ARTIFACT_SHAPE_PRE_PYX01",
+    "HISTORICAL_CONTEXT_NOT_EVALUABLE",
+    "HISTORICAL_PR_ALLOW_WITHOUT_PYTEST_EXECUTION"
+  ],
+  "generated_at": "2026-04-14T00:00:00Z",
+  "trace": {
+    "producer": "spectrum_systems.modules.runtime.retroactive_pytest_integrity_audit",
+    "classification_policy": "pyx01_execution_truth_backtest_v1",
+    "remediation_queue_limit": 50,
+    "scan_mode": "repo_local_artifacts_only"
+  }
+}

--- a/contracts/examples/retroactive_pytest_remediation_queue.json
+++ b/contracts/examples/retroactive_pytest_remediation_queue.json
@@ -1,0 +1,24 @@
+{
+  "artifact_type": "retroactive_pytest_remediation_queue",
+  "schema_version": "1.0.0",
+  "audit_result_ref": "outputs/retroactive_pytest_integrity_audit/retroactive_pytest_integrity_audit_result.json",
+  "queue_size": 1,
+  "items": [
+    {
+      "artifact_path": "outputs/history/run-001/contract_preflight_result_artifact.json",
+      "classification": "suspect_missing_pytest_execution",
+      "reason_codes": [
+        "HISTORICAL_ARTIFACT_SHAPE_PRE_PYX01",
+        "HISTORICAL_PR_ALLOW_WITHOUT_PYTEST_EXECUTION"
+      ],
+      "recommended_action": "re_run_governed_preflight_if_commit_pair_reconstructable",
+      "quarantine_recommendation": "quarantine_from_trusted_baseline_metrics_until_revalidated"
+    }
+  ],
+  "generated_at": "2026-04-14T00:00:00Z",
+  "trace": {
+    "producer": "spectrum_systems.modules.runtime.retroactive_pytest_integrity_audit",
+    "queue_policy": "bounded_suspect_only",
+    "queue_limit": 50
+  }
+}

--- a/contracts/schemas/contract_preflight_result_artifact.schema.json
+++ b/contracts/schemas/contract_preflight_result_artifact.schema.json
@@ -24,7 +24,8 @@
     "pytest_execution",
     "pqx_required_context_enforcement",
     "control_signal",
-    "trace"
+    "trace",
+    "pytest_execution_record_ref"
   ],
   "properties": {
     "artifact_type": {
@@ -32,7 +33,7 @@
     },
     "schema_version": {
       "type": "string",
-      "const": "1.2.0"
+      "const": "1.3.0"
     },
     "preflight_status": {
       "type": "string",
@@ -173,6 +174,10 @@
           "uniqueItems": true
         }
       }
+    },
+    "pytest_execution_record_ref": {
+      "type": "string",
+      "minLength": 1
     },
     "pqx_required_context_enforcement": {
       "type": "object",

--- a/contracts/schemas/pytest_execution_record.schema.json
+++ b/contracts/schemas/pytest_execution_record.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/pytest_execution_record.schema.json",
+  "title": "Pytest Execution Record",
+  "description": "Canonical preflight-owned pytest execution evidence artifact for PR trust gating.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "event_name",
+    "workflow_name",
+    "workflow_job",
+    "executed",
+    "pytest_command",
+    "selected_targets",
+    "configured_selected_targets",
+    "fallback_targets",
+    "fallback_used",
+    "targeted_selection_empty",
+    "fallback_selection_empty",
+    "selection_reason_codes",
+    "collection_count",
+    "exit_code",
+    "execution_count",
+    "execution_entries",
+    "timestamp",
+    "failure_reason"
+  ],
+  "properties": {
+    "artifact_type": {"const": "pytest_execution_record"},
+    "schema_version": {"const": "1.0.0"},
+    "event_name": {"type": "string", "minLength": 1},
+    "workflow_name": {"type": ["string", "null"]},
+    "workflow_job": {"type": ["string", "null"]},
+    "executed": {"type": "boolean"},
+    "pytest_command": {"type": "string"},
+    "selected_targets": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+    "configured_selected_targets": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+    "fallback_targets": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+    "fallback_used": {"type": "boolean"},
+    "targeted_selection_empty": {"type": "boolean"},
+    "fallback_selection_empty": {"type": "boolean"},
+    "selection_reason_codes": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+    "collection_count": {"type": ["integer", "null"], "minimum": 0},
+    "exit_code": {"type": "integer", "minimum": 0},
+    "execution_count": {"type": "integer", "minimum": 0},
+    "execution_entries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["target", "command", "exit_code"],
+        "properties": {
+          "target": {"type": "string", "minLength": 1},
+          "command": {"type": "string", "minLength": 1},
+          "exit_code": {"type": "integer", "minimum": 0}
+        }
+      }
+    },
+    "timestamp": {"type": "string", "format": "date-time"},
+    "failure_reason": {"type": ["string", "null"]}
+  }
+}

--- a/contracts/schemas/retroactive_pytest_integrity_audit_result.schema.json
+++ b/contracts/schemas/retroactive_pytest_integrity_audit_result.schema.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/retroactive_pytest_integrity_audit_result.schema.json",
+  "title": "Retroactive Pytest Integrity Audit Result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "audit_scope",
+    "scanned_run_count",
+    "trusted_count",
+    "suspect_count",
+    "unable_to_evaluate_count",
+    "suspect_runs",
+    "remediation_queue",
+    "summary_reason_codes",
+    "generated_at",
+    "trace"
+  ],
+  "properties": {
+    "artifact_type": {"const": "retroactive_pytest_integrity_audit_result"},
+    "schema_version": {"const": "1.0.0"},
+    "audit_scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["roots", "artifact_globs", "repo_root"],
+      "properties": {
+        "roots": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+        "artifact_globs": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+        "repo_root": {"type": "string", "minLength": 1}
+      }
+    },
+    "scanned_run_count": {"type": "integer", "minimum": 0},
+    "trusted_count": {"type": "integer", "minimum": 0},
+    "suspect_count": {"type": "integer", "minimum": 0},
+    "unable_to_evaluate_count": {"type": "integer", "minimum": 0},
+    "suspect_runs": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/runClassification"}
+    },
+    "remediation_queue": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/remediationItem"}
+    },
+    "summary_reason_codes": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1},
+      "uniqueItems": true
+    },
+    "generated_at": {"type": "string", "format": "date-time"},
+    "trace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["producer", "classification_policy", "remediation_queue_limit", "scan_mode"],
+      "properties": {
+        "producer": {"type": "string", "minLength": 1},
+        "classification_policy": {"type": "string", "minLength": 1},
+        "remediation_queue_limit": {"type": "integer", "minimum": 1},
+        "scan_mode": {"type": "string", "const": "repo_local_artifacts_only"}
+      }
+    }
+  },
+  "$defs": {
+    "runClassification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["artifact_path", "classification", "reason_codes", "trusting_outcome", "context", "remediation_recommendation"],
+      "properties": {
+        "artifact_path": {"type": "string", "minLength": 1},
+        "classification": {
+          "type": "string",
+          "enum": [
+            "trusted",
+            "suspect_missing_pytest_execution",
+            "suspect_non_authoritative_pytest",
+            "suspect_incomplete_execution_accounting",
+            "unable_to_evaluate"
+          ]
+        },
+        "reason_codes": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+        "trusting_outcome": {"type": "boolean"},
+        "context": {"type": "string", "enum": ["pr", "non_pr", "unknown"]},
+        "remediation_recommendation": {
+          "type": "string",
+          "enum": [
+            "none",
+            "manual_operator_review_required",
+            "re_run_governed_preflight_if_commit_pair_reconstructable"
+          ]
+        }
+      }
+    },
+    "remediationItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "artifact_path",
+        "classification",
+        "reason_codes",
+        "recommended_action",
+        "quarantine_recommendation"
+      ],
+      "properties": {
+        "artifact_path": {"type": "string", "minLength": 1},
+        "classification": {
+          "type": "string",
+          "enum": [
+            "suspect_missing_pytest_execution",
+            "suspect_non_authoritative_pytest",
+            "suspect_incomplete_execution_accounting"
+          ]
+        },
+        "reason_codes": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+        "recommended_action": {
+          "type": "string",
+          "enum": [
+            "manual_operator_review_required",
+            "re_run_governed_preflight_if_commit_pair_reconstructable"
+          ]
+        },
+        "quarantine_recommendation": {
+          "type": "string",
+          "const": "quarantine_from_trusted_baseline_metrics_until_revalidated"
+        }
+      }
+    }
+  }
+}

--- a/contracts/schemas/retroactive_pytest_remediation_queue.schema.json
+++ b/contracts/schemas/retroactive_pytest_remediation_queue.schema.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/retroactive_pytest_remediation_queue.schema.json",
+  "title": "Retroactive Pytest Remediation Queue",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "audit_result_ref",
+    "queue_size",
+    "items",
+    "generated_at",
+    "trace"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "retroactive_pytest_remediation_queue"
+    },
+    "schema_version": {
+      "const": "1.0.0"
+    },
+    "audit_result_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "queue_size": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "artifact_path",
+          "classification",
+          "reason_codes",
+          "recommended_action",
+          "quarantine_recommendation"
+        ],
+        "properties": {
+          "artifact_path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "classification": {
+            "type": "string",
+            "enum": [
+              "suspect_missing_pytest_execution",
+              "suspect_non_authoritative_pytest",
+              "suspect_incomplete_execution_accounting"
+            ]
+          },
+          "reason_codes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "uniqueItems": true
+          },
+          "recommended_action": {
+            "type": "string",
+            "enum": [
+              "manual_operator_review_required",
+              "re_run_governed_preflight_if_commit_pair_reconstructable"
+            ]
+          },
+          "quarantine_recommendation": {
+            "type": "string",
+            "const": "quarantine_from_trusted_baseline_metrics_until_revalidated"
+          }
+        }
+      }
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "trace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "producer",
+        "queue_policy",
+        "queue_limit"
+      ],
+      "properties": {
+        "producer": {
+          "type": "string",
+          "minLength": 1
+        },
+        "queue_policy": {
+          "type": "string",
+          "const": "bounded_suspect_only"
+        },
+        "queue_limit": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    }
+  }
+}

--- a/contracts/standards-manifest.json
+++ b/contracts/standards-manifest.json
@@ -1,12 +1,12 @@
 {
   "artifact_type": "standards_manifest",
   "artifact_id": "STD-CONTRACTS",
-  "artifact_version": "1.3.131",
+  "artifact_version": "1.3.132",
   "schema_version": "1.3.99",
   "standards_version": "1.0.83",
-  "record_id": "REC-STD-2026-04-13-RAX-SERIAL-OPERATING-SUBSTRATE",
-  "run_id": "run-20260413T000000Z-rax-serial-operating-substrate",
-  "created_at": "2026-04-13T00:00:00Z",
+  "record_id": "REC-STD-2026-04-14-AUD-01-RETROACTIVE-PYTEST-INTEGRITY",
+  "run_id": "run-20260414T000000Z-aud-01-retroactive-pytest-integrity",
+  "created_at": "2026-04-14T00:00:00Z",
   "created_by": {
     "name": "Spectrum Systems Architecture Team",
     "role": "standards-publication",
@@ -15,7 +15,7 @@
     "contact": "architecture@spectrum-systems.test"
   },
   "source_repo": "nicklasorte/spectrum-systems",
-  "source_repo_version": "1.3.131",
+  "source_repo_version": "1.3.132",
   "input_artifacts": [
     {
       "artifact_id": "STD-CONTRACTS",
@@ -27,6 +27,32 @@
     }
   ],
   "contracts": [
+    {
+      "artifact_type": "abstention_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.0.83",
+      "last_updated_in": "1.0.83",
+      "example_path": "contracts/examples/abstention_record.json",
+      "notes": "CDX-01 next-phase governed contract surface."
+    },
+    {
+      "artifact_type": "active_set_snapshot",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.0.83",
+      "last_updated_in": "1.0.83",
+      "example_path": "contracts/examples/active_set_snapshot.json",
+      "notes": "CDX-01 next-phase governed contract surface."
+    },
     {
       "artifact_type": "adaptive_execution_observability",
       "artifact_class": "coordination",
@@ -955,6 +981,32 @@
       "notes": "Canonical human-facing spreadsheet interface with fixed headers, order, and normalized mapping; payloads should be wrapped in the artifact envelope standard."
     },
     {
+      "artifact_type": "comparison_result_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.0.83",
+      "last_updated_in": "1.0.83",
+      "example_path": "contracts/examples/comparison_result_record.json",
+      "notes": "CDX-01 next-phase governed contract surface."
+    },
+    {
+      "artifact_type": "comparison_run_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.0.83",
+      "last_updated_in": "1.0.83",
+      "example_path": "contracts/examples/comparison_run_record.json",
+      "notes": "CDX-01 next-phase governed contract surface."
+    },
+    {
       "artifact_type": "complexity_budget",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -1367,6 +1419,32 @@
       "artifact_type": "correction_pattern_record",
       "example_path": "contracts/examples/correction_pattern_record.json",
       "notes": "BATCH-11 deterministic recurrence-driven correction pattern artifact with explicit remediation type mapping."
+    },
+    {
+      "artifact_type": "cost_budget_status",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.0.83",
+      "last_updated_in": "1.0.83",
+      "example_path": "contracts/examples/cost_budget_status.json",
+      "notes": "CDX-01 next-phase governed contract surface."
+    },
+    {
+      "artifact_type": "cross_artifact_consistency_report",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.0.83",
+      "last_updated_in": "1.0.83",
+      "example_path": "contracts/examples/cross_artifact_consistency_report.json",
+      "notes": "CDX-01 next-phase governed contract surface."
     },
     {
       "artifact_type": "cross_run_intelligence_decision",
@@ -2213,6 +2291,19 @@
       "notes": "BBC governed versioned dataset of eval_case and failure_eval_case members with deterministic admission summary and policy linkage. Includes explicit canonicalization_policy_id governance linkage."
     },
     {
+      "artifact_type": "eval_dataset_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.0.83",
+      "last_updated_in": "1.0.83",
+      "example_path": "contracts/examples/eval_dataset_record.json",
+      "notes": "CDX-01 next-phase governed contract surface."
+    },
+    {
       "artifact_type": "eval_expansion_record",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -2224,6 +2315,19 @@
       "last_updated_in": "1.3.131",
       "example_path": "contracts/examples/eval_expansion_record.json",
       "notes": "RAX serial operating substrate governance contract."
+    },
+    {
+      "artifact_type": "eval_registry_entry",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.0.83",
+      "last_updated_in": "1.0.83",
+      "example_path": "contracts/examples/eval_registry_entry.json",
+      "notes": "CDX-01 next-phase governed contract surface."
     },
     {
       "artifact_type": "eval_registry_snapshot",
@@ -2263,6 +2367,19 @@
       "last_updated_in": "1.0.7",
       "example_path": "contracts/examples/eval_run.json",
       "notes": "Governed eval-run record covering case set, system version, dataset version, and run timestamp."
+    },
+    {
+      "artifact_type": "eval_slice_definition",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.0.83",
+      "last_updated_in": "1.0.83",
+      "example_path": "contracts/examples/eval_slice_definition.json",
+      "notes": "CDX-01 next-phase governed contract surface."
     },
     {
       "artifact_type": "eval_slice_summary",
@@ -2437,6 +2554,19 @@
       "last_updated_in": "1.0.0",
       "example_path": "contracts/examples/evidence_map.json",
       "notes": "Evidence map linking strategic claims to anchored source evidence."
+    },
+    {
+      "artifact_type": "evidence_sufficiency_result",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.0.83",
+      "last_updated_in": "1.0.83",
+      "example_path": "contracts/examples/evidence_sufficiency_result.json",
+      "notes": "CDX-01 next-phase governed contract surface."
     },
     {
       "artifact_class": "coordination",
@@ -2619,6 +2749,19 @@
       "notes": "BATCH-MB-01 finite failure class registry for deterministic one-class mapping."
     },
     {
+      "artifact_type": "failure_derived_eval_case",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.0.83",
+      "last_updated_in": "1.0.83",
+      "example_path": "contracts/examples/failure_derived_eval_case.json",
+      "notes": "CDX-01 next-phase governed contract surface."
+    },
+    {
       "artifact_type": "failure_diagnosis_artifact",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -2629,7 +2772,7 @@
       "introduced_in": "1.3.74",
       "last_updated_in": "1.3.89",
       "example_path": "contracts/examples/failure_diagnosis_artifact.json",
-      "notes": "BATCH-FRE-01 deterministic failure intake/classification artifact for governed failure\u2192diagnosis handoff; diagnosis-only with no repair execution authority."
+      "notes": "BATCH-FRE-01 deterministic failure intake/classification artifact for governed failure→diagnosis handoff; diagnosis-only with no repair execution authority."
     },
     {
       "artifact_type": "failure_eval_case",
@@ -2642,7 +2785,7 @@
       "introduced_in": "1.0.8",
       "last_updated_in": "1.0.41",
       "example_path": "contracts/examples/failure_eval_case.json",
-      "notes": "AG-05 deterministic failure\u2192eval auto-generation artifact for bounded runtime failure, review-required halt, and control-indeterminate non-allow source conditions."
+      "notes": "AG-05 deterministic failure→eval auto-generation artifact for bounded runtime failure, review-required halt, and control-indeterminate non-allow source conditions."
     },
     {
       "artifact_type": "failure_learning_record_artifact",
@@ -2785,7 +2928,7 @@
       "introduced_in": "1.3.86",
       "last_updated_in": "1.3.86",
       "example_path": "contracts/examples/github_review_handoff_artifact.json",
-      "notes": "BATCH-GHA-CORE-01 deterministic GHA-01\u2192GHA-02 handoff index for fail-closed artifact routing without adding workflow decision logic."
+      "notes": "BATCH-GHA-CORE-01 deterministic GHA-01→GHA-02 handoff index for fail-closed artifact routing without adding workflow decision logic."
     },
     {
       "artifact_type": "glossary_entry",
@@ -2853,6 +2996,19 @@
       "notes": "HS-19 deterministic claim-level grounding/fact-check eval artifact with bounded failure classes and fail-closed policy traceability."
     },
     {
+      "artifact_type": "guardrail_event",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.0.83",
+      "last_updated_in": "1.0.83",
+      "example_path": "contracts/examples/guardrail_event.json",
+      "notes": "CDX-01 next-phase governed contract surface."
+    },
+    {
       "artifact_type": "handoff_artifact",
       "artifact_class": "governance",
       "schema_version": "1.0.0",
@@ -2864,6 +3020,32 @@
       "last_updated_in": "1.3.92",
       "example_path": "contracts/examples/handoff_artifact.json",
       "notes": "HR-B canonical governed reset-with-handoff state transfer artifact."
+    },
+    {
+      "artifact_type": "handoff_package",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.0.83",
+      "last_updated_in": "1.0.83",
+      "example_path": "contracts/examples/handoff_package.json",
+      "notes": "CDX-01 next-phase governed contract surface."
+    },
+    {
+      "artifact_type": "handoff_validation_result",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.0.83",
+      "last_updated_in": "1.0.83",
+      "example_path": "contracts/examples/handoff_validation_result.json",
+      "notes": "CDX-01 next-phase governed contract surface."
     },
     {
       "artifact_type": "hitl_override_decision",
@@ -3672,6 +3854,19 @@
       "notes": "RAX serial operating substrate governance contract."
     },
     {
+      "artifact_type": "latency_budget_status",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.0.83",
+      "last_updated_in": "1.0.83",
+      "example_path": "contracts/examples/latency_budget_status.json",
+      "notes": "CDX-01 next-phase governed contract surface."
+    },
+    {
       "artifact_type": "maintain_cycle_record",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -3820,6 +4015,19 @@
       "last_updated_in": "1.0.88",
       "example_path": "contracts/examples/meeting_minutes_record.example.json",
       "notes": "Machine-validated meeting minutes record emitted from meeting-minutes-engine for downstream consumption and DOCX rendering; payloads should be wrapped in the artifact envelope standard."
+    },
+    {
+      "artifact_type": "migration_plan_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.0.83",
+      "last_updated_in": "1.0.83",
+      "example_path": "contracts/examples/migration_plan_record.json",
+      "notes": "CDX-01 next-phase governed contract surface."
     },
     {
       "artifact_type": "milestone_plan",
@@ -4306,6 +4514,19 @@
       "last_updated_in": "1.3.61",
       "example_path": "contracts/examples/override_hotspot_report.json",
       "notes": "BATCH-12 ST-18 deterministic override concentration hotspots for governance attention."
+    },
+    {
+      "artifact_type": "override_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.0.83",
+      "last_updated_in": "1.0.83",
+      "example_path": "contracts/examples/override_record.json",
+      "notes": "CDX-01 next-phase governed contract surface."
     },
     {
       "artifact_type": "pattern_mining_recommendation",
@@ -4854,7 +5075,7 @@
       "introduced_in": "1.0.86",
       "last_updated_in": "1.0.87",
       "example_path": "contracts/examples/pqx_n_slice_validation_record.json",
-      "notes": "B30 first 5\u201310 slice governed-run readiness validation artifact."
+      "notes": "B30 first 5–10 slice governed-run readiness validation artifact."
     },
     {
       "artifact_type": "pqx_review_result",
@@ -5000,6 +5221,19 @@
       "notes": "PFX-01 governed preflight BLOCK auto-repair artifact."
     },
     {
+      "artifact_type": "preflight_recovery_outcome_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.1.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.126",
+      "last_updated_in": "1.3.126",
+      "example_path": "contracts/examples/preflight_recovery_outcome_record.json",
+      "notes": "PRF-06 terminal repair-state outcome for governed contract preflight."
+    },
+    {
       "artifact_type": "preflight_repair_attempt_record",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -5050,19 +5284,6 @@
       "last_updated_in": "1.3.125",
       "example_path": "contracts/examples/preflight_repair_validation_record.json",
       "notes": "PFX-01 governed preflight BLOCK auto-repair artifact."
-    },
-    {
-      "artifact_type": "preflight_recovery_outcome_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.1.0",
-      "status": "stable",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.126",
-      "last_updated_in": "1.3.126",
-      "example_path": "contracts/examples/preflight_recovery_outcome_record.json",
-      "notes": "PRF-06 terminal repair-state outcome for governed contract preflight."
     },
     {
       "artifact_type": "prg_governance_bundle",
@@ -5825,6 +6046,19 @@
       "notes": "MASTER-ROADMAP-001 governed advanced control-plane contract artifact."
     },
     {
+      "artifact_type": "query_index_manifest",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.0.83",
+      "last_updated_in": "1.0.83",
+      "example_path": "contracts/examples/query_index_manifest.json",
+      "notes": "CDX-01 next-phase governed contract surface."
+    },
+    {
       "artifact_type": "rax_adversarial_pattern_candidate",
       "artifact_class": "governance",
       "schema_version": "1.0.0",
@@ -6525,7 +6759,7 @@
       "introduced_in": "1.3.75",
       "last_updated_in": "1.3.77",
       "example_path": "contracts/examples/repair_prompt_artifact.json",
-      "notes": "BATCH-FRE-02 deterministic diagnosis\u2192repair bridge artifact defining bounded Codex-ready repair instructions, validation commands, constraints, and success criteria."
+      "notes": "BATCH-FRE-02 deterministic diagnosis→repair bridge artifact defining bounded Codex-ready repair instructions, validation commands, constraints, and success criteria."
     },
     {
       "artifact_class": "coordination",
@@ -6658,6 +6892,45 @@
       "notes": "HR-B canonical governed resume attempt artifact linked to checkpoint continuity state."
     },
     {
+      "artifact_type": "retirement_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.0.83",
+      "last_updated_in": "1.0.83",
+      "example_path": "contracts/examples/retirement_record.json",
+      "notes": "CDX-01 next-phase governed contract surface."
+    },
+    {
+      "artifact_type": "retroactive_pytest_integrity_audit_result",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.132",
+      "last_updated_in": "1.3.132",
+      "example_path": "contracts/examples/retroactive_pytest_integrity_audit_result.json",
+      "notes": "AUD-01 deterministic historical preflight trust backtest artifact classifying PYX-01 execution-truth integrity outcomes."
+    },
+    {
+      "artifact_type": "retroactive_pytest_remediation_queue",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.132",
+      "last_updated_in": "1.3.132",
+      "example_path": "contracts/examples/retroactive_pytest_remediation_queue.json",
+      "notes": "AUD-01 bounded remediation queue artifact for suspect historical preflight runs pending revalidation/quarantine decisions."
+    },
+    {
       "artifact_type": "reuse_record_artifact",
       "artifact_class": "governance",
       "schema_version": "1.0.0",
@@ -6787,7 +7060,7 @@
       "introduced_in": "1.3.98",
       "last_updated_in": "1.3.98",
       "example_path": "contracts/examples/review_fix_execution_request_artifact.json",
-      "notes": "RQX-B2 one-cycle governed request artifact requiring RQX\u2192TPA\u2192PQX\u2192RQX routing with max cycle count = 1."
+      "notes": "RQX-B2 one-cycle governed request artifact requiring RQX→TPA→PQX→RQX routing with max cycle count = 1."
     },
     {
       "artifact_type": "review_fix_execution_result_artifact",
@@ -6879,6 +7152,19 @@
       "last_updated_in": "1.3.101",
       "example_path": "contracts/examples/review_operator_handoff_artifact.json",
       "notes": "RQX-B3 strict unresolved post-cycle operator handoff artifact emitted after bounded one-cycle execution without automatic recursion."
+    },
+    {
+      "artifact_type": "review_outcome_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.0.83",
+      "last_updated_in": "1.0.83",
+      "example_path": "contracts/examples/review_outcome_record.json",
+      "notes": "CDX-01 next-phase governed contract surface."
     },
     {
       "artifact_type": "review_projection_bundle_artifact",
@@ -6985,6 +7271,19 @@
       "last_updated_in": "1.3.114",
       "example_path": "contracts/examples/ril_closeout_gate_record.json",
       "notes": "CDE-001 bounded decision authority and RIL closeout contract."
+    },
+    {
+      "artifact_type": "risk_classification_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.0.83",
+      "last_updated_in": "1.0.83",
+      "example_path": "contracts/examples/risk_classification_record.json",
+      "notes": "CDX-01 next-phase governed contract surface."
     },
     {
       "artifact_type": "risk_register",
@@ -7261,6 +7560,19 @@
       "notes": "BATCH-11 deterministic rollback planning artifact for promotion-sensitive and roadmap mutation reversibility guarantees."
     },
     {
+      "artifact_type": "route_candidate_set",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.0.83",
+      "last_updated_in": "1.0.83",
+      "example_path": "contracts/examples/route_candidate_set.json",
+      "notes": "CDX-01 next-phase governed contract surface."
+    },
+    {
       "artifact_type": "routing_decision",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -7272,6 +7584,19 @@
       "last_updated_in": "1.0.44",
       "example_path": "contracts/examples/routing_decision.json",
       "notes": "HS-04 deterministic runtime routing decision artifact linking policy selection, resolved prompt version, selected model id, and trace identifiers."
+    },
+    {
+      "artifact_type": "routing_decision_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.0.83",
+      "last_updated_in": "1.0.83",
+      "example_path": "contracts/examples/routing_decision_record.json",
+      "notes": "CDX-01 next-phase governed contract surface."
     },
     {
       "artifact_type": "routing_policy",
@@ -7725,6 +8050,32 @@
       "notes": "Gate-focused readiness assessment highlighting missing artifacts and blockers; payloads should be wrapped in the artifact envelope standard."
     },
     {
+      "artifact_type": "supersession_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.0.83",
+      "last_updated_in": "1.0.83",
+      "example_path": "contracts/examples/supersession_record.json",
+      "notes": "CDX-01 next-phase governed contract surface."
+    },
+    {
+      "artifact_type": "synthesized_trust_signal",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.0.83",
+      "last_updated_in": "1.0.83",
+      "example_path": "contracts/examples/synthesized_trust_signal.json",
+      "notes": "CDX-01 next-phase governed contract surface."
+    },
+    {
       "artifact_type": "system_budget_policy",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -7906,6 +8257,19 @@
       "last_updated_in": "1.3.124",
       "example_path": "contracts/examples/termination_signal_record.json",
       "notes": "CDE/BAX/CDE governed authority contract."
+    },
+    {
+      "artifact_type": "test_inventory_integrity_result",
+      "artifact_class": "governance",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.0.83",
+      "last_updated_in": "1.0.83",
+      "example_path": "contracts/examples/test_inventory_integrity_result.json",
+      "notes": "Governed pytest inventory integrity artifact for PR/default suite discovery and regression enforcement."
     },
     {
       "artifact_type": "tlc_handoff_debt_record",
@@ -8427,344 +8791,6 @@
       "last_updated_in": "1.0.82",
       "example_path": "contracts/examples/xrun_signal_quality_result.json",
       "notes": "VAL-06 governed validation artifact proving deterministic XRUN-01 pattern/action/signal quality and fail-closed handling under insufficient/malformed inputs."
-    },
-    {
-      "artifact_type": "eval_registry_entry",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.0.83",
-      "last_updated_in": "1.0.83",
-      "example_path": "contracts/examples/eval_registry_entry.json",
-      "notes": "CDX-01 next-phase governed contract surface."
-    },
-    {
-      "artifact_type": "eval_dataset_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.0.83",
-      "last_updated_in": "1.0.83",
-      "example_path": "contracts/examples/eval_dataset_record.json",
-      "notes": "CDX-01 next-phase governed contract surface."
-    },
-    {
-      "artifact_type": "eval_slice_definition",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.0.83",
-      "last_updated_in": "1.0.83",
-      "example_path": "contracts/examples/eval_slice_definition.json",
-      "notes": "CDX-01 next-phase governed contract surface."
-    },
-    {
-      "artifact_type": "failure_derived_eval_case",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.0.83",
-      "last_updated_in": "1.0.83",
-      "example_path": "contracts/examples/failure_derived_eval_case.json",
-      "notes": "CDX-01 next-phase governed contract surface."
-    },
-    {
-      "artifact_type": "evidence_sufficiency_result",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.0.83",
-      "last_updated_in": "1.0.83",
-      "example_path": "contracts/examples/evidence_sufficiency_result.json",
-      "notes": "CDX-01 next-phase governed contract surface."
-    },
-    {
-      "artifact_type": "abstention_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.0.83",
-      "last_updated_in": "1.0.83",
-      "example_path": "contracts/examples/abstention_record.json",
-      "notes": "CDX-01 next-phase governed contract surface."
-    },
-    {
-      "artifact_type": "route_candidate_set",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.0.83",
-      "last_updated_in": "1.0.83",
-      "example_path": "contracts/examples/route_candidate_set.json",
-      "notes": "CDX-01 next-phase governed contract surface."
-    },
-    {
-      "artifact_type": "routing_decision_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.0.83",
-      "last_updated_in": "1.0.83",
-      "example_path": "contracts/examples/routing_decision_record.json",
-      "notes": "CDX-01 next-phase governed contract surface."
-    },
-    {
-      "artifact_type": "comparison_run_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.0.83",
-      "last_updated_in": "1.0.83",
-      "example_path": "contracts/examples/comparison_run_record.json",
-      "notes": "CDX-01 next-phase governed contract surface."
-    },
-    {
-      "artifact_type": "comparison_result_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.0.83",
-      "last_updated_in": "1.0.83",
-      "example_path": "contracts/examples/comparison_result_record.json",
-      "notes": "CDX-01 next-phase governed contract surface."
-    },
-    {
-      "artifact_type": "guardrail_event",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.0.83",
-      "last_updated_in": "1.0.83",
-      "example_path": "contracts/examples/guardrail_event.json",
-      "notes": "CDX-01 next-phase governed contract surface."
-    },
-    {
-      "artifact_type": "cost_budget_status",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.0.83",
-      "last_updated_in": "1.0.83",
-      "example_path": "contracts/examples/cost_budget_status.json",
-      "notes": "CDX-01 next-phase governed contract surface."
-    },
-    {
-      "artifact_type": "latency_budget_status",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.0.83",
-      "last_updated_in": "1.0.83",
-      "example_path": "contracts/examples/latency_budget_status.json",
-      "notes": "CDX-01 next-phase governed contract surface."
-    },
-    {
-      "artifact_type": "override_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.0.83",
-      "last_updated_in": "1.0.83",
-      "example_path": "contracts/examples/override_record.json",
-      "notes": "CDX-01 next-phase governed contract surface."
-    },
-    {
-      "artifact_type": "review_outcome_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.0.83",
-      "last_updated_in": "1.0.83",
-      "example_path": "contracts/examples/review_outcome_record.json",
-      "notes": "CDX-01 next-phase governed contract surface."
-    },
-    {
-      "artifact_type": "handoff_package",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.0.83",
-      "last_updated_in": "1.0.83",
-      "example_path": "contracts/examples/handoff_package.json",
-      "notes": "CDX-01 next-phase governed contract surface."
-    },
-    {
-      "artifact_type": "handoff_validation_result",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.0.83",
-      "last_updated_in": "1.0.83",
-      "example_path": "contracts/examples/handoff_validation_result.json",
-      "notes": "CDX-01 next-phase governed contract surface."
-    },
-    {
-      "artifact_type": "cross_artifact_consistency_report",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.0.83",
-      "last_updated_in": "1.0.83",
-      "example_path": "contracts/examples/cross_artifact_consistency_report.json",
-      "notes": "CDX-01 next-phase governed contract surface."
-    },
-    {
-      "artifact_type": "migration_plan_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.0.83",
-      "last_updated_in": "1.0.83",
-      "example_path": "contracts/examples/migration_plan_record.json",
-      "notes": "CDX-01 next-phase governed contract surface."
-    },
-    {
-      "artifact_type": "risk_classification_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.0.83",
-      "last_updated_in": "1.0.83",
-      "example_path": "contracts/examples/risk_classification_record.json",
-      "notes": "CDX-01 next-phase governed contract surface."
-    },
-    {
-      "artifact_type": "supersession_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.0.83",
-      "last_updated_in": "1.0.83",
-      "example_path": "contracts/examples/supersession_record.json",
-      "notes": "CDX-01 next-phase governed contract surface."
-    },
-    {
-      "artifact_type": "retirement_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.0.83",
-      "last_updated_in": "1.0.83",
-      "example_path": "contracts/examples/retirement_record.json",
-      "notes": "CDX-01 next-phase governed contract surface."
-    },
-    {
-      "artifact_type": "active_set_snapshot",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.0.83",
-      "last_updated_in": "1.0.83",
-      "example_path": "contracts/examples/active_set_snapshot.json",
-      "notes": "CDX-01 next-phase governed contract surface."
-    },
-    {
-      "artifact_type": "query_index_manifest",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.0.83",
-      "last_updated_in": "1.0.83",
-      "example_path": "contracts/examples/query_index_manifest.json",
-      "notes": "CDX-01 next-phase governed contract surface."
-    },
-    {
-      "artifact_type": "synthesized_trust_signal",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.0.83",
-      "last_updated_in": "1.0.83",
-      "example_path": "contracts/examples/synthesized_trust_signal.json",
-      "notes": "CDX-01 next-phase governed contract surface."
-    },
-    {
-      "artifact_type": "test_inventory_integrity_result",
-      "artifact_class": "governance",
-      "schema_version": "1.0.0",
-      "status": "stable",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.0.83",
-      "last_updated_in": "1.0.83",
-      "example_path": "contracts/examples/test_inventory_integrity_result.json",
-      "notes": "Governed pytest inventory integrity artifact for PR/default suite discovery and regression enforcement."
     }
   ]
 }

--- a/contracts/standards-manifest.json
+++ b/contracts/standards-manifest.json
@@ -1,11 +1,11 @@
 {
   "artifact_type": "standards_manifest",
   "artifact_id": "STD-CONTRACTS",
-  "artifact_version": "1.3.132",
+  "artifact_version": "1.3.133",
   "schema_version": "1.3.99",
   "standards_version": "1.0.83",
-  "record_id": "REC-STD-2026-04-14-AUD-01-RETROACTIVE-PYTEST-INTEGRITY",
-  "run_id": "run-20260414T000000Z-aud-01-retroactive-pytest-integrity",
+  "record_id": "REC-STD-2026-04-14-PYX-02-PR-PYTEST-ENFORCEMENT",
+  "run_id": "run-20260414T000000Z-pyx-02-pr-pytest-enforcement",
   "created_at": "2026-04-14T00:00:00Z",
   "created_by": {
     "name": "Spectrum Systems Architecture Team",
@@ -15,7 +15,7 @@
     "contact": "architecture@spectrum-systems.test"
   },
   "source_repo": "nicklasorte/spectrum-systems",
-  "source_repo_version": "1.3.132",
+  "source_repo_version": "1.3.133",
   "input_artifacts": [
     {
       "artifact_id": "STD-CONTRACTS",
@@ -5992,6 +5992,19 @@
       "last_updated_in": "1.3.116",
       "example_path": "contracts/examples/publication_attempt_record.json",
       "notes": "DASHBOARD-REFRESH-PUBLISH-LOOP-01 governed allow/block/freeze publication decision artifact."
+    },
+    {
+      "artifact_type": "pytest_execution_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.133",
+      "last_updated_in": "1.3.133",
+      "example_path": "contracts/examples/pytest_execution_record.json",
+      "notes": "PYX-02 canonical preflight-owned pytest execution evidence artifact for pull_request trust gating fail-closed checks."
     },
     {
       "artifact_type": "qos_backpressure_signal",

--- a/docs/governance/README.md
+++ b/docs/governance/README.md
@@ -98,3 +98,14 @@ Each template already wires:
   - `pytest tests/test_governed_prompt_surface_sync.py`
 
 A missing governance reference is a blocking defect and must be remediated before prompt execution.
+
+## Retroactive pytest integrity audit (AUD-01)
+Use this governed backtest to retrieve historical preflight evidence and classify trust posture relative to PYX-01 execution-truth authority.
+
+- Runtime module: `spectrum_systems/modules/runtime/retroactive_pytest_integrity_audit.py`
+- CLI: `scripts/run_retroactive_pytest_integrity_audit.py`
+- Output artifacts:
+  - `outputs/retroactive_pytest_integrity_audit/retroactive_pytest_integrity_audit_result.json`
+  - `outputs/retroactive_pytest_integrity_audit/retroactive_pytest_remediation_queue.json`
+
+This audit does not replace forward preflight authority. It isolates historical suspect runs for bounded remediation and quarantine decisions.

--- a/docs/review-actions/PLAN-AUD-01-2026-04-14.md
+++ b/docs/review-actions/PLAN-AUD-01-2026-04-14.md
@@ -1,0 +1,23 @@
+# Plan — AUD-01 — 2026-04-14
+
+## Prompt type
+BUILD
+
+## Roadmap item
+AUD-01
+
+## Objective
+Implement a governed, deterministic retroactive pytest integrity audit capability that backtests historical preflight artifacts against PYX-01 execution-truth authority rules, emits schema-bound audit/remediation artifacts, and documents operator usage and trust limits.
+
+## Scope
+1. Add runtime classification module for historical preflight artifact loading, normalization, trust classification, reason codes, and bounded remediation recommendations.
+2. Add strict contract schema(s) and example artifact(s) for retroactive pytest integrity audit outputs.
+3. Add thin CLI script to scan repo-known artifact roots, run the audit module, and write deterministic output artifacts under governed outputs.
+4. Add focused tests for trusted/suspect/unable classification behavior, non-PR context handling, remediation queue determinism, and schema/example validation.
+5. Add review artifact documenting methodology, scan scope, limits, risks, and operator workflow.
+6. Wire canonical governance/review index references and standards manifest entries for new contract artifacts.
+
+## Validation
+- `pytest tests/test_retroactive_pytest_integrity_audit.py`
+- `pytest tests/test_contracts.py tests/test_contract_enforcement.py tests/test_contract_bootstrap.py`
+- `python scripts/run_contract_enforcement.py`

--- a/docs/review-actions/PLAN-PYX-02-2026-04-14.md
+++ b/docs/review-actions/PLAN-PYX-02-2026-04-14.md
@@ -1,0 +1,24 @@
+# Plan — PYX-02 — 2026-04-14
+
+## Prompt type
+BUILD
+
+## Roadmap item
+PYX-02
+
+## Objective
+Restore mandatory pull_request pytest execution in the real preflight enforcement seam and fail closed when execution evidence is missing, non-authoritative, or inconsistent.
+
+## Scope
+1. Trace and document the live PR workflow execution chain and root cause in `docs/reviews/PYX-02_pr_pytest_execution_path_review.md`.
+2. Harden canonical preflight runtime (`scripts/run_contract_preflight.py`) to emit deterministic pytest execution evidence artifact and block PR trust when evidence invariants fail.
+3. Update workflow enforcement (`.github/workflows/artifact-boundary.yml`) to validate preflight-owned pytest execution evidence artifact before allowing trusted outcomes.
+4. Add/extend contract schemas/examples for pytest execution evidence and preflight artifact linkage.
+5. Add focused tests for workflow path assertions and fail-closed preflight behavior.
+6. Update standards manifest registrations/version for any new contract artifacts.
+
+## Validation
+- `pytest tests/test_contract_preflight.py`
+- `pytest tests/test_artifact_boundary_workflow_pytest_enforcement.py`
+- `pytest tests/test_contracts.py tests/test_contract_enforcement.py tests/test_contract_bootstrap.py`
+- `python scripts/run_contract_enforcement.py`

--- a/docs/reviews/AUD-01-retroactive-pytest-integrity-audit.md
+++ b/docs/reviews/AUD-01-retroactive-pytest-integrity-audit.md
@@ -1,0 +1,54 @@
+# AUD-01 — Retroactive Pytest Integrity Audit
+
+## Summary
+AUD-01 adds a governed retroactive backtest capability that re-evaluates historical preflight artifacts for PYX-01 pytest execution authority compliance. The capability emits deterministic, schema-bound audit and remediation artifacts without mutating historical evidence.
+
+## Methodology
+1. Retrieve historical preflight artifacts from repo-local governed roots (`outputs/`, `artifacts/`, `data/`).
+2. Normalize each artifact into a deterministic trust classification tuple:
+   - classification
+   - reason codes
+   - context (`pr`, `non_pr`, `unknown`)
+   - remediation recommendation
+3. Apply PYX-01 backtest rules:
+   - PR trust outcomes (`ALLOW`/`WARN`/`passed`) require authoritative `pytest_execution` truth from preflight-owned fields.
+   - Missing or incomplete execution-truth fields are suspect.
+   - Workflow/downstream pytest evidence is non-authoritative.
+4. Emit:
+   - `retroactive_pytest_integrity_audit_result`
+   - bounded `retroactive_pytest_remediation_queue`
+
+## Scan scope
+- `**/contract_preflight_result_artifact.json`
+- `**/contract_preflight_report.json`
+- Restricted to repo-local scan roots only (no network, no external system scan).
+
+## Trust limits
+- The audit can only reason over persisted artifacts available in-repo.
+- If context cannot be recovered (missing event shape), the run is classified `unable_to_evaluate` rather than trusted.
+- This audit does not reconstruct git history or infer missing artifacts from workflow logs.
+
+## False-positive / false-negative risks
+### False positives
+- Historical non-PR runs with partial fields may still appear suspect if they claim PR-style trust semantics.
+
+### False negatives
+- If non-authoritative workflow evidence is embedded in unrecognized custom fields, detection may miss it.
+- Missing historical artifacts cannot be evaluated and are explicitly isolated as `unable_to_evaluate`.
+
+## Operator usage
+1. Run: `python scripts/run_retroactive_pytest_integrity_audit.py`
+2. Review result artifact counts and reason-code summary.
+3. Treat remediation queue as bounded worklist:
+   - re-run governed preflight when commit-pair context is reconstructable
+   - otherwise perform manual operator review
+   - quarantine suspect runs from trusted baseline metrics until revalidated
+
+## Determinism and fail-closed behavior
+- Input traversal and output ordering are path-sorted.
+- Queue size is explicitly bounded.
+- Command exits non-zero only when audit execution invariants fail.
+- Suspect findings are data outcomes, not process failures.
+
+## Next operator step
+Run this audit as part of governance health checks and triage queue items to close historical trust debt before using legacy run sets as baseline-quality evidence.

--- a/docs/reviews/PYX-02_pr_pytest_execution_path_review.md
+++ b/docs/reviews/PYX-02_pr_pytest_execution_path_review.md
@@ -1,0 +1,32 @@
+# PYX-02 — PR Pytest Execution Path Review
+
+## Scope inspected
+- `.github/workflows/artifact-boundary.yml`
+- `.github/workflows/pr-autofix-contract-preflight.yml`
+- `scripts/run_contract_preflight.py`
+- `scripts/run_github_pr_autofix_contract_preflight.py`
+- `spectrum_systems/modules/runtime/github_pr_autofix_contract_preflight.py`
+- `spectrum_systems/modules/runtime/test_inventory_integrity.py`
+
+## Live pull_request workflow path
+1. `artifact-boundary.yml` triggers on `pull_request`.
+2. Job `contract-preflight` runs `scripts/build_preflight_pqx_wrapper.py` then `scripts/run_contract_preflight.py`.
+3. If first pass blocks and auto-repair is eligible, same job runs `scripts/run_github_pr_autofix_contract_preflight.py` (which reruns preflight).
+4. `contract-preflight` currently checks `contract_preflight_result_artifact.json` and only enforces `pytest_execution.pytest_execution_count >= 1` for `ALLOW/WARN` outcomes.
+5. Separate job `run-pytest` runs direct `pytest` but is explicitly non-authoritative redundancy; trust authority is preflight artifact.
+
+## Where pytest is executed
+- Not directly in the preflight workflow step shell.
+- Indirectly inside `scripts/run_contract_preflight.py` through `run_targeted_pytests(...)`.
+- Fallback PR targets are run in preflight when no deterministic target selection exists.
+
+## Is `scripts/run_contract_preflight.py` in the live PR path?
+Yes. It is in the canonical `artifact-boundary.yml` pull_request path and is the trust authority surface used by downstream checks.
+
+## Current gap (pre-fix)
+- Workflow-level guard only verifies `pytest_execution_count` from preflight artifact.
+- There is no dedicated schema-bound pytest execution evidence artifact with executed flag, per-command exit accounting, or explicit failure reason.
+- This allows “report-only” trust interpretation risk: a thin count field can be present without strong evidence semantics (artifact existence + authoritative execution accounting contract).
+
+## Exact root cause of “PR had no pytest”
+The enforcement seam relied on coarse `pytest_execution_count` signaling rather than a strict preflight-owned pytest execution evidence artifact and invariant checks. That left a trust gap where audit/reporting hardening could land without fully hard-failing all missing-or-non-authoritative execution evidence states in the canonical PR gate.

--- a/docs/reviews/review-registry.md
+++ b/docs/reviews/review-registry.md
@@ -20,6 +20,8 @@ See `docs/reviews/README.md` for the review protocol and `ADR-005-review-protoco
 | [2026-03-18-maturity-review](2026-03-18-maturity-review.md) | 2026-03-18 | REVIEW — Focused control-loop maturity assessment (AN–AW2 scope) | spectrum-systems | Copilot (Architecture Agent) | Open | 7/20 | Re-run after MR-001 through MR-005 complete (operational AU→AW2 cycle with committed artifacts). Target: advance score from L7 to L9. |
 | [2026-03-22-governed-prompt-queue-live-review-invocation-impl-review](governed_prompt_queue_live_review_invocation_impl_review.md) | 2026-03-22 | Pre-implementation surgical design review — first bounded live review invocation slice | spectrum-systems | Claude (Reasoning Agent — Sonnet 4.6) | Open | — | When LI-CR-3 (write ordering spec) and LI-CR-4 (failure-to-state mapping) are published: implementation may begin. Re-review when first live invocation implementation is complete. Verdict: PASS. Trust: YES. |
 
+| [AUD-01-retroactive-pytest-integrity-audit](AUD-01-retroactive-pytest-integrity-audit.md) | 2026-04-14 | BUILD — Retroactive pytest execution integrity backtest review | spectrum-systems | Codex (repository execution) | Open | — | Re-run after first bounded remediation queue cycle completes and suspect set is triaged. |
+
 ## Carried-Forward Findings (as of 2026-03-17 closure verification)
 
 The following findings from prior reviews remain unresolved and are tracked in the `2026-03-16-governance-constitution-deep-review` registry entry. See `review-registry.json` for full `carried_forward_findings` detail.

--- a/scripts/run_contract_preflight.py
+++ b/scripts/run_contract_preflight.py
@@ -19,7 +19,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from spectrum_systems.contracts import load_schema  # noqa: E402
+from spectrum_systems.contracts import load_schema, validate_artifact  # noqa: E402
 from spectrum_systems.governance.contract_impact import analyze_contract_impact  # noqa: E402
 from spectrum_systems.modules.runtime.changed_path_resolution import (  # noqa: E402
     resolve_changed_paths,
@@ -726,6 +726,69 @@ def run_targeted_pytests(paths: list[str], *, execution_log: list[dict[str, Any]
     return failures
 
 
+def build_pytest_execution_record(
+    *,
+    event_name: str,
+    execution_log: list[dict[str, Any]],
+    selected_targets: list[str],
+    fallback_targets: list[str],
+    fallback_used: bool,
+    targeted_selection_empty: bool,
+    fallback_selection_empty: bool,
+    selection_reason_codes: list[str],
+) -> dict[str, Any]:
+    entries: list[dict[str, Any]] = []
+    for item in execution_log:
+        entries.append(
+            {
+                "target": str(item.get("target", "")),
+                "command": str(item.get("command", "")),
+                "exit_code": int(item.get("returncode", 0)),
+            }
+        )
+    effective_targets = sorted(
+        {
+            str(entry.get("target", "")).strip()
+            for entry in entries
+            if str(entry.get("target", "")).strip()
+        }
+    )
+    aggregate_exit_code = 0
+    if entries:
+        aggregate_exit_code = max(int(entry.get("exit_code", 0)) for entry in entries)
+    executed = len(entries) > 0
+    failure_reason = None
+    if not executed:
+        failure_reason = "no_pytest_command_executed"
+    elif aggregate_exit_code != 0:
+        failure_reason = "pytest_command_failed"
+
+    workflow_name = str(os.environ.get("GITHUB_WORKFLOW", "")).strip()
+    workflow_job = str(os.environ.get("GITHUB_JOB", "")).strip()
+    return {
+        "artifact_type": "pytest_execution_record",
+        "schema_version": "1.0.0",
+        "event_name": event_name,
+        "workflow_name": workflow_name or None,
+        "workflow_job": workflow_job or None,
+        "executed": executed,
+        "pytest_command": " ; ".join(str(entry.get("command", "")) for entry in entries),
+        "selected_targets": effective_targets,
+        "configured_selected_targets": sorted(set(selected_targets)),
+        "fallback_targets": sorted(set(fallback_targets)),
+        "fallback_used": bool(fallback_used),
+        "targeted_selection_empty": bool(targeted_selection_empty),
+        "fallback_selection_empty": bool(fallback_selection_empty),
+        "selection_reason_codes": sorted(set(selection_reason_codes)),
+        "collection_count": None,
+        "exit_code": aggregate_exit_code,
+        "execution_count": len(entries),
+        "execution_entries": entries,
+        "timestamp": _utc_now(),
+        "failure_reason": failure_reason,
+    }
+
+
 def detect_masked_failures(failures: list[dict[str, Any]]) -> list[dict[str, Any]]:
     masked: list[dict[str, Any]] = []
     for item in failures:
@@ -1232,7 +1295,7 @@ def build_preflight_result_artifact(
         }
     return {
         "artifact_type": "contract_preflight_result_artifact",
-        "schema_version": "1.2.0",
+        "schema_version": "1.3.0",
         "preflight_status": report.get("status", "failed"),
         "changed_contracts": report.get("changed_contracts", []),
         "impacted_producers": report.get("impact", {}).get("producers", []),
@@ -1250,6 +1313,7 @@ def build_preflight_result_artifact(
         "pqx_gap_work_items_ref": report.get("pqx_gap_work_items_ref"),
         "control_surface_gap_blocking": bool(report.get("control_surface_gap_blocking", False)),
         "pytest_execution": report.get("pytest_execution", {}),
+        "pytest_execution_record_ref": report.get("pytest_execution_record_ref"),
         "pqx_required_context_enforcement": {
             "classification": str(required_context.get("classification", "exploration_only_or_non_governed")),
             "execution_context": str(required_context.get("execution_context", "unspecified")),
@@ -1776,6 +1840,39 @@ def main() -> int:
         "fallback_selection_empty": fallback_selection_empty,
         "selection_reason_codes": sorted(set(pytest_selection_reason_codes)),
     }
+    pytest_execution_record = build_pytest_execution_record(
+        event_name=str(ref_context.event_name or ""),
+        execution_log=pytest_execution_log,
+        selected_targets=selected_pytest_targets,
+        fallback_targets=fallback_pytest_targets,
+        fallback_used=fallback_pytest_used,
+        targeted_selection_empty=targeted_selection_empty,
+        fallback_selection_empty=fallback_selection_empty,
+        selection_reason_codes=pytest_selection_reason_codes,
+    )
+    validate_artifact(pytest_execution_record, "pytest_execution_record")
+    pytest_execution_record_path = output_dir / "pytest_execution_record.json"
+    pytest_execution_record_path.write_text(json.dumps(pytest_execution_record, indent=2) + "\n", encoding="utf-8")
+    report["pytest_execution_record_ref"] = str(pytest_execution_record_path)
+
+    if is_pull_request_event:
+        if not bool(pytest_execution_record.get("executed", False)):
+            report["status"] = "failed"
+            report["invariant_violations"] = sorted(
+                set(report.get("invariant_violations", []) + ["PR_PYTEST_EXECUTION_RECORD_REQUIRED"])
+            )
+            report["recommended_repair_areas"] = sorted(
+                set(report.get("recommended_repair_areas", []) + ["restore canonical PR pytest execution path"])
+            )
+        if not report["pytest_execution"]["selected_targets"] and not report["pytest_execution"]["fallback_targets"]:
+            report["status"] = "failed"
+            report["invariant_violations"] = sorted(
+                set(report.get("invariant_violations", []) + ["PR_PYTEST_SELECTED_TARGETS_EMPTY"])
+            )
+            report["recommended_repair_areas"] = sorted(
+                set(report.get("recommended_repair_areas", []) + ["restore deterministic PR pytest target selection"])
+            )
+
     if report["control_surface_enforcement"] and report["control_surface_enforcement"].get("enforcement_status") == "BLOCK":
         report["status"] = "failed"
         report["invariant_violations"] = sorted(

--- a/scripts/run_retroactive_pytest_integrity_audit.py
+++ b/scripts/run_retroactive_pytest_integrity_audit.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Run deterministic retroactive PYX-01 pytest integrity backtest."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from spectrum_systems.modules.runtime.retroactive_pytest_integrity_audit import (  # noqa: E402
+    RetroactivePytestIntegrityAuditError,
+    run_retroactive_pytest_integrity_audit,
+    scan_historical_preflight_artifacts,
+)
+
+
+DEFAULT_SCAN_ROOTS = ["outputs", "artifacts", "data"]
+DEFAULT_OUTPUT_DIR = "outputs/retroactive_pytest_integrity_audit"
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run retroactive pytest integrity audit against local governed artifacts.")
+    parser.add_argument(
+        "--scan-root",
+        action="append",
+        default=[],
+        help="Optional scan roots (repeatable). Defaults to repo-known roots: outputs, artifacts, data.",
+    )
+    parser.add_argument("--output-dir", default=DEFAULT_OUTPUT_DIR, help="Output directory for audit artifacts.")
+    parser.add_argument("--remediation-queue-limit", type=int, default=50, help="Maximum remediation items to emit.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+
+    scan_roots_raw = args.scan_root or DEFAULT_SCAN_ROOTS
+    scan_roots = [
+        (REPO_ROOT / root).resolve() if not Path(root).is_absolute() else Path(root)
+        for root in scan_roots_raw
+    ]
+
+    scanned_artifacts = scan_historical_preflight_artifacts(scan_roots)
+    audit_scope = {
+        "roots": [str(path) for path in scan_roots],
+        "artifact_globs": ["**/contract_preflight_result_artifact.json", "**/contract_preflight_report.json"],
+        "repo_root": str(REPO_ROOT),
+    }
+
+    result, queue = run_retroactive_pytest_integrity_audit(
+        scanned_artifacts=scanned_artifacts,
+        audit_scope=audit_scope,
+        remediation_queue_limit=args.remediation_queue_limit,
+    )
+
+    output_dir = (REPO_ROOT / args.output_dir).resolve() if not Path(args.output_dir).is_absolute() else Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    result_path = output_dir / "retroactive_pytest_integrity_audit_result.json"
+    queue_path = output_dir / "retroactive_pytest_remediation_queue.json"
+
+    result_path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    queue_path.write_text(json.dumps(queue, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    print(
+        json.dumps(
+            {
+                "result_path": str(result_path),
+                "queue_path": str(queue_path),
+                "scanned_run_count": result["scanned_run_count"],
+                "suspect_count": result["suspect_count"],
+                "unable_to_evaluate_count": result["unable_to_evaluate_count"],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except RetroactivePytestIntegrityAuditError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        raise SystemExit(2)

--- a/spectrum_systems/modules/runtime/github_pr_autofix_contract_preflight.py
+++ b/spectrum_systems/modules/runtime/github_pr_autofix_contract_preflight.py
@@ -209,6 +209,8 @@ def classify_preflight_block(*, report: dict[str, Any]) -> tuple[str, list[str]]
             return "no_tests_discovered", ["PR_PYTEST_EXECUTION_REQUIRED"]
         if "PREFLIGHT_PASS_WITHOUT_PYTEST_EXECUTION" in invariant_violations:
             return "no_tests_discovered", ["PREFLIGHT_PASS_WITHOUT_PYTEST_EXECUTION"]
+        if "PR_PYTEST_EXECUTION_RECORD_REQUIRED" in invariant_violations:
+            return "no_tests_discovered", ["PR_PYTEST_EXECUTION_RECORD_REQUIRED"]
         if "PR_PYTEST_SELECTED_TARGETS_EMPTY" in invariant_violations:
             return "no_tests_discovered", ["PR_PYTEST_SELECTED_TARGETS_EMPTY"]
         if "PR_PYTEST_FALLBACK_TARGETS_EMPTY" in invariant_violations:

--- a/spectrum_systems/modules/runtime/preflight_failure_normalizer.py
+++ b/spectrum_systems/modules/runtime/preflight_failure_normalizer.py
@@ -19,7 +19,11 @@ def normalize_preflight_failure(report: dict[str, Any]) -> dict[str, Any]:
         "has_invariant_violations": bool(report.get("invariant_violations")),
         "has_control_surface_gap": bool(report.get("control_surface_gap_blocking")),
         "has_pytest_execution_gap": bool(
-            {"PR_PYTEST_EXECUTION_REQUIRED", "PREFLIGHT_PASS_WITHOUT_PYTEST_EXECUTION"}
+            {
+                "PR_PYTEST_EXECUTION_REQUIRED",
+                "PREFLIGHT_PASS_WITHOUT_PYTEST_EXECUTION",
+                "PR_PYTEST_EXECUTION_RECORD_REQUIRED",
+            }
             & set(report.get("invariant_violations", []))
         ),
         "has_test_inventory_failure": (

--- a/spectrum_systems/modules/runtime/retroactive_pytest_integrity_audit.py
+++ b/spectrum_systems/modules/runtime/retroactive_pytest_integrity_audit.py
@@ -1,0 +1,307 @@
+"""Deterministic retroactive audit for PYX-01 pytest execution integrity.
+
+This module backtests historical preflight artifacts to identify runs that may
+have been treated as trusted without authoritative pytest execution truth.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from spectrum_systems.contracts import validate_artifact
+
+
+class RetroactivePytestIntegrityAuditError(ValueError):
+    """Raised when retroactive audit execution invariants are violated."""
+
+
+KNOWN_PR_EVENTS = {
+    "pull_request",
+    "pull_request_target",
+    "pull_request_review",
+    "pull_request_review_comment",
+}
+
+TRUSTING_DECISIONS = {"ALLOW", "WARN"}
+TRUSTING_STATUSES = {"passed", "warn", "warning"}
+
+REASON_HISTORICAL_ALLOW_WITHOUT_PYTEST = "HISTORICAL_PR_ALLOW_WITHOUT_PYTEST_EXECUTION"
+REASON_HISTORICAL_WARN_WITHOUT_PYTEST = "HISTORICAL_WARN_WITHOUT_PYTEST_EXECUTION"
+REASON_FIELDS_MISSING = "HISTORICAL_EXECUTION_FIELDS_MISSING"
+REASON_NON_AUTHORITATIVE = "HISTORICAL_NON_AUTHORITATIVE_TEST_EVIDENCE"
+REASON_PRE_PYX_SHAPE = "HISTORICAL_ARTIFACT_SHAPE_PRE_PYX01"
+REASON_CONTEXT_NOT_EVALUABLE = "HISTORICAL_CONTEXT_NOT_EVALUABLE"
+REASON_INCOMPLETE_ACCOUNTING = "HISTORICAL_INCOMPLETE_EXECUTION_ACCOUNTING"
+
+REQUIRED_EXECUTION_FIELDS = {
+    "event_name",
+    "pytest_execution_count",
+    "pytest_commands",
+    "selected_targets",
+    "fallback_targets",
+    "fallback_used",
+    "targeted_selection_empty",
+    "fallback_selection_empty",
+    "selection_reason_codes",
+}
+
+
+def _read_json_object(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise RetroactivePytestIntegrityAuditError(f"missing_artifact:{path}") from exc
+    except json.JSONDecodeError as exc:
+        raise RetroactivePytestIntegrityAuditError(f"invalid_json:{path}:{exc}") from exc
+    if not isinstance(payload, dict):
+        raise RetroactivePytestIntegrityAuditError(f"artifact_not_object:{path}")
+    return payload
+
+
+def _derive_event_name(payload: dict[str, Any]) -> str | None:
+    pytest_execution = payload.get("pytest_execution")
+    if isinstance(pytest_execution, dict):
+        event_name = pytest_execution.get("event_name")
+        if isinstance(event_name, str) and event_name.strip():
+            return event_name.strip()
+    changed_path_detection = payload.get("changed_path_detection")
+    if isinstance(changed_path_detection, dict):
+        ref_context = changed_path_detection.get("ref_context")
+        if isinstance(ref_context, dict):
+            event_name = ref_context.get("event_name")
+            if isinstance(event_name, str) and event_name.strip():
+                return event_name.strip()
+    return None
+
+
+def _is_trusting_outcome(payload: dict[str, Any]) -> bool:
+    status = str(payload.get("preflight_status") or payload.get("status") or "").strip().lower()
+    if status in TRUSTING_STATUSES:
+        return True
+    control_signal = payload.get("control_signal")
+    if isinstance(control_signal, dict):
+        decision = str(control_signal.get("strategy_gate_decision") or "").strip().upper()
+        if decision in TRUSTING_DECISIONS:
+            return True
+    return False
+
+
+def _missing_execution_fields(pytest_execution: dict[str, Any]) -> list[str]:
+    return sorted(field for field in REQUIRED_EXECUTION_FIELDS if field not in pytest_execution)
+
+
+def _has_non_authoritative_evidence(payload: dict[str, Any]) -> bool:
+    lower_keys = {str(key).lower() for key in payload.keys()}
+    if any("workflow_pytest" in key or "downstream_pytest" in key for key in lower_keys):
+        return True
+    evidence_refs = payload.get("evidence_refs")
+    if isinstance(evidence_refs, list):
+        for item in evidence_refs:
+            text = str(item).lower()
+            if "workflow" in text and "pytest" in text:
+                return True
+    return False
+
+
+def classify_historical_preflight_artifact(payload: dict[str, Any], *, artifact_path: str) -> dict[str, Any]:
+    """Classify one historical artifact into trusted/suspect/unable state."""
+    reasons: list[str] = []
+
+    artifact_type = str(payload.get("artifact_type") or "")
+    if artifact_type not in {"contract_preflight_result_artifact", ""}:
+        return {
+            "artifact_path": artifact_path,
+            "classification": "unable_to_evaluate",
+            "reason_codes": [REASON_CONTEXT_NOT_EVALUABLE],
+            "trusting_outcome": False,
+            "context": "unknown",
+            "remediation_recommendation": "manual_operator_review_required",
+        }
+
+    trusting_outcome = _is_trusting_outcome(payload)
+    event_name = _derive_event_name(payload)
+    is_pr = event_name in KNOWN_PR_EVENTS
+    context = "pr" if is_pr else ("non_pr" if event_name else "unknown")
+
+    pytest_execution = payload.get("pytest_execution")
+    if pytest_execution is None:
+        reasons.append(REASON_PRE_PYX_SHAPE)
+        if trusting_outcome and is_pr:
+            decision = str(((payload.get("control_signal") or {}).get("strategy_gate_decision") or "")).upper()
+            reasons.append(REASON_HISTORICAL_WARN_WITHOUT_PYTEST if decision == "WARN" else REASON_HISTORICAL_ALLOW_WITHOUT_PYTEST)
+    elif not isinstance(pytest_execution, dict):
+        reasons.append(REASON_FIELDS_MISSING)
+    else:
+        missing = _missing_execution_fields(pytest_execution)
+        if missing:
+            reasons.append(REASON_FIELDS_MISSING)
+        if trusting_outcome and is_pr:
+            count = pytest_execution.get("pytest_execution_count")
+            if not isinstance(count, int) or count < 1:
+                reasons.append(REASON_INCOMPLETE_ACCOUNTING)
+                decision = str(((payload.get("control_signal") or {}).get("strategy_gate_decision") or "")).upper()
+                reasons.append(REASON_HISTORICAL_WARN_WITHOUT_PYTEST if decision == "WARN" else REASON_HISTORICAL_ALLOW_WITHOUT_PYTEST)
+
+    if trusting_outcome and _has_non_authoritative_evidence(payload):
+        reasons.append(REASON_NON_AUTHORITATIVE)
+
+    if context == "unknown":
+        reasons.append(REASON_CONTEXT_NOT_EVALUABLE)
+
+    deduped_reasons = sorted(set(reasons))
+    if any(
+        code in deduped_reasons
+        for code in {
+            REASON_HISTORICAL_ALLOW_WITHOUT_PYTEST,
+            REASON_HISTORICAL_WARN_WITHOUT_PYTEST,
+            REASON_FIELDS_MISSING,
+            REASON_NON_AUTHORITATIVE,
+            REASON_INCOMPLETE_ACCOUNTING,
+            REASON_PRE_PYX_SHAPE,
+        }
+    ):
+        classification = (
+            "unable_to_evaluate"
+            if REASON_CONTEXT_NOT_EVALUABLE in deduped_reasons and context == "unknown"
+            else (
+                "suspect_non_authoritative_pytest"
+                if REASON_NON_AUTHORITATIVE in deduped_reasons
+                else (
+                    "suspect_incomplete_execution_accounting"
+                    if REASON_INCOMPLETE_ACCOUNTING in deduped_reasons
+                    else "suspect_missing_pytest_execution"
+                )
+            )
+        )
+    elif REASON_CONTEXT_NOT_EVALUABLE in deduped_reasons:
+        classification = "unable_to_evaluate"
+    else:
+        classification = "trusted"
+
+    remediation = "none"
+    if classification.startswith("suspect"):
+        remediation = "manual_operator_review_required"
+        if context == "pr":
+            remediation = "re_run_governed_preflight_if_commit_pair_reconstructable"
+
+    return {
+        "artifact_path": artifact_path,
+        "classification": classification,
+        "reason_codes": deduped_reasons,
+        "trusting_outcome": trusting_outcome,
+        "context": context,
+        "remediation_recommendation": remediation,
+    }
+
+
+def scan_historical_preflight_artifacts(scan_roots: list[Path]) -> list[dict[str, Any]]:
+    """Load historical preflight artifacts under governed repo-known locations."""
+    paths: set[Path] = set()
+    patterns = ("**/contract_preflight_result_artifact.json", "**/contract_preflight_report.json")
+    for root in scan_roots:
+        if not root.exists():
+            continue
+        for pattern in patterns:
+            for path in root.glob(pattern):
+                if path.is_file():
+                    paths.add(path)
+
+    artifacts: list[dict[str, Any]] = []
+    for path in sorted(paths, key=lambda item: str(item).lower()):
+        payload = _read_json_object(path)
+        payload["__artifact_path"] = str(path.as_posix())
+        artifacts.append(payload)
+    return artifacts
+
+
+def run_retroactive_pytest_integrity_audit(
+    *,
+    scanned_artifacts: list[dict[str, Any]],
+    audit_scope: dict[str, Any],
+    remediation_queue_limit: int = 50,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Produce schema-bound audit result and bounded remediation queue artifacts."""
+    if remediation_queue_limit < 1:
+        raise RetroactivePytestIntegrityAuditError("remediation_queue_limit must be >= 1")
+
+    classified_runs = [
+        classify_historical_preflight_artifact(artifact, artifact_path=str(artifact.get("__artifact_path") or "unknown"))
+        for artifact in scanned_artifacts
+    ]
+    classified_runs = sorted(classified_runs, key=lambda item: item["artifact_path"])
+
+    suspect_runs = [item for item in classified_runs if item["classification"].startswith("suspect")]
+    unable_runs = [item for item in classified_runs if item["classification"] == "unable_to_evaluate"]
+    trusted_runs = [item for item in classified_runs if item["classification"] == "trusted"]
+
+    remediation_queue = [
+        {
+            "artifact_path": item["artifact_path"],
+            "classification": item["classification"],
+            "reason_codes": item["reason_codes"],
+            "recommended_action": item["remediation_recommendation"],
+            "quarantine_recommendation": "quarantine_from_trusted_baseline_metrics_until_revalidated",
+        }
+        for item in suspect_runs[:remediation_queue_limit]
+    ]
+
+    generated_at = "1970-01-01T00:00:00Z"
+    source_timestamps = sorted(
+        {
+            str(artifact.get("generated_at"))
+            for artifact in scanned_artifacts
+            if isinstance(artifact.get("generated_at"), str) and artifact.get("generated_at")
+        }
+    )
+    if source_timestamps:
+        generated_at = source_timestamps[-1]
+
+    summary_reason_codes = sorted({code for item in classified_runs for code in item.get("reason_codes", [])})
+
+    result = {
+        "artifact_type": "retroactive_pytest_integrity_audit_result",
+        "schema_version": "1.0.0",
+        "audit_scope": audit_scope,
+        "scanned_run_count": len(classified_runs),
+        "trusted_count": len(trusted_runs),
+        "suspect_count": len(suspect_runs),
+        "unable_to_evaluate_count": len(unable_runs),
+        "suspect_runs": suspect_runs,
+        "remediation_queue": remediation_queue,
+        "summary_reason_codes": summary_reason_codes,
+        "generated_at": generated_at,
+        "trace": {
+            "producer": "spectrum_systems.modules.runtime.retroactive_pytest_integrity_audit",
+            "classification_policy": "pyx01_execution_truth_backtest_v1",
+            "remediation_queue_limit": remediation_queue_limit,
+            "scan_mode": "repo_local_artifacts_only",
+        },
+    }
+
+    queue = {
+        "artifact_type": "retroactive_pytest_remediation_queue",
+        "schema_version": "1.0.0",
+        "audit_result_ref": "outputs/retroactive_pytest_integrity_audit/retroactive_pytest_integrity_audit_result.json",
+        "queue_size": len(remediation_queue),
+        "items": remediation_queue,
+        "generated_at": generated_at,
+        "trace": {
+            "producer": "spectrum_systems.modules.runtime.retroactive_pytest_integrity_audit",
+            "queue_policy": "bounded_suspect_only",
+            "queue_limit": remediation_queue_limit,
+        },
+    }
+
+    validate_artifact(result, "retroactive_pytest_integrity_audit_result")
+    validate_artifact(queue, "retroactive_pytest_remediation_queue")
+    return result, queue
+
+
+__all__ = [
+    "RetroactivePytestIntegrityAuditError",
+    "classify_historical_preflight_artifact",
+    "run_retroactive_pytest_integrity_audit",
+    "scan_historical_preflight_artifacts",
+]

--- a/tests/test_artifact_boundary_workflow_pytest_enforcement.py
+++ b/tests/test_artifact_boundary_workflow_pytest_enforcement.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+
+ARTIFACT_BOUNDARY_WORKFLOW = Path('.github/workflows/artifact-boundary.yml')
+AUTOFIX_WORKFLOW = Path('.github/workflows/pr-autofix-contract-preflight.yml')
+
+
+def test_artifact_boundary_workflow_uses_contract_preflight_on_pull_request() -> None:
+    text = ARTIFACT_BOUNDARY_WORKFLOW.read_text(encoding='utf-8')
+    assert 'pull_request:' in text
+    assert 'python scripts/run_contract_preflight.py' in text
+
+
+def test_artifact_boundary_workflow_fail_closes_on_missing_pytest_execution_record() -> None:
+    text = ARTIFACT_BOUNDARY_WORKFLOW.read_text(encoding='utf-8')
+    assert 'pytest_execution_record_ref' in text
+    assert 'missing pytest_execution_record_ref' in text
+    assert 'executed=false' in text
+    assert 'empty selected_targets' in text
+
+
+def test_autofix_workflow_enforces_pytest_execution_record_for_allow_warn() -> None:
+    text = AUTOFIX_WORKFLOW.read_text(encoding='utf-8')
+    assert 'pytest_execution_record_ref' in text
+    assert 'allow decision with executed=false' in text
+    assert 'allow decision with empty selected_targets' in text

--- a/tests/test_contract_preflight.py
+++ b/tests/test_contract_preflight.py
@@ -1077,7 +1077,7 @@ def test_main_governed_context_with_valid_wrapper_allows(tmp_path: Path, monkeyp
     report = json.loads((output_dir / "contract_preflight_report.json").read_text(encoding="utf-8"))
     assert report["pqx_required_context_enforcement"]["status"] == "allow"
     artifact = json.loads((output_dir / "contract_preflight_result_artifact.json").read_text(encoding="utf-8"))
-    assert artifact["schema_version"] == "1.2.0"
+    assert artifact["schema_version"] == "1.3.0"
     assert artifact["pqx_required_context_enforcement"]["status"] == "allow"
 
 
@@ -1965,8 +1965,12 @@ def test_pull_request_blocks_when_no_pytest_execution_and_no_fallback_targets(tm
     assert code == 2
     report = json.loads((output_dir / "contract_preflight_report.json").read_text(encoding="utf-8"))
     assert "PR_PYTEST_FALLBACK_TARGETS_EMPTY" in report["invariant_violations"]
+    assert "PR_PYTEST_EXECUTION_RECORD_REQUIRED" in report["invariant_violations"]
     assert report["pytest_execution"]["pytest_execution_count"] == 0
     assert report["pytest_execution"]["fallback_used"] is True
+    execution_record = json.loads((output_dir / "pytest_execution_record.json").read_text(encoding="utf-8"))
+    assert execution_record["executed"] is False
+    assert execution_record["failure_reason"] == "no_pytest_command_executed"
 
 
 def test_pull_request_no_targeted_tests_uses_governed_fallback(tmp_path: Path, monkeypatch) -> None:
@@ -2018,6 +2022,11 @@ def test_pull_request_no_targeted_tests_uses_governed_fallback(tmp_path: Path, m
     artifact = json.loads((output_dir / "contract_preflight_result_artifact.json").read_text(encoding="utf-8"))
     assert artifact["pytest_execution"]["pytest_execution_count"] == 1
     assert "selection_reason_codes" in artifact["pytest_execution"]
+    assert artifact["pytest_execution_record_ref"] == str(output_dir / "pytest_execution_record.json")
+    execution_record = json.loads((output_dir / "pytest_execution_record.json").read_text(encoding="utf-8"))
+    assert execution_record["executed"] is True
+    assert execution_record["exit_code"] == 0
+    assert execution_record["selected_targets"] == ["tests/test_run_github_pr_autofix_contract_preflight.py"]
 
 
 def test_push_noop_does_not_require_pull_request_pytest_invariant(tmp_path: Path, monkeypatch) -> None:
@@ -2076,5 +2085,4 @@ def test_pull_request_fails_closed_when_fallback_reports_success_without_executi
     code = preflight.main()
     assert code == 2
     report = json.loads((output_dir / "contract_preflight_report.json").read_text(encoding="utf-8"))
-    assert "PR_PYTEST_EXECUTION_REQUIRED" in report["invariant_violations"]
-    assert "PREFLIGHT_PASS_WITHOUT_PYTEST_EXECUTION" in report["invariant_violations"]
+    assert "PR_PYTEST_EXECUTION_RECORD_REQUIRED" in report["invariant_violations"]

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -647,6 +647,7 @@ class ContractSchemaTests(unittest.TestCase):
     def test_contract_preflight_result_artifact_example_validates(self) -> None:
         instance = load_example("contract_preflight_result_artifact")
         validate_artifact(instance, "contract_preflight_result_artifact")
+        assert instance["pytest_execution_record_ref"]
         required_context = instance["pqx_required_context_enforcement"]
         assert required_context["status"] in {"allow", "block"}
         assert isinstance(required_context["blocking_reasons"], list)
@@ -657,6 +658,12 @@ class ContractSchemaTests(unittest.TestCase):
         }
         assert isinstance(required_context["requires_pqx_execution"], bool)
         assert required_context["enforcement_decision"] in {"allow", "block"}
+
+    def test_pytest_execution_record_example_validates(self) -> None:
+        instance = load_example("pytest_execution_record")
+        validate_artifact(instance, "pytest_execution_record")
+        assert instance["artifact_type"] == "pytest_execution_record"
+        assert isinstance(instance["execution_entries"], list)
 
     def test_control_surface_obedience_result_example_validates(self) -> None:
         instance = load_example("control_surface_obedience_result")

--- a/tests/test_github_pr_autofix_contract_preflight.py
+++ b/tests/test_github_pr_autofix_contract_preflight.py
@@ -99,6 +99,18 @@ def test_preflight_pass_without_execution_invariant_is_classified_for_repair() -
     assert diagnosis["reason_codes"] == ["PREFLIGHT_PASS_WITHOUT_PYTEST_EXECUTION"]
 
 
+def test_pytest_execution_record_required_invariant_is_classified_for_repair() -> None:
+    diagnosis = build_preflight_block_diagnosis_record(
+        report={
+            "invariant_violations": ["PR_PYTEST_EXECUTION_RECORD_REQUIRED"],
+            "normalized_failure": {"failure_class": "test_inventory_regression", "repairable": True},
+        },
+        preflight_artifact={"control_signal": {"strategy_gate_decision": "BLOCK"}, "generated_at": "2026"},
+    )
+    assert diagnosis["failure_class"] == "no_tests_discovered"
+    assert diagnosis["reason_codes"] == ["PR_PYTEST_EXECUTION_RECORD_REQUIRED"]
+
+
 def test_bounded_repair_plan_creation_known_category() -> None:
     diagnosis = build_preflight_block_diagnosis_record(
         report={"missing_required_surface": ["x"]},

--- a/tests/test_pqx_slice_runner.py
+++ b/tests/test_pqx_slice_runner.py
@@ -355,7 +355,7 @@ def _execution_impact_artifact(*, blocking: bool, indeterminate: bool, safe_to_e
 def _preflight_artifact(*, status: str, decision: str, masking_detected: bool = False, degraded: bool = False) -> dict:
     return {
         "artifact_type": "contract_preflight_result_artifact",
-        "schema_version": "1.2.0",
+        "schema_version": "1.3.0",
         "preflight_status": status,
         "changed_contracts": ["contracts/schemas/roadmap_eligibility_artifact.schema.json"],
         "impacted_producers": [
@@ -386,6 +386,18 @@ def _preflight_artifact(*, status: str, decision: str, masking_detected: bool = 
         "control_surface_gap_result_ref": None,
         "pqx_gap_work_items_ref": None,
         "control_surface_gap_blocking": False,
+        "pytest_execution": {
+            "event_name": "pull_request",
+            "pytest_execution_count": 1,
+            "pytest_commands": ["python -m pytest -q tests/test_contract_preflight.py"],
+            "selected_targets": ["tests/test_contract_preflight.py"],
+            "fallback_targets": [],
+            "fallback_used": False,
+            "targeted_selection_empty": False,
+            "fallback_selection_empty": True,
+            "selection_reason_codes": [],
+        },
+        "pytest_execution_record_ref": "outputs/contract_preflight/pytest_execution_record.json",
         "pqx_required_context_enforcement": {
             "classification": "governed_pqx_required",
             "execution_context": "pqx_governed",

--- a/tests/test_preflight_failure_normalizer.py
+++ b/tests/test_preflight_failure_normalizer.py
@@ -29,3 +29,9 @@ def test_preflight_pass_without_execution_maps_to_inventory_regression() -> None
     report = {"invariant_violations": ["PREFLIGHT_PASS_WITHOUT_PYTEST_EXECUTION"]}
     result = normalize_preflight_failure(report)
     assert result["failure_class"] == "test_inventory_regression"
+
+
+def test_execution_record_required_maps_to_inventory_regression() -> None:
+    report = {"invariant_violations": ["PR_PYTEST_EXECUTION_RECORD_REQUIRED"]}
+    result = normalize_preflight_failure(report)
+    assert result["failure_class"] == "test_inventory_regression"

--- a/tests/test_retroactive_pytest_integrity_audit.py
+++ b/tests/test_retroactive_pytest_integrity_audit.py
@@ -1,0 +1,169 @@
+import json
+from pathlib import Path
+
+from spectrum_systems.contracts import validate_artifact
+from spectrum_systems.modules.runtime.retroactive_pytest_integrity_audit import (
+    classify_historical_preflight_artifact,
+    run_retroactive_pytest_integrity_audit,
+    scan_historical_preflight_artifacts,
+)
+
+
+def test_trusted_post_pyx01_artifact_is_trusted() -> None:
+    artifact = {
+        "artifact_type": "contract_preflight_result_artifact",
+        "preflight_status": "passed",
+        "control_signal": {"strategy_gate_decision": "ALLOW"},
+        "generated_at": "2026-04-10T00:00:00Z",
+        "pytest_execution": {
+            "event_name": "pull_request",
+            "pytest_execution_count": 1,
+            "pytest_commands": ["python -m pytest tests/test_contract_preflight.py"],
+            "selected_targets": ["tests/test_contract_preflight.py"],
+            "fallback_targets": [],
+            "fallback_used": False,
+            "targeted_selection_empty": False,
+            "fallback_selection_empty": True,
+            "selection_reason_codes": [],
+        },
+    }
+
+    classified = classify_historical_preflight_artifact(artifact, artifact_path="x.json")
+    assert classified["classification"] == "trusted"
+
+
+def test_historical_allow_without_execution_is_suspect() -> None:
+    artifact = {
+        "artifact_type": "contract_preflight_result_artifact",
+        "preflight_status": "passed",
+        "control_signal": {"strategy_gate_decision": "ALLOW"},
+        "generated_at": "2026-03-01T00:00:00Z",
+        "pytest_execution": {
+            "event_name": "pull_request",
+            "pytest_execution_count": 0,
+            "pytest_commands": [],
+            "selected_targets": [],
+            "fallback_targets": [],
+            "fallback_used": True,
+            "targeted_selection_empty": True,
+            "fallback_selection_empty": True,
+            "selection_reason_codes": ["PR_PYTEST_SELECTED_TARGETS_EMPTY"],
+        },
+    }
+
+    classified = classify_historical_preflight_artifact(artifact, artifact_path="x.json")
+    assert classified["classification"] == "suspect_incomplete_execution_accounting"
+    assert "HISTORICAL_PR_ALLOW_WITHOUT_PYTEST_EXECUTION" in classified["reason_codes"]
+
+
+def test_pre_pyx01_shape_is_flagged_deterministically() -> None:
+    artifact = {
+        "artifact_type": "contract_preflight_result_artifact",
+        "preflight_status": "passed",
+        "control_signal": {"strategy_gate_decision": "WARN"},
+        "changed_path_detection": {"ref_context": {"event_name": "pull_request"}},
+    }
+
+    classified = classify_historical_preflight_artifact(artifact, artifact_path="x.json")
+    assert classified["classification"] == "suspect_missing_pytest_execution"
+    assert "HISTORICAL_ARTIFACT_SHAPE_PRE_PYX01" in classified["reason_codes"]
+    assert "HISTORICAL_WARN_WITHOUT_PYTEST_EXECUTION" in classified["reason_codes"]
+
+
+def test_unable_to_evaluate_when_context_missing() -> None:
+    artifact = {
+        "artifact_type": "contract_preflight_result_artifact",
+        "preflight_status": "failed",
+    }
+
+    classified = classify_historical_preflight_artifact(artifact, artifact_path="x.json")
+    assert classified["classification"] == "unable_to_evaluate"
+    assert "HISTORICAL_CONTEXT_NOT_EVALUABLE" in classified["reason_codes"]
+
+
+def test_non_pr_context_not_misclassified_as_pr_failure() -> None:
+    artifact = {
+        "artifact_type": "contract_preflight_result_artifact",
+        "preflight_status": "passed",
+        "control_signal": {"strategy_gate_decision": "ALLOW"},
+        "pytest_execution": {
+            "event_name": "push",
+            "pytest_execution_count": 0,
+            "pytest_commands": [],
+            "selected_targets": [],
+            "fallback_targets": [],
+            "fallback_used": False,
+            "targeted_selection_empty": True,
+            "fallback_selection_empty": True,
+            "selection_reason_codes": [],
+        },
+    }
+
+    classified = classify_historical_preflight_artifact(artifact, artifact_path="x.json")
+    assert classified["classification"] == "trusted"
+
+
+def test_deterministic_remediation_queue_and_schema_validation(tmp_path: Path) -> None:
+    root = tmp_path / "outputs"
+    first = root / "a" / "contract_preflight_result_artifact.json"
+    first.parent.mkdir(parents=True, exist_ok=True)
+    first.write_text(
+        json.dumps(
+            {
+                "artifact_type": "contract_preflight_result_artifact",
+                "preflight_status": "passed",
+                "control_signal": {"strategy_gate_decision": "ALLOW"},
+                "changed_path_detection": {"ref_context": {"event_name": "pull_request"}},
+                "generated_at": "2026-02-01T00:00:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    second = root / "b" / "contract_preflight_result_artifact.json"
+    second.parent.mkdir(parents=True, exist_ok=True)
+    second.write_text(
+        json.dumps(
+            {
+                "artifact_type": "contract_preflight_result_artifact",
+                "preflight_status": "passed",
+                "control_signal": {"strategy_gate_decision": "ALLOW"},
+                "generated_at": "2026-04-01T00:00:00Z",
+                "pytest_execution": {
+                    "event_name": "pull_request",
+                    "pytest_execution_count": 1,
+                    "pytest_commands": ["pytest tests/test_contract_preflight.py"],
+                    "selected_targets": ["tests/test_contract_preflight.py"],
+                    "fallback_targets": [],
+                    "fallback_used": False,
+                    "targeted_selection_empty": False,
+                    "fallback_selection_empty": True,
+                    "selection_reason_codes": [],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    scanned = scan_historical_preflight_artifacts([root])
+    result, queue = run_retroactive_pytest_integrity_audit(
+        scanned_artifacts=scanned,
+        audit_scope={"roots": [str(root)], "artifact_globs": ["**/contract_preflight_result_artifact.json"], "repo_root": str(tmp_path)},
+        remediation_queue_limit=5,
+    )
+
+    assert result["scanned_run_count"] == 2
+    assert result["suspect_count"] == 1
+    assert result["trusted_count"] == 1
+    assert queue["queue_size"] == 1
+    assert queue["items"][0]["artifact_path"].endswith("a/contract_preflight_result_artifact.json")
+
+    validate_artifact(result, "retroactive_pytest_integrity_audit_result")
+    validate_artifact(queue, "retroactive_pytest_remediation_queue")
+
+
+def test_examples_validate() -> None:
+    audit_example = json.loads(Path("contracts/examples/retroactive_pytest_integrity_audit_result.json").read_text(encoding="utf-8"))
+    queue_example = json.loads(Path("contracts/examples/retroactive_pytest_remediation_queue.json").read_text(encoding="utf-8"))
+    validate_artifact(audit_example, "retroactive_pytest_integrity_audit_result")
+    validate_artifact(queue_example, "retroactive_pytest_remediation_queue")


### PR DESCRIPTION
### Motivation
- Close the historical trust gap by retroactively backtesting historical preflight artifacts against the PYX-01 execution-truth model to find runs that may have been trusted without authoritative pytest execution evidence. 
- Produce deterministic, schema-bound audit artifacts and a bounded remediation queue so operators can triage and quarantine suspect historical runs without mutating any historical evidence. 
- Keep the implementation repo-native, deterministic, fail-closed on invariants, and limited to repo-local artifact surfaces. 

### Description
- Added a runtime classification module `spectrum_systems/modules/runtime/retroactive_pytest_integrity_audit.py` that loads historical preflight artifacts, deterministically classifies runs into `trusted`, `suspect_missing_pytest_execution`, `suspect_non_authoritative_pytest`, `suspect_incomplete_execution_accounting`, or `unable_to_evaluate`, emits normalized reason codes, and recommends remediation. 
- Added a thin CLI `scripts/run_retroactive_pytest_integrity_audit.py` that scans repo-known roots (defaults: `outputs`, `artifacts`, `data`), invokes the runtime module, and writes two schema-bound outputs to `outputs/retroactive_pytest_integrity_audit/`: `retroactive_pytest_integrity_audit_result.json` and `retroactive_pytest_remediation_queue.json`. 
- Added strict artifact contracts and examples: `contracts/schemas/retroactive_pytest_integrity_audit_result.schema.json`, `contracts/schemas/retroactive_pytest_remediation_queue.schema.json`, and matching examples in `contracts/examples/`. 
- Added focused tests `tests/test_retroactive_pytest_integrity_audit.py`, a plan `docs/review-actions/PLAN-AUD-01-2026-04-14.md`, and a review artifact `docs/reviews/AUD-01-retroactive-pytest-integrity-audit.md`, and registered the new artifacts in `contracts/standards-manifest.json`. 

### Testing
- Ran `pytest tests/test_retroactive_pytest_integrity_audit.py` and the new test suite passed (7 passed). 
- Ran contract validation suites `pytest tests/test_contracts.py tests/test_contract_enforcement.py tests/test_contract_bootstrap.py` and they passed (129 tests passed). 
- Executed `python scripts/run_contract_enforcement.py` to validate manifest/register integration and it completed successfully. 
- Ran the repository contract-boundary audit `.codex/skills/contract-boundary-audit/run.sh` which completed with non-blocking warnings (PASS-WARN). 
- Exercised the CLI with `python scripts/run_retroactive_pytest_integrity_audit.py --scan-root outputs --output-dir outputs/retroactive_pytest_integrity_audit` which produced the governed output artifacts (scan completed; outputs written); schema validation of produced artifacts is enforced by the runtime module.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de3c09b8448329a712054e74339cbd)