### PR TITLE
TSI-01: Enforce pytest selection integrity and add trust-gap audit

### DIFF
--- a/.github/workflows/artifact-boundary.yml
+++ b/.github/workflows/artifact-boundary.yml
@@ -176,6 +176,18 @@ if os.environ.get("GITHUB_EVENT_NAME") == "pull_request":
         raise SystemExit("workflow/preflight trust mismatch: PR allow with executed=false")
     if decision in {"ALLOW", "WARN"} and not selected_targets:
         raise SystemExit("workflow/preflight trust mismatch: PR allow with empty selected_targets")
+    selection_ref = str(payload.get("pytest_selection_integrity_result_ref") or "").strip()
+    selection = payload.get("pytest_selection_integrity") or {}
+    if not selection_ref:
+        raise SystemExit("workflow/preflight trust mismatch: missing pytest_selection_integrity_result_ref")
+    selection_path = Path(selection_ref)
+    if not selection_path.is_file():
+        raise SystemExit(f"workflow/preflight trust mismatch: missing pytest_selection_integrity_result artifact at {selection_ref}")
+    selection_from_ref = json.loads(selection_path.read_text(encoding="utf-8"))
+    if str(selection_from_ref.get("selection_integrity_decision") or "BLOCK") != "ALLOW" and decision in {"ALLOW", "WARN"}:
+        raise SystemExit("workflow/preflight trust mismatch: allow decision with blocked pytest selection integrity")
+    if selection and str(selection.get("selection_integrity_decision") or "BLOCK") != "ALLOW" and decision in {"ALLOW", "WARN"}:
+        raise SystemExit("workflow/preflight trust mismatch: allow decision with in-artifact blocked pytest selection integrity")
 PY
 
       - name: Upload contract preflight outputs

--- a/.github/workflows/artifact-boundary.yml
+++ b/.github/workflows/artifact-boundary.yml
@@ -117,11 +117,8 @@ jobs:
           preflight_exit=$?
           set -e
 
-          if [[ "$preflight_exit" -eq 0 ]]; then
-            exit 0
-          fi
-
-          auto_repair_allowed=$(python - <<'PY'
+          if [[ "$preflight_exit" -ne 0 ]]; then
+            auto_repair_allowed=$(python - <<'PY'
 import json
 from pathlib import Path
 path = Path("outputs/contract_preflight/preflight_repair_plan_record.json")
@@ -133,11 +130,11 @@ else:
 PY
 )
 
-          if [[ "$auto_repair_allowed" != "true" ]]; then
-            exit "$preflight_exit"
-          fi
+            if [[ "$auto_repair_allowed" != "true" ]]; then
+              exit "$preflight_exit"
+            fi
 
-          python scripts/run_github_pr_autofix_contract_preflight.py \
+            python scripts/run_github_pr_autofix_contract_preflight.py \
             --output-dir outputs/contract_preflight \
             --base-ref "${{ steps.preflight-refs.outputs.base_ref }}" \
             --head-ref "${{ steps.preflight-refs.outputs.head_ref }}" \
@@ -146,6 +143,7 @@ PY
             --pqx-wrapper-path outputs/contract_preflight/preflight_pqx_task_wrapper.json \
             --authority-evidence-ref artifacts/pqx_runs/preflight.pqx_slice_execution_record.json \
             --same-repo-write-allowed
+          fi
 
           # Preflight is the canonical authority for PR pytest execution truth.
           python - <<'PY'

--- a/.github/workflows/pr-autofix-contract-preflight.yml
+++ b/.github/workflows/pr-autofix-contract-preflight.yml
@@ -150,6 +150,18 @@ jobs:
               raise SystemExit("workflow/preflight trust mismatch: allow decision with executed=false")
           if initial in {"ALLOW", "WARN"} and not selected_targets:
               raise SystemExit("workflow/preflight trust mismatch: allow decision with empty selected_targets")
+          selection_ref = str(payload.get("pytest_selection_integrity_result_ref") or "").strip()
+          selection = payload.get("pytest_selection_integrity") or {}
+          if not selection_ref:
+              raise SystemExit("workflow/preflight trust mismatch: missing pytest_selection_integrity_result_ref")
+          selection_path = Path(selection_ref)
+          if not selection_path.exists():
+              raise SystemExit(f"workflow/preflight trust mismatch: missing pytest_selection_integrity_result artifact at {selection_ref}")
+          selection_from_ref = json.loads(selection_path.read_text(encoding="utf-8"))
+          if initial in {"ALLOW", "WARN"} and str(selection_from_ref.get("selection_integrity_decision") or "BLOCK") != "ALLOW":
+              raise SystemExit("workflow/preflight trust mismatch: allow decision with blocked pytest selection integrity")
+          if initial in {"ALLOW", "WARN"} and str(selection.get("selection_integrity_decision") or "BLOCK") != "ALLOW":
+              raise SystemExit("workflow/preflight trust mismatch: allow decision with in-artifact blocked pytest selection integrity")
           if initial != "BLOCK":
               raise SystemExit(0 if initial in {"ALLOW", "WARN"} else 2)
           outcome_path = out / "preflight_recovery_outcome_record.json"

--- a/contracts/examples/contract_preflight_result_artifact.example.json
+++ b/contracts/examples/contract_preflight_result_artifact.example.json
@@ -1,6 +1,6 @@
 {
   "artifact_type": "contract_preflight_result_artifact",
-  "schema_version": "1.3.0",
+  "schema_version": "1.4.0",
   "preflight_status": "passed",
   "changed_contracts": [
     "contracts/schemas/roadmap_eligibility_artifact.schema.json"
@@ -70,5 +70,27 @@
     ],
     "provenance_ref": "contracts/standards-manifest.json"
   },
-  "pytest_execution_record_ref": "outputs/contract_preflight/pytest_execution_record.json"
+  "pytest_execution_record_ref": "outputs/contract_preflight/pytest_execution_record.json",
+  "pytest_selection_integrity": {
+    "artifact_type": "pytest_selection_integrity_result",
+    "schema_version": "1.0.0",
+    "changed_paths": [
+      "contracts/schemas/roadmap_eligibility_artifact.schema.json"
+    ],
+    "required_test_targets": [
+      "tests/test_roadmap_eligibility.py"
+    ],
+    "selected_test_targets": [
+      "tests/test_roadmap_eligibility.py"
+    ],
+    "missing_required_targets": [],
+    "selection_count": 1,
+    "minimum_selection_threshold": 1,
+    "threshold_satisfied": true,
+    "impacted_surface_count": 1,
+    "selection_integrity_decision": "ALLOW",
+    "blocking_reasons": [],
+    "generated_at": "2026-04-14T00:00:00Z"
+  },
+  "pytest_selection_integrity_result_ref": "outputs/contract_preflight/pytest_selection_integrity_result.json"
 }

--- a/contracts/examples/contract_preflight_result_artifact.json
+++ b/contracts/examples/contract_preflight_result_artifact.json
@@ -1,6 +1,6 @@
 {
   "artifact_type": "contract_preflight_result_artifact",
-  "schema_version": "1.3.0",
+  "schema_version": "1.4.0",
   "preflight_status": "passed",
   "changed_contracts": [
     "contracts/schemas/roadmap_eligibility_artifact.schema.json"
@@ -89,5 +89,27 @@
     ],
     "provenance_ref": "contracts/standards-manifest.json"
   },
-  "pytest_execution_record_ref": "outputs/contract_preflight/pytest_execution_record.json"
+  "pytest_execution_record_ref": "outputs/contract_preflight/pytest_execution_record.json",
+  "pytest_selection_integrity": {
+    "artifact_type": "pytest_selection_integrity_result",
+    "schema_version": "1.0.0",
+    "changed_paths": [
+      "contracts/schemas/roadmap_eligibility_artifact.schema.json"
+    ],
+    "required_test_targets": [
+      "tests/test_roadmap_eligibility.py"
+    ],
+    "selected_test_targets": [
+      "tests/test_roadmap_eligibility.py"
+    ],
+    "missing_required_targets": [],
+    "selection_count": 1,
+    "minimum_selection_threshold": 1,
+    "threshold_satisfied": true,
+    "impacted_surface_count": 1,
+    "selection_integrity_decision": "ALLOW",
+    "blocking_reasons": [],
+    "generated_at": "2026-04-14T00:00:00Z"
+  },
+  "pytest_selection_integrity_result_ref": "outputs/contract_preflight/pytest_selection_integrity_result.json"
 }

--- a/contracts/examples/preflight_block_diagnosis_record.json
+++ b/contracts/examples/preflight_block_diagnosis_record.json
@@ -8,5 +8,9 @@
   "reason_codes": [
     "PQX_REQUIRED_CONTEXT_WRAPPER_BLOCK"
   ],
-  "root_cause_summary": "preflight wrapper context invalid"
+  "root_cause_summary": "preflight wrapper context invalid",
+  "normalized_failure": {
+    "failure_class": "invalid_wrapper",
+    "repairable": true
+  }
 }

--- a/contracts/examples/pytest_selection_integrity_result.json
+++ b/contracts/examples/pytest_selection_integrity_result.json
@@ -1,0 +1,23 @@
+{
+  "artifact_type": "pytest_selection_integrity_result",
+  "schema_version": "1.0.0",
+  "changed_paths": [
+    "scripts/run_contract_preflight.py",
+    "tests/test_contract_preflight.py"
+  ],
+  "required_test_targets": [
+    "tests/test_contract_preflight.py"
+  ],
+  "selected_test_targets": [
+    "tests/test_contract_preflight.py",
+    "tests/test_run_github_pr_autofix_contract_preflight.py"
+  ],
+  "missing_required_targets": [],
+  "selection_count": 2,
+  "minimum_selection_threshold": 1,
+  "threshold_satisfied": true,
+  "impacted_surface_count": 2,
+  "selection_integrity_decision": "ALLOW",
+  "blocking_reasons": [],
+  "generated_at": "2026-04-14T00:00:00Z"
+}

--- a/contracts/examples/pytest_trust_gap_audit_result.json
+++ b/contracts/examples/pytest_trust_gap_audit_result.json
@@ -1,0 +1,52 @@
+{
+  "artifact_type": "pytest_trust_gap_audit_result",
+  "schema_version": "1.0.0",
+  "audit_scope": {
+    "roots": [
+      "outputs",
+      "artifacts",
+      "data"
+    ],
+    "artifact_globs": [
+      "**/contract_preflight_result_artifact.json"
+    ],
+    "max_artifacts": 50,
+    "repo_root": "/workspace/spectrum-systems"
+  },
+  "scanned_artifact_count": 3,
+  "suspect_count": 2,
+  "suspect_runs": [
+    {
+      "artifact_path": "outputs/history/run-001/contract_preflight_result_artifact.json",
+      "classification": "weak_evidence",
+      "context": "pr",
+      "trusting_outcome": true,
+      "reason_codes": [
+        "MISSING_PYTEST_SELECTION_INTEGRITY_ARTIFACT",
+        "TRUSTED_OUTCOME_WITH_GAP"
+      ]
+    },
+    {
+      "artifact_path": "outputs/history/run-002/contract_preflight_result_artifact.json",
+      "classification": "missing_evidence",
+      "context": "unknown",
+      "trusting_outcome": true,
+      "reason_codes": [
+        "MISSING_PYTEST_EXECUTION_ARTIFACT",
+        "TRUSTED_OUTCOME_WITH_GAP"
+      ]
+    }
+  ],
+  "summary_reason_codes": [
+    "MISSING_PYTEST_EXECUTION_ARTIFACT",
+    "MISSING_PYTEST_SELECTION_INTEGRITY_ARTIFACT",
+    "TRUSTED_OUTCOME_WITH_GAP"
+  ],
+  "generated_at": "2026-04-14T00:00:00Z",
+  "trace": {
+    "producer": "spectrum_systems.modules.runtime.pytest_trust_gap_audit",
+    "classification_policy": "tsi-01-trust-gap-v1",
+    "scan_mode": "repo_local_artifacts_only",
+    "read_only": true
+  }
+}

--- a/contracts/schemas/contract_preflight_result_artifact.schema.json
+++ b/contracts/schemas/contract_preflight_result_artifact.schema.json
@@ -25,7 +25,9 @@
     "pqx_required_context_enforcement",
     "control_signal",
     "trace",
-    "pytest_execution_record_ref"
+    "pytest_execution_record_ref",
+    "pytest_selection_integrity",
+    "pytest_selection_integrity_result_ref"
   ],
   "properties": {
     "artifact_type": {
@@ -33,7 +35,7 @@
     },
     "schema_version": {
       "type": "string",
-      "const": "1.3.0"
+      "const": "1.4.0"
     },
     "preflight_status": {
       "type": "string",
@@ -149,28 +151,51 @@
         "selection_reason_codes"
       ],
       "properties": {
-        "event_name": {"type": "string"},
-        "pytest_execution_count": {"type": "integer", "minimum": 0},
+        "event_name": {
+          "type": "string"
+        },
+        "pytest_execution_count": {
+          "type": "integer",
+          "minimum": 0
+        },
         "pytest_commands": {
           "type": "array",
-          "items": {"type": "string", "minLength": 1}
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
         },
         "selected_targets": {
           "type": "array",
-          "items": {"type": "string", "minLength": 1},
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
           "uniqueItems": true
         },
         "fallback_targets": {
           "type": "array",
-          "items": {"type": "string", "minLength": 1},
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
           "uniqueItems": true
         },
-        "fallback_used": {"type": "boolean"},
-        "targeted_selection_empty": {"type": "boolean"},
-        "fallback_selection_empty": {"type": "boolean"},
+        "fallback_used": {
+          "type": "boolean"
+        },
+        "targeted_selection_empty": {
+          "type": "boolean"
+        },
+        "fallback_selection_empty": {
+          "type": "boolean"
+        },
         "selection_reason_codes": {
           "type": "array",
-          "items": {"type": "string", "minLength": 1},
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
           "uniqueItems": true
         }
       }
@@ -351,6 +376,103 @@
           "minLength": 1
         }
       }
+    },
+    "pytest_selection_integrity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "artifact_type",
+        "schema_version",
+        "changed_paths",
+        "required_test_targets",
+        "selected_test_targets",
+        "missing_required_targets",
+        "selection_count",
+        "minimum_selection_threshold",
+        "threshold_satisfied",
+        "impacted_surface_count",
+        "selection_integrity_decision",
+        "blocking_reasons",
+        "generated_at"
+      ],
+      "properties": {
+        "artifact_type": {
+          "const": "pytest_selection_integrity_result"
+        },
+        "schema_version": {
+          "const": "1.0.0"
+        },
+        "changed_paths": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "required_test_targets": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "selected_test_targets": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "missing_required_targets": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "selection_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "minimum_selection_threshold": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "threshold_satisfied": {
+          "type": "boolean"
+        },
+        "impacted_surface_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "selection_integrity_decision": {
+          "type": "string",
+          "enum": [
+            "ALLOW",
+            "BLOCK"
+          ]
+        },
+        "blocking_reasons": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "generated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "pytest_selection_integrity_result_ref": {
+      "type": "string",
+      "minLength": 1
     }
   }
 }

--- a/contracts/schemas/failure_repair_candidate_artifact.schema.json
+++ b/contracts/schemas/failure_repair_candidate_artifact.schema.json
@@ -70,7 +70,11 @@
         "internal_preflight_error",
         "test_inventory_regression",
         "control_surface_gap",
-        "downstream_test_failure"
+        "downstream_test_failure",
+        "pytest_selection_missing",
+        "pytest_selection_mismatch",
+        "pytest_selection_filtering",
+        "pytest_selection_threshold"
       ]
     },
     "safe_to_repair": {
@@ -99,7 +103,9 @@
     },
     "reason_codes": {
       "type": "array",
-      "items": {"type": "string"},
+      "items": {
+        "type": "string"
+      },
       "uniqueItems": true
     },
     "retry_budget": {
@@ -108,7 +114,9 @@
     },
     "rerun_prerequisites": {
       "type": "array",
-      "items": {"type": "string"},
+      "items": {
+        "type": "string"
+      },
       "uniqueItems": true
     }
   }

--- a/contracts/schemas/preflight_block_diagnosis_record.schema.json
+++ b/contracts/schemas/preflight_block_diagnosis_record.schema.json
@@ -58,7 +58,11 @@
         "internal_preflight_error",
         "test_inventory_regression",
         "control_surface_gap",
-        "downstream_test_failure"
+        "downstream_test_failure",
+        "pytest_selection_missing",
+        "pytest_selection_mismatch",
+        "pytest_selection_filtering",
+        "pytest_selection_threshold"
       ]
     },
     "reason_codes": {
@@ -75,10 +79,18 @@
     "normalized_failure": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["failure_class", "repairable"],
+      "required": [
+        "failure_class",
+        "repairable"
+      ],
       "properties": {
-        "failure_class": {"type": "string", "minLength": 1},
-        "repairable": {"type": "boolean"}
+        "failure_class": {
+          "type": "string",
+          "minLength": 1
+        },
+        "repairable": {
+          "type": "boolean"
+        }
       }
     }
   }

--- a/contracts/schemas/pytest_selection_integrity_result.schema.json
+++ b/contracts/schemas/pytest_selection_integrity_result.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/pytest_selection_integrity_result.schema.json",
+  "title": "Pytest Selection Integrity Result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "changed_paths",
+    "required_test_targets",
+    "selected_test_targets",
+    "missing_required_targets",
+    "selection_count",
+    "minimum_selection_threshold",
+    "threshold_satisfied",
+    "impacted_surface_count",
+    "selection_integrity_decision",
+    "blocking_reasons",
+    "generated_at"
+  ],
+  "properties": {
+    "artifact_type": {"const": "pytest_selection_integrity_result"},
+    "schema_version": {"const": "1.0.0"},
+    "changed_paths": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+    "required_test_targets": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+    "selected_test_targets": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+    "missing_required_targets": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+    "selection_count": {"type": "integer", "minimum": 0},
+    "minimum_selection_threshold": {"type": "integer", "minimum": 1},
+    "threshold_satisfied": {"type": "boolean"},
+    "impacted_surface_count": {"type": "integer", "minimum": 0},
+    "selection_integrity_decision": {"type": "string", "enum": ["ALLOW", "BLOCK"]},
+    "blocking_reasons": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "PYTEST_SELECTION_EMPTY",
+          "PYTEST_REQUIRED_TARGETS_MISSING",
+          "PYTEST_SELECTION_THRESHOLD_NOT_MET",
+          "PYTEST_SELECTION_ARTIFACT_MISSING",
+          "PYTEST_SELECTION_ARTIFACT_INVALID",
+          "PYTEST_SELECTION_MISMATCH",
+          "PYTEST_SELECTION_FILTERING_DETECTED"
+        ]
+      },
+      "uniqueItems": true
+    },
+    "generated_at": {"type": "string", "format": "date-time"}
+  }
+}

--- a/contracts/schemas/pytest_trust_gap_audit_result.schema.json
+++ b/contracts/schemas/pytest_trust_gap_audit_result.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/pytest_trust_gap_audit_result.schema.json",
+  "title": "Pytest Trust Gap Audit Result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "audit_scope",
+    "scanned_artifact_count",
+    "suspect_count",
+    "suspect_runs",
+    "summary_reason_codes",
+    "generated_at",
+    "trace"
+  ],
+  "properties": {
+    "artifact_type": {"const": "pytest_trust_gap_audit_result"},
+    "schema_version": {"const": "1.0.0"},
+    "audit_scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["roots", "artifact_globs", "max_artifacts", "repo_root"],
+      "properties": {
+        "roots": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+        "artifact_globs": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+        "max_artifacts": {"type": "integer", "minimum": 1},
+        "repo_root": {"type": "string", "minLength": 1}
+      }
+    },
+    "scanned_artifact_count": {"type": "integer", "minimum": 0},
+    "suspect_count": {"type": "integer", "minimum": 0},
+    "suspect_runs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["artifact_path", "classification", "context", "trusting_outcome", "reason_codes"],
+        "properties": {
+          "artifact_path": {"type": "string", "minLength": 1},
+          "classification": {"type": "string", "enum": ["clean_evidence", "weak_evidence", "missing_evidence", "unable_to_evaluate"]},
+          "context": {"type": "string", "enum": ["pr", "non_pr", "unknown"]},
+          "trusting_outcome": {"type": "boolean"},
+          "reason_codes": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true}
+        }
+      }
+    },
+    "summary_reason_codes": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+    "generated_at": {"type": "string", "format": "date-time"},
+    "trace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["producer", "classification_policy", "scan_mode", "read_only"],
+      "properties": {
+        "producer": {"type": "string", "minLength": 1},
+        "classification_policy": {"type": "string", "minLength": 1},
+        "scan_mode": {"type": "string", "const": "repo_local_artifacts_only"},
+        "read_only": {"type": "boolean", "const": true}
+      }
+    }
+  }
+}

--- a/contracts/standards-manifest.json
+++ b/contracts/standards-manifest.json
@@ -1,11 +1,11 @@
 {
   "artifact_type": "standards_manifest",
   "artifact_id": "STD-CONTRACTS",
-  "artifact_version": "1.3.133",
+  "artifact_version": "1.3.134",
   "schema_version": "1.3.99",
-  "standards_version": "1.0.83",
-  "record_id": "REC-STD-2026-04-14-PYX-02-PR-PYTEST-ENFORCEMENT",
-  "run_id": "run-20260414T000000Z-pyx-02-pr-pytest-enforcement",
+  "standards_version": "1.0.84",
+  "record_id": "REC-STD-2026-04-14-TSI-01-SELECTION-INTEGRITY-AUDIT",
+  "run_id": "run-20260414T000000Z-tsi-01-selection-integrity-audit",
   "created_at": "2026-04-14T00:00:00Z",
   "created_by": {
     "name": "Spectrum Systems Architecture Team",
@@ -15,7 +15,7 @@
     "contact": "architecture@spectrum-systems.test"
   },
   "source_repo": "nicklasorte/spectrum-systems",
-  "source_repo_version": "1.3.133",
+  "source_repo_version": "1.3.134",
   "input_artifacts": [
     {
       "artifact_id": "STD-CONTRACTS",
@@ -2772,7 +2772,7 @@
       "introduced_in": "1.3.74",
       "last_updated_in": "1.3.89",
       "example_path": "contracts/examples/failure_diagnosis_artifact.json",
-      "notes": "BATCH-FRE-01 deterministic failure intake/classification artifact for governed failure→diagnosis handoff; diagnosis-only with no repair execution authority."
+      "notes": "BATCH-FRE-01 deterministic failure intake/classification artifact for governed failure\u2192diagnosis handoff; diagnosis-only with no repair execution authority."
     },
     {
       "artifact_type": "failure_eval_case",
@@ -2785,7 +2785,7 @@
       "introduced_in": "1.0.8",
       "last_updated_in": "1.0.41",
       "example_path": "contracts/examples/failure_eval_case.json",
-      "notes": "AG-05 deterministic failure→eval auto-generation artifact for bounded runtime failure, review-required halt, and control-indeterminate non-allow source conditions."
+      "notes": "AG-05 deterministic failure\u2192eval auto-generation artifact for bounded runtime failure, review-required halt, and control-indeterminate non-allow source conditions."
     },
     {
       "artifact_type": "failure_learning_record_artifact",
@@ -2928,7 +2928,7 @@
       "introduced_in": "1.3.86",
       "last_updated_in": "1.3.86",
       "example_path": "contracts/examples/github_review_handoff_artifact.json",
-      "notes": "BATCH-GHA-CORE-01 deterministic GHA-01→GHA-02 handoff index for fail-closed artifact routing without adding workflow decision logic."
+      "notes": "BATCH-GHA-CORE-01 deterministic GHA-01\u2192GHA-02 handoff index for fail-closed artifact routing without adding workflow decision logic."
     },
     {
       "artifact_type": "glossary_entry",
@@ -5075,7 +5075,7 @@
       "introduced_in": "1.0.86",
       "last_updated_in": "1.0.87",
       "example_path": "contracts/examples/pqx_n_slice_validation_record.json",
-      "notes": "B30 first 5–10 slice governed-run readiness validation artifact."
+      "notes": "B30 first 5\u201310 slice governed-run readiness validation artifact."
     },
     {
       "artifact_type": "pqx_review_result",
@@ -6772,7 +6772,7 @@
       "introduced_in": "1.3.75",
       "last_updated_in": "1.3.77",
       "example_path": "contracts/examples/repair_prompt_artifact.json",
-      "notes": "BATCH-FRE-02 deterministic diagnosis→repair bridge artifact defining bounded Codex-ready repair instructions, validation commands, constraints, and success criteria."
+      "notes": "BATCH-FRE-02 deterministic diagnosis\u2192repair bridge artifact defining bounded Codex-ready repair instructions, validation commands, constraints, and success criteria."
     },
     {
       "artifact_class": "coordination",
@@ -7073,7 +7073,7 @@
       "introduced_in": "1.3.98",
       "last_updated_in": "1.3.98",
       "example_path": "contracts/examples/review_fix_execution_request_artifact.json",
-      "notes": "RQX-B2 one-cycle governed request artifact requiring RQX→TPA→PQX→RQX routing with max cycle count = 1."
+      "notes": "RQX-B2 one-cycle governed request artifact requiring RQX\u2192TPA\u2192PQX\u2192RQX routing with max cycle count = 1."
     },
     {
       "artifact_type": "review_fix_execution_result_artifact",
@@ -8804,6 +8804,32 @@
       "last_updated_in": "1.0.82",
       "example_path": "contracts/examples/xrun_signal_quality_result.json",
       "notes": "VAL-06 governed validation artifact proving deterministic XRUN-01 pattern/action/signal quality and fail-closed handling under insufficient/malformed inputs."
+    },
+    {
+      "artifact_type": "pytest_selection_integrity_result",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.0.84",
+      "last_updated_in": "1.0.84",
+      "example_path": "contracts/examples/pytest_selection_integrity_result.json",
+      "notes": "TSI-01 governed fail-closed PR pytest selection integrity evidence artifact."
+    },
+    {
+      "artifact_type": "pytest_trust_gap_audit_result",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.0.84",
+      "last_updated_in": "1.0.84",
+      "example_path": "contracts/examples/pytest_trust_gap_audit_result.json",
+      "notes": "TSI-01 deterministic read-only audit artifact for historical pytest trust-gap evidence."
     }
   ]
 }

--- a/docs/governance/pytest_pr_selection_integrity_policy.json
+++ b/docs/governance/pytest_pr_selection_integrity_policy.json
@@ -1,0 +1,51 @@
+{
+  "artifact_type": "pytest_pr_selection_integrity_policy",
+  "schema_version": "1.0.0",
+  "policy_version": "1.0.0",
+  "minimum_selection_threshold": 1,
+  "allow_bounded_equivalence": true,
+  "governed_surface_prefixes": [
+    "contracts/",
+    "scripts/",
+    "spectrum_systems/",
+    "tests/",
+    ".github/workflows/",
+    "docs/governance/"
+  ],
+  "surface_rules": [
+    {
+      "path_prefix": "scripts/run_contract_preflight.py",
+      "required_test_targets": [
+        "tests/test_contract_preflight.py"
+      ]
+    },
+    {
+      "path_prefix": "spectrum_systems/modules/runtime/github_pr_autofix_contract_preflight.py",
+      "required_test_targets": [
+        "tests/test_github_pr_autofix_contract_preflight.py"
+      ]
+    },
+    {
+      "path_prefix": "spectrum_systems/modules/runtime/test_inventory_integrity.py",
+      "required_test_targets": [
+        "tests/test_test_inventory_integrity.py"
+      ]
+    },
+    {
+      "path_prefix": "contracts/",
+      "required_test_targets": [
+        "tests/test_contracts.py"
+      ]
+    }
+  ],
+  "bounded_equivalence": [
+    {
+      "required_target": "tests/test_contract_preflight.py",
+      "equivalent_targets": [
+        "tests/test_contract_preflight.py",
+        "tests/test_run_github_pr_autofix_contract_preflight.py"
+      ]
+    }
+  ],
+  "allowed_exceptions": []
+}

--- a/docs/governance/test_inventory_integrity.md
+++ b/docs/governance/test_inventory_integrity.md
@@ -52,3 +52,21 @@ This rewrites `docs/governance/pytest_pr_inventory_baseline.json` using determin
 - Integrity failure classes are surfaced directly in preflight diagnosis.
 - Contract preflight blocks merge/promotion when inventory drops or drifts silently.
 - Repair routing points to pytest config, test roots, CI working directory, or baseline refresh path depending on classification.
+
+## Pytest selection integrity hard gate (TSI-01)
+Preflight now emits and validates:
+- `outputs/contract_preflight/pytest_selection_integrity_result.json`
+
+Governed policy source:
+- `docs/governance/pytest_pr_selection_integrity_policy.json`
+
+Fail-closed invariant reason codes:
+- `PYTEST_SELECTION_EMPTY`
+- `PYTEST_REQUIRED_TARGETS_MISSING`
+- `PYTEST_SELECTION_THRESHOLD_NOT_MET`
+- `PYTEST_SELECTION_ARTIFACT_MISSING`
+- `PYTEST_SELECTION_ARTIFACT_INVALID`
+- `PYTEST_SELECTION_MISMATCH`
+- `PYTEST_SELECTION_FILTERING_DETECTED`
+
+PR trust gating requires both execution evidence and selection integrity evidence. Execution alone is non-sufficient.

--- a/docs/review-actions/PLAN-TSI-01-2026-04-14.md
+++ b/docs/review-actions/PLAN-TSI-01-2026-04-14.md
@@ -1,0 +1,65 @@
+# Plan — TSI-01 — 2026-04-14
+
+## Prompt type
+PLAN
+
+## Roadmap item
+TSI-01 — Enforce pytest selection integrity + backtest recent PR trust gap
+
+## Objective
+Add fail-closed pytest selection integrity enforcement and a deterministic trust-gap audit path so PR preflight cannot pass on execution evidence alone.
+
+## Declared files
+| File | Change type | Reason |
+| --- | --- | --- |
+| docs/review-actions/PLAN-TSI-01-2026-04-14.md | CREATE | Plan-first requirement for multi-file governance, contract, script, and test changes. |
+| scripts/run_contract_preflight.py | MODIFY | Compute and emit pytest selection integrity artifact, enforce fail-closed invariants, and wire into report/artifact outputs. |
+| spectrum_systems/modules/runtime/pytest_selection_integrity.py | CREATE | Pure runtime module for deterministic selection integrity evaluation from governed policy and preflight context. |
+| contracts/schemas/pytest_selection_integrity_result.schema.json | CREATE | Canonical schema for selection integrity artifact. |
+| contracts/examples/pytest_selection_integrity_result.json | CREATE | Golden example for selection integrity artifact contract. |
+| contracts/schemas/contract_preflight_result_artifact.schema.json | MODIFY | Require pytest selection integrity artifact fields in preflight result. |
+| contracts/examples/contract_preflight_result_artifact.json | MODIFY | Keep canonical preflight example aligned with schema and new integrity fields. |
+| contracts/examples/contract_preflight_result_artifact.example.json | MODIFY | Keep secondary preflight example aligned with schema and new integrity fields. |
+| docs/governance/pytest_pr_selection_integrity_policy.json | CREATE | Governed policy baseline defining threshold, mapping rules, and equivalence behavior. |
+| docs/governance/test_inventory_integrity.md | MODIFY | Document new selection integrity gate behavior and invariants. |
+| spectrum_systems/modules/runtime/preflight_failure_normalizer.py | MODIFY | Normalize selection integrity invariant failures into deterministic failure classes. |
+| spectrum_systems/modules/runtime/github_pr_autofix_contract_preflight.py | MODIFY | Deterministic classification and bounded auto-repair policy for selection integrity failures. |
+| .github/workflows/artifact-boundary.yml | MODIFY | Enforce presence/validity of both pytest execution and selection integrity artifacts. |
+| .github/workflows/pr-autofix-contract-preflight.yml | MODIFY | Enforce presence/validity of both pytest execution and selection integrity artifacts in autorepair workflow. |
+| spectrum_systems/modules/runtime/pytest_trust_gap_audit.py | CREATE | Deterministic read-only trust-gap audit module for recent preflight evidence. |
+| scripts/run_pytest_trust_gap_audit.py | CREATE | Thin CLI wrapper for trust-gap audit module with bounded/date-count inputs. |
+| contracts/schemas/pytest_trust_gap_audit_result.schema.json | CREATE | Canonical schema for trust-gap audit artifact. |
+| contracts/examples/pytest_trust_gap_audit_result.json | CREATE | Golden example for trust-gap audit artifact. |
+| tests/test_contract_preflight.py | MODIFY | Add blocking/allowance regression tests for selection integrity fail-closed behavior. |
+| tests/test_github_pr_autofix_contract_preflight.py | MODIFY | Add selection integrity classification and bounded repair tests. |
+| tests/test_test_inventory_integrity.py | MODIFY | Add regression guard ensuring execution-only evidence cannot pass integrity expectations. |
+| tests/test_pytest_selection_integrity.py | CREATE | Unit tests for selection integrity policy mapping and decision logic. |
+| tests/test_pytest_trust_gap_audit.py | CREATE | Unit tests for trust-gap audit missing/weak/clean evidence classification. |
+| tests/test_contracts.py | MODIFY | Validate new contract examples. |
+| contracts/standards-manifest.json | MODIFY | Register new contracts and bump manifest versioning metadata. |
+| docs/reviews/TSI-01_selection_integrity_and_audit_review.md | CREATE | Delivery report required by prompt. |
+
+## Contracts touched
+- `contract_preflight_result_artifact` (schema + examples, additive)
+- `pytest_selection_integrity_result` (new)
+- `pytest_trust_gap_audit_result` (new)
+- `standards_manifest` (version bump + contract registrations)
+
+## Tests that must pass after execution
+1. `python scripts/run_contract_preflight.py --help`
+2. `python -m pytest -q tests/test_contract_preflight.py`
+3. `python -m pytest -q tests/test_github_pr_autofix_contract_preflight.py`
+4. `python -m pytest -q tests/test_test_inventory_integrity.py`
+5. `python -m pytest -q tests/test_pytest_selection_integrity.py`
+6. `python -m pytest -q tests/test_pytest_trust_gap_audit.py`
+7. `python -m pytest -q tests/`
+8. `python scripts/run_contract_enforcement.py`
+
+## Scope exclusions
+- Do not replace or weaken existing pytest execution evidence enforcement.
+- Do not introduce non-deterministic or log-scraping trust logic.
+- Do not downgrade BLOCK semantics to WARN for invariant violations.
+- Do not perform unrelated refactors outside preflight/autofix/audit/policy surfaces.
+
+## Dependencies
+- Existing PYX execution evidence contract and preflight wiring are the required base.

--- a/docs/review-actions/PLAN-TSI-02-2026-04-14.md
+++ b/docs/review-actions/PLAN-TSI-02-2026-04-14.md
@@ -1,0 +1,41 @@
+# Plan — TSI-02 — 2026-04-14
+
+## Prompt type
+PLAN
+
+## Roadmap item
+TSI-02 — Wire pytest selection integrity into the actual PR execution path
+
+## Objective
+Ensure the authoritative PR workflow seam fail-closes on missing/invalid pytest execution + selection-integrity evidence in real CI execution paths, not only in helper/report code.
+
+## Declared files
+| File | Change type | Reason |
+| --- | --- | --- |
+| docs/review-actions/PLAN-TSI-02-2026-04-14.md | CREATE | PLAN-first requirement for multi-file seam hardening. |
+| .github/workflows/artifact-boundary.yml | MODIFY | Move/guarantee authoritative artifact validation executes on real PR pass path. |
+| .github/workflows/pr-autofix-contract-preflight.yml | MODIFY | Keep autofix preflight enforcement symmetric for execution + selection-integrity checks. |
+| scripts/run_contract_preflight.py | MODIFY | Add explicit PR selection-integrity invariant code and fail-closed wiring in authoritative script. |
+| spectrum_systems/modules/runtime/preflight_failure_normalizer.py | MODIFY | Include explicit `PR_PYTEST_SELECTION_INTEGRITY_REQUIRED` in normalization signals. |
+| tests/test_contract_preflight.py | MODIFY | Add regression proving preflight emits required explicit PR selection-integrity invariant. |
+| tests/test_artifact_boundary_workflow_pytest_enforcement.py | MODIFY | Add workflow-adjacent seam tests proving checks are present on the real path. |
+| docs/reviews/TSI-02_real_pr_seam_enforcement_review.md | CREATE | Required delivery review documenting seam identification and enforcement evidence. |
+
+## Contracts touched
+- None (behavioral seam wiring and tests only)
+
+## Tests that must pass after execution
+1. `python scripts/run_contract_preflight.py --help`
+2. `python -m pytest -q tests/test_contract_preflight.py`
+3. `python -m pytest -q tests/test_github_pr_autofix_contract_preflight.py`
+4. `python -m pytest -q tests/test_pytest_selection_integrity.py`
+5. `python -m pytest -q tests/test_artifact_boundary_workflow_pytest_enforcement.py`
+6. `python scripts/run_contract_enforcement.py`
+
+## Scope exclusions
+- Do not redesign preflight architecture.
+- Do not replace artifact-first trust logic with logs.
+- Do not add non-authoritative reporting-only paths.
+
+## Dependencies
+- Existing TSI-01 selection-integrity artifact and policy wiring.

--- a/docs/reviews/TSI-01_selection_integrity_and_audit_review.md
+++ b/docs/reviews/TSI-01_selection_integrity_and_audit_review.md
@@ -1,0 +1,89 @@
+# TSI-01 Selection Integrity + Trust-Gap Audit Review
+
+## 1. Intent
+Implement fail-closed hardening so PR trust cannot pass on pytest execution evidence alone by requiring governed pytest selection integrity evidence, and add a deterministic read-only audit path for recent historical trust gaps.
+
+## 2. Files added
+- `docs/review-actions/PLAN-TSI-01-2026-04-14.md`
+- `docs/governance/pytest_pr_selection_integrity_policy.json`
+- `contracts/schemas/pytest_selection_integrity_result.schema.json`
+- `contracts/examples/pytest_selection_integrity_result.json`
+- `contracts/schemas/pytest_trust_gap_audit_result.schema.json`
+- `contracts/examples/pytest_trust_gap_audit_result.json`
+- `spectrum_systems/modules/runtime/pytest_selection_integrity.py`
+- `spectrum_systems/modules/runtime/pytest_trust_gap_audit.py`
+- `scripts/run_pytest_trust_gap_audit.py`
+- `tests/test_pytest_selection_integrity.py`
+- `tests/test_pytest_trust_gap_audit.py`
+
+## 3. Files modified
+- `scripts/run_contract_preflight.py`
+- `spectrum_systems/modules/runtime/github_pr_autofix_contract_preflight.py`
+- `spectrum_systems/modules/runtime/preflight_failure_normalizer.py`
+- `contracts/schemas/contract_preflight_result_artifact.schema.json`
+- `contracts/examples/contract_preflight_result_artifact.json`
+- `contracts/examples/contract_preflight_result_artifact.example.json`
+- `contracts/schemas/preflight_block_diagnosis_record.schema.json`
+- `contracts/schemas/failure_repair_candidate_artifact.schema.json`
+- `contracts/examples/preflight_block_diagnosis_record.json`
+- `contracts/standards-manifest.json`
+- `.github/workflows/artifact-boundary.yml`
+- `.github/workflows/pr-autofix-contract-preflight.yml`
+- `docs/governance/test_inventory_integrity.md`
+- `tests/test_contract_preflight.py`
+- `tests/test_github_pr_autofix_contract_preflight.py`
+- `tests/test_test_inventory_integrity.py`
+- `tests/test_pqx_slice_runner.py`
+- `tests/test_contracts.py`
+
+## 4. New artifacts/contracts introduced
+- `pytest_selection_integrity_result` (new governed artifact + schema + example)
+- `pytest_trust_gap_audit_result` (new governed artifact + schema + example)
+- `contract_preflight_result_artifact` v`1.4.0` additive fields:
+  - `pytest_selection_integrity`
+  - `pytest_selection_integrity_result_ref`
+
+## 5. Policy decisions
+- Minimum PR selection threshold is explicit and versioned in governed policy (`minimum_selection_threshold: 1`).
+- Surface-to-required-test mapping is explicit and fail-closed in policy (`surface_rules`).
+- Bounded equivalence is explicit and opt-in (`allow_bounded_equivalence`).
+- Missing/invalid selection integrity evidence is treated as BLOCK.
+
+## 6. Failure modes closed
+- PR allow with empty pytest target selection.
+- PR allow with missing required governed target coverage.
+- PR allow with threshold under-selection.
+- PR allow with missing/invalid selection integrity artifact.
+- PR allow with filtering-detected target collapse.
+- Autofix false-success when rerun lacks valid execution + valid selection integrity evidence.
+
+## 7. Remaining risks
+- Historical runs without artifacts remain uncertain; audit explicitly classifies as suspect/unknown rather than fabricating trust.
+- Governance policy drift can re-open gaps if mappings are not updated with new governed surfaces.
+
+## 8. Tests added/updated
+- Added `tests/test_pytest_selection_integrity.py`.
+- Added `tests/test_pytest_trust_gap_audit.py`.
+- Updated preflight tests for selection-integrity BLOCK and artifact emission paths.
+- Updated autofix tests for new selection-integrity failure classes and bounded repair behavior.
+- Updated contract tests and pqx slice runner fixtures for new preflight artifact schema requirements.
+
+## 9. Validation commands run
+1. `python scripts/run_contract_preflight.py --help`
+2. `python -m pytest -q tests/test_contract_preflight.py`
+3. `python -m pytest -q tests/test_github_pr_autofix_contract_preflight.py`
+4. `python -m pytest -q tests/test_test_inventory_integrity.py`
+5. `python -m pytest -q tests/`
+6. `python scripts/run_contract_enforcement.py`
+
+## 10. Exact results
+- `python scripts/run_contract_preflight.py --help` exited `0`.
+- `python -m pytest -q tests/test_contract_preflight.py` passed (`71 passed`).
+- `python -m pytest -q tests/test_github_pr_autofix_contract_preflight.py` passed (`27 passed`).
+- `python -m pytest -q tests/test_test_inventory_integrity.py` passed (`9 passed`).
+- `python -m pytest -q tests/` passed (`6655 passed, 1 skipped`).
+- `python scripts/run_contract_enforcement.py` passed (`failures=0 warnings=0 not_yet_enforceable=0`).
+
+## 11. Follow-on recommendations
+- Add a CI job that runs `scripts/run_pytest_trust_gap_audit.py` on a bounded rolling window and publishes suspect trend history.
+- Add a policy-change checklist requiring same-change updates to `pytest_pr_selection_integrity_policy.json` for new governed runtime surfaces.

--- a/docs/reviews/TSI-02_real_pr_seam_enforcement_review.md
+++ b/docs/reviews/TSI-02_real_pr_seam_enforcement_review.md
@@ -1,0 +1,52 @@
+# TSI-02 Real PR Seam Enforcement Review
+
+## 1. Real PR seam identified
+The authoritative PR pass/fail seam is the `contract-preflight` job in `.github/workflows/artifact-boundary.yml`, which executes `scripts/run_contract_preflight.py` and then validates `outputs/contract_preflight/contract_preflight_result_artifact.json` as the trust authority for pytest execution and selection integrity.
+
+## 2. Files added
+- `docs/review-actions/PLAN-TSI-02-2026-04-14.md`
+- `docs/reviews/TSI-02_real_pr_seam_enforcement_review.md`
+
+## 3. Files modified
+- `.github/workflows/artifact-boundary.yml`
+- `.github/workflows/pr-autofix-contract-preflight.yml`
+- `scripts/run_contract_preflight.py`
+- `spectrum_systems/modules/runtime/preflight_failure_normalizer.py`
+- `spectrum_systems/modules/runtime/github_pr_autofix_contract_preflight.py`
+- `tests/test_artifact_boundary_workflow_pytest_enforcement.py`
+- `tests/test_contract_preflight.py`
+- `tests/test_github_pr_autofix_contract_preflight.py`
+
+## 4. What was previously unwired
+`artifact-boundary.yml` returned early when `run_contract_preflight.py` exited 0, bypassing workflow-level artifact trust checks on the actual happy path. This allowed the real PR seam to skip execution/selection artifact validation despite having report/schema coverage.
+
+## 5. What is now enforced
+- Workflow no longer bypasses artifact validation on `preflight_exit==0`; artifact checks run on the real PR path.
+- PR allow/warn now fail-closes if either execution artifact or selection-integrity artifact is missing/invalid/blocked.
+- Preflight now emits explicit invariant `PR_PYTEST_SELECTION_INTEGRITY_REQUIRED` alongside fail-closed selection reason codes.
+- Autofix classification handles `PR_PYTEST_SELECTION_INTEGRITY_REQUIRED` deterministically as a selection-integrity failure class.
+
+## 6. Tests added/updated
+- Workflow-adjacent seam tests assert no early bypass and assert selection-integrity guard clauses in both workflows.
+- Preflight regression test asserts explicit `PR_PYTEST_SELECTION_INTEGRITY_REQUIRED` invariant presence.
+- Autofix classification regression test covers `PR_PYTEST_SELECTION_INTEGRITY_REQUIRED` mapping.
+
+## 7. Validation commands run
+1. `python scripts/run_contract_preflight.py --help`
+2. `python -m pytest -q tests/test_contract_preflight.py`
+3. `python -m pytest -q tests/test_github_pr_autofix_contract_preflight.py`
+4. `python -m pytest -q tests/test_pytest_selection_integrity.py`
+5. `python -m pytest -q tests/test_artifact_boundary_workflow_pytest_enforcement.py`
+6. `python scripts/run_contract_enforcement.py`
+
+## 8. Exact results
+- help command passed.
+- `tests/test_contract_preflight.py` passed.
+- `tests/test_github_pr_autofix_contract_preflight.py` passed.
+- `tests/test_pytest_selection_integrity.py` passed.
+- `tests/test_artifact_boundary_workflow_pytest_enforcement.py` passed.
+- contract enforcement passed with zero failures.
+
+## 9. Remaining risks
+- Workflow assertions are string-based (workflow-adjacent); they prove seam wiring but not execution semantics of GitHub runner itself.
+- Governance policy drift still requires same-change updates when new governed surfaces are added.

--- a/scripts/run_contract_preflight.py
+++ b/scripts/run_contract_preflight.py
@@ -1953,7 +1953,9 @@ def main() -> int:
         selection_reasons = [str(item) for item in (selection_integrity.get("blocking_reasons") or []) if isinstance(item, str)]
         if str(selection_integrity.get("selection_integrity_decision") or "BLOCK") != "ALLOW":
             report["status"] = "failed"
-            report["invariant_violations"] = sorted(set(report.get("invariant_violations", []) + selection_reasons))
+            report["invariant_violations"] = sorted(
+                set(report.get("invariant_violations", []) + selection_reasons + ["PR_PYTEST_SELECTION_INTEGRITY_REQUIRED"])
+            )
             report["recommended_repair_areas"] = sorted(
                 set(report.get("recommended_repair_areas", []) + ["restore deterministic PR pytest selection integrity coverage"])
             )
@@ -2023,7 +2025,9 @@ def main() -> int:
     pytest_execution_count = int(pytest_execution.get("pytest_execution_count", 0)) if isinstance(pytest_execution, dict) else 0
     if is_pull_request_event and not str(report.get("pytest_selection_integrity_result_ref") or "").strip():
         report["status"] = "failed"
-        report["invariant_violations"] = sorted(set(report.get("invariant_violations", []) + ["PYTEST_SELECTION_ARTIFACT_MISSING"]))
+        report["invariant_violations"] = sorted(
+            set(report.get("invariant_violations", []) + ["PYTEST_SELECTION_ARTIFACT_MISSING", "PR_PYTEST_SELECTION_INTEGRITY_REQUIRED"])
+        )
 
     if is_pull_request_event and report.get("status") == "passed" and pytest_execution_count < 1:
         report["status"] = "failed"

--- a/scripts/run_contract_preflight.py
+++ b/scripts/run_contract_preflight.py
@@ -70,6 +70,10 @@ from spectrum_systems.modules.runtime.test_inventory_integrity import (  # noqa:
     evaluate_test_inventory_integrity,
     refresh_baseline as refresh_test_inventory_baseline,
 )
+from spectrum_systems.modules.runtime.pytest_selection_integrity import (  # noqa: E402
+    PytestSelectionIntegrityError,
+    evaluate_pytest_selection_integrity,
+)
 
 DEFAULT_REQUIRED_SMOKE_TESTS = [
     "tests/test_roadmap_eligibility.py",
@@ -127,6 +131,7 @@ _GOVERNED_PROMPT_SURFACE_REGISTRY = REPO_ROOT / "docs" / "governance" / "governe
 _SYSTEM_REGISTRY_PATH = REPO_ROOT / "docs" / "architecture" / "system_registry.md"
 _SYSTEM_REGISTRY_GUARD_POLICY_PATH = REPO_ROOT / "contracts" / "governance" / "system_registry_guard_policy.json"
 _TEST_INVENTORY_BASELINE_PATH = REPO_ROOT / "docs" / "governance" / "pytest_pr_inventory_baseline.json"
+_PYTEST_SELECTION_INTEGRITY_POLICY_PATH = REPO_ROOT / "docs" / "governance" / "pytest_pr_selection_integrity_policy.json"
 _DEFAULT_PR_INVENTORY_TARGETS = ["tests/test_eval_dataset_registry.py"]
 _GOVERNED_PR_FALLBACK_PYTEST_TARGETS = [
     "tests/test_run_github_pr_autofix_contract_preflight.py",
@@ -852,6 +857,13 @@ def render_markdown(report: dict[str, Any]) -> str:
         lines.append(f"- **pytest_fallback_used**: {pytest_execution.get('fallback_used', False)}")
         lines.append(f"- **pytest_selected_target_count**: {len(pytest_execution.get('selected_targets', []))}")
 
+    pytest_selection_integrity = report.get("pytest_selection_integrity")
+    if isinstance(pytest_selection_integrity, dict):
+        lines.append(f"- **pytest_selection_integrity_decision**: {pytest_selection_integrity.get('selection_integrity_decision', 'BLOCK')}")
+        lines.append(f"- **pytest_selection_count**: {pytest_selection_integrity.get('selection_count', 0)}")
+        lines.append(f"- **pytest_required_target_count**: {len(pytest_selection_integrity.get('required_test_targets', []))}")
+        lines.append(f"- **pytest_selection_blocking_reasons**: {len(pytest_selection_integrity.get('blocking_reasons', []))}")
+
     lines.append("")
     pqx_execution_policy = report.get("pqx_execution_policy")
     if isinstance(pqx_execution_policy, dict):
@@ -1295,7 +1307,7 @@ def build_preflight_result_artifact(
         }
     return {
         "artifact_type": "contract_preflight_result_artifact",
-        "schema_version": "1.3.0",
+        "schema_version": "1.4.0",
         "preflight_status": report.get("status", "failed"),
         "changed_contracts": report.get("changed_contracts", []),
         "impacted_producers": report.get("impact", {}).get("producers", []),
@@ -1314,6 +1326,8 @@ def build_preflight_result_artifact(
         "control_surface_gap_blocking": bool(report.get("control_surface_gap_blocking", False)),
         "pytest_execution": report.get("pytest_execution", {}),
         "pytest_execution_record_ref": report.get("pytest_execution_record_ref"),
+        "pytest_selection_integrity": report.get("pytest_selection_integrity", {}),
+        "pytest_selection_integrity_result_ref": report.get("pytest_selection_integrity_result_ref"),
         "pqx_required_context_enforcement": {
             "classification": str(required_context.get("classification", "exploration_only_or_non_governed")),
             "execution_context": str(required_context.get("execution_context", "unspecified")),
@@ -1673,6 +1687,8 @@ def main() -> int:
             "system_registry_guard_result_ref": str(srg_output_path),
             "test_inventory_integrity": test_inventory_payload,
             "test_inventory_integrity_result_ref": str(test_inventory_artifact_path),
+            "pytest_selection_integrity": {},
+            "pytest_selection_integrity_result_ref": None,
         }
     elif not surface_classification["required_paths"]:
         report = {
@@ -1707,6 +1723,8 @@ def main() -> int:
             "system_registry_guard_result_ref": str(srg_output_path),
             "test_inventory_integrity": test_inventory_payload,
             "test_inventory_integrity_result_ref": str(test_inventory_artifact_path),
+            "pytest_selection_integrity": {},
+            "pytest_selection_integrity_result_ref": None,
         }
     else:
         if changed_contract_paths:
@@ -1802,6 +1820,8 @@ def main() -> int:
             "system_registry_guard_result_ref": str(srg_output_path),
             "test_inventory_integrity": test_inventory_payload,
             "test_inventory_integrity_result_ref": str(test_inventory_artifact_path),
+            "pytest_selection_integrity": {},
+            "pytest_selection_integrity_result_ref": None,
         }
     if is_pull_request_event and report.get("status") == "passed" and not pytest_execution_log:
         fallback_pytest_targets = _resolve_existing_pytest_targets(_GOVERNED_PR_FALLBACK_PYTEST_TARGETS)
@@ -1855,6 +1875,62 @@ def main() -> int:
     pytest_execution_record_path.write_text(json.dumps(pytest_execution_record, indent=2) + "\n", encoding="utf-8")
     report["pytest_execution_record_ref"] = str(pytest_execution_record_path)
 
+    required_targets_for_integrity = sorted(set(smoke_targets + forced_targets)) if "smoke_targets" in locals() and "forced_targets" in locals() else []
+    try:
+        selection_eval = evaluate_pytest_selection_integrity(
+            changed_paths=detection.changed_paths,
+            selected_test_targets=sorted(set(selected_pytest_targets + fallback_pytest_targets)),
+            required_test_targets=required_targets_for_integrity,
+            pytest_execution_record=pytest_execution_record,
+            policy_path=_PYTEST_SELECTION_INTEGRITY_POLICY_PATH,
+            generated_at=_utc_now(),
+        )
+        report["pytest_selection_integrity"] = selection_eval.payload
+    except PytestSelectionIntegrityError:
+        report["pytest_selection_integrity"] = {
+            "artifact_type": "pytest_selection_integrity_result",
+            "schema_version": "1.0.0",
+            "changed_paths": sorted(set(detection.changed_paths)),
+            "required_test_targets": required_targets_for_integrity,
+            "selected_test_targets": sorted(set(selected_pytest_targets + fallback_pytest_targets)),
+            "missing_required_targets": required_targets_for_integrity,
+            "selection_count": len(sorted(set(selected_pytest_targets + fallback_pytest_targets))),
+            "minimum_selection_threshold": 1,
+            "threshold_satisfied": False,
+            "impacted_surface_count": len(detection.changed_paths),
+            "selection_integrity_decision": "BLOCK",
+            "blocking_reasons": ["PYTEST_SELECTION_ARTIFACT_INVALID"],
+            "generated_at": _utc_now(),
+        }
+    selection_integrity_valid = True
+    try:
+        validate_artifact(report["pytest_selection_integrity"], "pytest_selection_integrity_result")
+    except Exception:
+        selection_integrity_valid = False
+        report["status"] = "failed"
+        report["invariant_violations"] = sorted(set(report.get("invariant_violations", []) + ["PYTEST_SELECTION_ARTIFACT_INVALID"]))
+        report["pytest_selection_integrity"] = {
+            "artifact_type": "pytest_selection_integrity_result",
+            "schema_version": "1.0.0",
+            "changed_paths": sorted(set(detection.changed_paths)),
+            "required_test_targets": required_targets_for_integrity,
+            "selected_test_targets": sorted(set(selected_pytest_targets + fallback_pytest_targets)),
+            "missing_required_targets": required_targets_for_integrity,
+            "selection_count": len(sorted(set(selected_pytest_targets + fallback_pytest_targets))),
+            "minimum_selection_threshold": 1,
+            "threshold_satisfied": False,
+            "impacted_surface_count": len(detection.changed_paths),
+            "selection_integrity_decision": "BLOCK",
+            "blocking_reasons": ["PYTEST_SELECTION_ARTIFACT_INVALID"],
+            "generated_at": _utc_now(),
+        }
+    selection_integrity_path = output_dir / "pytest_selection_integrity_result.json"
+    if selection_integrity_valid:
+        selection_integrity_path.write_text(json.dumps(report["pytest_selection_integrity"], indent=2) + "\n", encoding="utf-8")
+        report["pytest_selection_integrity_result_ref"] = str(selection_integrity_path)
+    else:
+        report["pytest_selection_integrity_result_ref"] = None
+
     if is_pull_request_event:
         if not bool(pytest_execution_record.get("executed", False)):
             report["status"] = "failed"
@@ -1871,6 +1947,15 @@ def main() -> int:
             )
             report["recommended_repair_areas"] = sorted(
                 set(report.get("recommended_repair_areas", []) + ["restore deterministic PR pytest target selection"])
+            )
+
+        selection_integrity = report.get("pytest_selection_integrity") or {}
+        selection_reasons = [str(item) for item in (selection_integrity.get("blocking_reasons") or []) if isinstance(item, str)]
+        if str(selection_integrity.get("selection_integrity_decision") or "BLOCK") != "ALLOW":
+            report["status"] = "failed"
+            report["invariant_violations"] = sorted(set(report.get("invariant_violations", []) + selection_reasons))
+            report["recommended_repair_areas"] = sorted(
+                set(report.get("recommended_repair_areas", []) + ["restore deterministic PR pytest selection integrity coverage"])
             )
 
     if report["control_surface_enforcement"] and report["control_surface_enforcement"].get("enforcement_status") == "BLOCK":
@@ -1936,6 +2021,10 @@ def main() -> int:
         )
     pytest_execution = report.get("pytest_execution", {})
     pytest_execution_count = int(pytest_execution.get("pytest_execution_count", 0)) if isinstance(pytest_execution, dict) else 0
+    if is_pull_request_event and not str(report.get("pytest_selection_integrity_result_ref") or "").strip():
+        report["status"] = "failed"
+        report["invariant_violations"] = sorted(set(report.get("invariant_violations", []) + ["PYTEST_SELECTION_ARTIFACT_MISSING"]))
+
     if is_pull_request_event and report.get("status") == "passed" and pytest_execution_count < 1:
         report["status"] = "failed"
         report["invariant_violations"] = sorted(

--- a/scripts/run_pytest_trust_gap_audit.py
+++ b/scripts/run_pytest_trust_gap_audit.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Run deterministic pytest trust-gap audit over recent local preflight artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from spectrum_systems.modules.runtime.pytest_trust_gap_audit import run_pytest_trust_gap_audit, scan_preflight_artifacts  # noqa: E402
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run deterministic pytest trust-gap audit.")
+    parser.add_argument("--scan-root", action="append", default=[], help="Scan root (repeatable). Defaults to outputs/artifacts/data.")
+    parser.add_argument("--max-artifacts", type=int, default=50, help="Maximum artifacts to evaluate.")
+    parser.add_argument("--output-dir", default="outputs/pytest_trust_gap_audit", help="Audit output directory.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    scan_root_raw = args.scan_root or ["outputs", "artifacts", "data"]
+    roots = [Path(root) if Path(root).is_absolute() else (REPO_ROOT / root) for root in scan_root_raw]
+    scanned = scan_preflight_artifacts(roots, max_artifacts=args.max_artifacts)
+    scope = {
+        "roots": [str(path) for path in roots],
+        "artifact_globs": ["**/contract_preflight_result_artifact.json"],
+        "max_artifacts": args.max_artifacts,
+        "repo_root": str(REPO_ROOT),
+    }
+    result = run_pytest_trust_gap_audit(scanned_artifacts=scanned, audit_scope=scope)
+
+    output_dir = Path(args.output_dir) if Path(args.output_dir).is_absolute() else (REPO_ROOT / args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    result_path = output_dir / "pytest_trust_gap_audit_result.json"
+    result_path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"result_path": str(result_path), "scanned_artifact_count": result["scanned_artifact_count"], "suspect_count": result["suspect_count"]}, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/spectrum_systems/modules/runtime/github_pr_autofix_contract_preflight.py
+++ b/spectrum_systems/modules/runtime/github_pr_autofix_contract_preflight.py
@@ -219,6 +219,8 @@ def classify_preflight_block(*, report: dict[str, Any]) -> tuple[str, list[str]]
             return "no_tests_discovered", ["PR_PYTEST_SELECTED_TARGETS_EMPTY"]
         if "PR_PYTEST_FALLBACK_TARGETS_EMPTY" in invariant_violations:
             return "no_tests_discovered", ["PR_PYTEST_FALLBACK_TARGETS_EMPTY"]
+        if "PR_PYTEST_SELECTION_INTEGRITY_REQUIRED" in invariant_violations:
+            return "pytest_selection_missing", ["PR_PYTEST_SELECTION_INTEGRITY_REQUIRED"]
         if "PYTEST_SELECTION_ARTIFACT_MISSING" in invariant_violations or "PYTEST_SELECTION_ARTIFACT_INVALID" in invariant_violations:
             return "pytest_selection_missing", [code for code in invariant_violations if code.startswith("PYTEST_SELECTION_ARTIFACT")][:1] or ["PYTEST_SELECTION_ARTIFACT_MISSING"]
         if "PYTEST_SELECTION_FILTERING_DETECTED" in invariant_violations:

--- a/spectrum_systems/modules/runtime/github_pr_autofix_contract_preflight.py
+++ b/spectrum_systems/modules/runtime/github_pr_autofix_contract_preflight.py
@@ -38,6 +38,10 @@ KNOWN_REPAIR_CATEGORIES = {
     "test_inventory_regression",
     "control_surface_gap",
     "downstream_test_failure",
+    "pytest_selection_missing",
+    "pytest_selection_mismatch",
+    "pytest_selection_filtering",
+    "pytest_selection_threshold",
 }
 
 TERMINAL_STATES = {
@@ -215,6 +219,14 @@ def classify_preflight_block(*, report: dict[str, Any]) -> tuple[str, list[str]]
             return "no_tests_discovered", ["PR_PYTEST_SELECTED_TARGETS_EMPTY"]
         if "PR_PYTEST_FALLBACK_TARGETS_EMPTY" in invariant_violations:
             return "no_tests_discovered", ["PR_PYTEST_FALLBACK_TARGETS_EMPTY"]
+        if "PYTEST_SELECTION_ARTIFACT_MISSING" in invariant_violations or "PYTEST_SELECTION_ARTIFACT_INVALID" in invariant_violations:
+            return "pytest_selection_missing", [code for code in invariant_violations if code.startswith("PYTEST_SELECTION_ARTIFACT")][:1] or ["PYTEST_SELECTION_ARTIFACT_MISSING"]
+        if "PYTEST_SELECTION_FILTERING_DETECTED" in invariant_violations:
+            return "pytest_selection_filtering", ["PYTEST_SELECTION_FILTERING_DETECTED"]
+        if "PYTEST_SELECTION_THRESHOLD_NOT_MET" in invariant_violations:
+            return "pytest_selection_threshold", ["PYTEST_SELECTION_THRESHOLD_NOT_MET"]
+        if "PYTEST_SELECTION_MISMATCH" in invariant_violations or "PYTEST_REQUIRED_TARGETS_MISSING" in invariant_violations or "PYTEST_SELECTION_EMPTY" in invariant_violations:
+            return "pytest_selection_mismatch", [code for code in invariant_violations if code in {"PYTEST_SELECTION_MISMATCH","PYTEST_REQUIRED_TARGETS_MISSING","PYTEST_SELECTION_EMPTY"}] or ["PYTEST_SELECTION_MISMATCH"]
         if "artifact_validation_failure" in invariant_violations:
             return "schema_violation", ["artifact_validation_failure"]
         if "repair_pipeline_failure" in invariant_violations:
@@ -244,9 +256,10 @@ def _repair_policy(failure_class: str) -> tuple[str, bool, bool]:
         "collection_failure",
         "working_directory_mismatch",
         "accidental_filtering_detected",
+        "pytest_selection_missing",
     }:
         return "auto_repair_allowed", True, False
-    if failure_class in {"non_repairable_policy_violation", "lineage_missing", "downstream_test_failure"}:
+    if failure_class in {"non_repairable_policy_violation", "lineage_missing", "downstream_test_failure", "pytest_selection_mismatch", "pytest_selection_filtering", "pytest_selection_threshold"}:
         return "auto_repair_forbidden", False, True
     if failure_class in {"internal_preflight_error"}:
         return "escalation_required", False, True
@@ -313,6 +326,10 @@ def build_preflight_repair_plan_record(*, diagnosis_record: dict[str, Any]) -> d
         "collection_failure": ["tests/", "pytest.ini"],
         "working_directory_mismatch": [".github/workflows/", "scripts/run_contract_preflight.py"],
         "accidental_filtering_detected": ["pytest.ini", ".github/workflows/"],
+        "pytest_selection_missing": ["docs/governance/pytest_pr_selection_integrity_policy.json", "scripts/run_contract_preflight.py"],
+        "pytest_selection_mismatch": ["docs/governance/pytest_pr_selection_integrity_policy.json", "tests/"],
+        "pytest_selection_filtering": ["pytest.ini", "docs/governance/pytest_pr_selection_integrity_policy.json"],
+        "pytest_selection_threshold": ["docs/governance/pytest_pr_selection_integrity_policy.json"],
         "control_surface_gap": ["outputs/contract_preflight", "scripts/run_contract_preflight.py"],
         "downstream_test_failure": ["tests/", "scripts/run_contract_preflight.py"],
     }[category]
@@ -664,6 +681,14 @@ def run_preflight_block_autorepair(
     rerun = command_runner(rerun_cmd, repo_root)
     rerun_artifact = _read_json(output_dir / "contract_preflight_result_artifact.json")
     rerun_decision = str(((rerun_artifact.get("control_signal") or {}).get("strategy_gate_decision")) or "BLOCK")
+    rerun_exec_ref = str(rerun_artifact.get("pytest_execution_record_ref") or "").strip()
+    rerun_selection_ref = str(rerun_artifact.get("pytest_selection_integrity_result_ref") or "").strip()
+    rerun_selection = rerun_artifact.get("pytest_selection_integrity") if isinstance(rerun_artifact.get("pytest_selection_integrity"), dict) else {}
+    rerun_execution_ok = bool(rerun_exec_ref)
+    rerun_selection_ok = bool(rerun_selection_ref) and str(rerun_selection.get("selection_integrity_decision") or "BLOCK") == "ALLOW"
+    if not (rerun_execution_ok and rerun_selection_ok):
+        rerun_decision = "BLOCK"
+
     result = build_preflight_repair_result_record(
         attempt_id=attempt["attempt_id"],
         plan_record=plan,

--- a/spectrum_systems/modules/runtime/preflight_failure_normalizer.py
+++ b/spectrum_systems/modules/runtime/preflight_failure_normalizer.py
@@ -35,6 +35,7 @@ def normalize_preflight_failure(report: dict[str, Any]) -> dict[str, Any]:
                 "PYTEST_SELECTION_ARTIFACT_INVALID",
                 "PYTEST_SELECTION_MISMATCH",
                 "PYTEST_SELECTION_FILTERING_DETECTED",
+                "PR_PYTEST_SELECTION_INTEGRITY_REQUIRED",
             }
             & set(report.get("invariant_violations", []))
         ),

--- a/spectrum_systems/modules/runtime/preflight_failure_normalizer.py
+++ b/spectrum_systems/modules/runtime/preflight_failure_normalizer.py
@@ -26,6 +26,18 @@ def normalize_preflight_failure(report: dict[str, Any]) -> dict[str, Any]:
             }
             & set(report.get("invariant_violations", []))
         ),
+        "has_pytest_selection_gap": bool(
+            {
+                "PYTEST_SELECTION_EMPTY",
+                "PYTEST_REQUIRED_TARGETS_MISSING",
+                "PYTEST_SELECTION_THRESHOLD_NOT_MET",
+                "PYTEST_SELECTION_ARTIFACT_MISSING",
+                "PYTEST_SELECTION_ARTIFACT_INVALID",
+                "PYTEST_SELECTION_MISMATCH",
+                "PYTEST_SELECTION_FILTERING_DETECTED",
+            }
+            & set(report.get("invariant_violations", []))
+        ),
         "has_test_inventory_failure": (
             report.get("test_inventory_integrity", {}).get("failure_class") not in {None, "success"}
         ),
@@ -36,6 +48,8 @@ def normalize_preflight_failure(report: dict[str, Any]) -> dict[str, Any]:
     elif signals["has_missing_surface"]:
         failure_class = "contract_mismatch"
     elif signals["has_test_inventory_failure"]:
+        failure_class = "test_inventory_regression"
+    elif signals["has_pytest_selection_gap"]:
         failure_class = "test_inventory_regression"
     elif signals["has_control_surface_gap"]:
         failure_class = "control_surface_gap"

--- a/spectrum_systems/modules/runtime/pytest_selection_integrity.py
+++ b/spectrum_systems/modules/runtime/pytest_selection_integrity.py
@@ -1,0 +1,166 @@
+"""Deterministic pytest selection integrity evaluation for contract preflight."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+class PytestSelectionIntegrityError(ValueError):
+    """Raised when policy or runtime inputs are malformed."""
+
+
+@dataclass(frozen=True)
+class SelectionIntegrityEvaluation:
+    status: str
+    decision: str
+    blocking_reasons: list[str]
+    payload: dict[str, Any]
+
+
+def _load_policy(policy_path: Path) -> dict[str, Any]:
+    if not policy_path.is_file():
+        raise PytestSelectionIntegrityError(f"missing_selection_policy:{policy_path}")
+    payload = json.loads(policy_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise PytestSelectionIntegrityError("selection policy must be a JSON object")
+    return payload
+
+
+def _required_targets_from_policy(*, changed_paths: list[str], policy: dict[str, Any]) -> list[str]:
+    rules = policy.get("surface_rules")
+    if not isinstance(rules, list):
+        return []
+    required: set[str] = set()
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        prefix = str(rule.get("path_prefix") or "").strip()
+        targets = rule.get("required_test_targets") or []
+        if not prefix or not isinstance(targets, list):
+            continue
+        if any(path.startswith(prefix) for path in changed_paths):
+            required.update(str(target).strip() for target in targets if isinstance(target, str) and str(target).strip())
+    return sorted(required)
+
+
+def _collect_equivalence_groups(policy: dict[str, Any]) -> dict[str, list[str]]:
+    groups: dict[str, list[str]] = {}
+    raw = policy.get("bounded_equivalence")
+    if not isinstance(raw, list):
+        return groups
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        required_target = str(item.get("required_target") or "").strip()
+        equivalents = item.get("equivalent_targets") or []
+        if not required_target or not isinstance(equivalents, list):
+            continue
+        normalized = sorted({str(target).strip() for target in equivalents if isinstance(target, str) and str(target).strip()})
+        if normalized:
+            groups[required_target] = normalized
+    return groups
+
+
+def evaluate_pytest_selection_integrity(
+    *,
+    changed_paths: list[str],
+    selected_test_targets: list[str],
+    required_test_targets: list[str],
+    pytest_execution_record: dict[str, Any] | None,
+    policy_path: Path,
+    generated_at: str,
+) -> SelectionIntegrityEvaluation:
+    """Evaluate fail-closed selection integrity evidence for preflight."""
+    policy = _load_policy(policy_path)
+    minimum_selection_threshold = int(policy.get("minimum_selection_threshold") or 1)
+    if minimum_selection_threshold < 1:
+        raise PytestSelectionIntegrityError("minimum_selection_threshold must be >= 1")
+
+    governed_prefixes = [
+        str(item).strip()
+        for item in (policy.get("governed_surface_prefixes") or [])
+        if isinstance(item, str) and str(item).strip()
+    ]
+    changed_paths_norm = sorted({str(path).strip() for path in changed_paths if isinstance(path, str) and str(path).strip()})
+    selected_targets_norm = sorted({str(path).strip() for path in selected_test_targets if isinstance(path, str) and str(path).strip()})
+
+    policy_required_targets = _required_targets_from_policy(changed_paths=changed_paths_norm, policy=policy)
+    effective_required = sorted(set(required_test_targets) | set(policy_required_targets))
+
+    impacted_governed_paths = [
+        path for path in changed_paths_norm if any(path.startswith(prefix) for prefix in governed_prefixes)
+    ]
+    impacted_surface_count = len(impacted_governed_paths)
+
+    reasons: list[str] = []
+    missing_required_targets: list[str] = []
+
+    executed = bool((pytest_execution_record or {}).get("executed", False))
+    if not executed:
+        reasons.append("PYTEST_SELECTION_ARTIFACT_MISSING")
+
+    if not selected_targets_norm:
+        reasons.append("PYTEST_SELECTION_EMPTY")
+
+    if impacted_surface_count > 0 and not effective_required:
+        reasons.append("PYTEST_REQUIRED_TARGETS_MISSING")
+
+    equivalence_allowed = bool(policy.get("allow_bounded_equivalence", False))
+    equivalence_groups = _collect_equivalence_groups(policy)
+    selected_set = set(selected_targets_norm)
+    for target in effective_required:
+        if target in selected_set:
+            continue
+        equivalents = equivalence_groups.get(target, []) if equivalence_allowed else []
+        if equivalents and selected_set.intersection(equivalents):
+            continue
+        missing_required_targets.append(target)
+
+    if missing_required_targets:
+        reasons.append("PYTEST_SELECTION_MISMATCH")
+
+    threshold_satisfied = len(selected_targets_norm) >= minimum_selection_threshold
+    if not threshold_satisfied:
+        reasons.append("PYTEST_SELECTION_THRESHOLD_NOT_MET")
+
+    reason_codes_from_execution = {
+        str(code)
+        for code in ((pytest_execution_record or {}).get("selection_reason_codes") or [])
+        if isinstance(code, str)
+    }
+    if {"PR_PYTEST_SELECTED_TARGETS_EMPTY", "PR_PYTEST_FALLBACK_TARGETS_EMPTY"} & reason_codes_from_execution:
+        reasons.append("PYTEST_SELECTION_FILTERING_DETECTED")
+
+    reasons = sorted(set(reasons))
+    decision = "ALLOW" if not reasons else "BLOCK"
+    payload = {
+        "artifact_type": "pytest_selection_integrity_result",
+        "schema_version": "1.0.0",
+        "changed_paths": changed_paths_norm,
+        "required_test_targets": effective_required,
+        "selected_test_targets": selected_targets_norm,
+        "missing_required_targets": sorted(set(missing_required_targets)),
+        "selection_count": len(selected_targets_norm),
+        "minimum_selection_threshold": minimum_selection_threshold,
+        "threshold_satisfied": threshold_satisfied,
+        "impacted_surface_count": impacted_surface_count,
+        "selection_integrity_decision": decision,
+        "blocking_reasons": reasons,
+        "generated_at": generated_at,
+    }
+    return SelectionIntegrityEvaluation(
+        status="passed" if decision == "ALLOW" else "failed",
+        decision=decision,
+        blocking_reasons=reasons,
+        payload=payload,
+    )
+
+
+__all__ = [
+    "PytestSelectionIntegrityError",
+    "SelectionIntegrityEvaluation",
+    "evaluate_pytest_selection_integrity",
+]

--- a/spectrum_systems/modules/runtime/pytest_trust_gap_audit.py
+++ b/spectrum_systems/modules/runtime/pytest_trust_gap_audit.py
@@ -1,0 +1,127 @@
+"""Deterministic read-only audit for pytest trust gaps in recent preflight artifacts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from spectrum_systems.contracts import validate_artifact
+
+TRUSTING_DECISIONS = {"ALLOW", "WARN"}
+KNOWN_PR_EVENTS = {"pull_request", "pull_request_target", "pull_request_review", "pull_request_review_comment"}
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"artifact_not_object:{path}")
+    return payload
+
+
+def scan_preflight_artifacts(scan_roots: list[Path], *, max_artifacts: int = 100) -> list[dict[str, Any]]:
+    paths: list[Path] = []
+    for root in scan_roots:
+        if not root.exists():
+            continue
+        for path in root.glob("**/contract_preflight_result_artifact.json"):
+            if path.is_file():
+                paths.append(path)
+    deduped = sorted({path.resolve() for path in paths}, key=lambda p: str(p))[:max_artifacts]
+    artifacts: list[dict[str, Any]] = []
+    for path in deduped:
+        payload = _read_json(path)
+        payload["__artifact_path"] = str(path.as_posix())
+        artifacts.append(payload)
+    return artifacts
+
+
+def _event_name(payload: dict[str, Any]) -> str:
+    execution = payload.get("pytest_execution")
+    if isinstance(execution, dict) and isinstance(execution.get("event_name"), str):
+        return str(execution.get("event_name"))
+    return ""
+
+
+def _is_trusting(payload: dict[str, Any]) -> bool:
+    signal = payload.get("control_signal")
+    if isinstance(signal, dict):
+        decision = str(signal.get("strategy_gate_decision") or "").upper()
+        if decision in TRUSTING_DECISIONS:
+            return True
+    return str(payload.get("preflight_status") or "").lower() == "passed"
+
+
+def classify_artifact(payload: dict[str, Any]) -> dict[str, Any]:
+    path = str(payload.get("__artifact_path") or "unknown")
+    reasons: list[str] = []
+    trusting = _is_trusting(payload)
+    event_name = _event_name(payload)
+    context = "pr" if event_name in KNOWN_PR_EVENTS else ("non_pr" if event_name else "unknown")
+
+    execution = payload.get("pytest_execution")
+    if not isinstance(execution, dict):
+        reasons.append("MISSING_PYTEST_EXECUTION_ARTIFACT")
+    else:
+        if int(execution.get("pytest_execution_count") or 0) < 1:
+            reasons.append("PYTEST_EXECUTION_COUNT_TOO_SMALL")
+        selected = execution.get("selected_targets") or []
+        if not isinstance(selected, list) or not selected:
+            reasons.append("PYTEST_SELECTED_TARGETS_EMPTY")
+
+    selection = payload.get("pytest_selection_integrity")
+    if not isinstance(selection, dict):
+        reasons.append("MISSING_PYTEST_SELECTION_INTEGRITY_ARTIFACT")
+    else:
+        if str(selection.get("selection_integrity_decision") or "BLOCK") != "ALLOW":
+            reasons.append("PYTEST_SELECTION_INTEGRITY_NOT_ALLOW")
+
+    classification = "clean_evidence"
+    if reasons:
+        classification = "weak_evidence" if context != "unknown" else "missing_evidence"
+    if context == "unknown" and reasons:
+        classification = "unable_to_evaluate"
+
+    if trusting and reasons:
+        reasons.append("TRUSTED_OUTCOME_WITH_GAP")
+
+    return {
+        "artifact_path": path,
+        "classification": classification,
+        "context": context,
+        "trusting_outcome": trusting,
+        "reason_codes": sorted(set(reasons)),
+    }
+
+
+def run_pytest_trust_gap_audit(*, scanned_artifacts: list[dict[str, Any]], audit_scope: dict[str, Any]) -> dict[str, Any]:
+    classified = [classify_artifact(item) for item in scanned_artifacts]
+    classified = sorted(classified, key=lambda item: item["artifact_path"])
+    suspects = [item for item in classified if item["classification"] in {"weak_evidence", "missing_evidence", "unable_to_evaluate"}]
+
+    generated_at = "1970-01-01T00:00:00Z"
+    timestamps = sorted({str(item.get("generated_at")) for item in scanned_artifacts if isinstance(item.get("generated_at"), str)})
+    if timestamps:
+        generated_at = timestamps[-1]
+
+    result = {
+        "artifact_type": "pytest_trust_gap_audit_result",
+        "schema_version": "1.0.0",
+        "audit_scope": audit_scope,
+        "scanned_artifact_count": len(classified),
+        "suspect_count": len(suspects),
+        "suspect_runs": suspects,
+        "summary_reason_codes": sorted({code for item in suspects for code in item.get("reason_codes", [])}),
+        "generated_at": generated_at,
+        "trace": {
+            "producer": "spectrum_systems.modules.runtime.pytest_trust_gap_audit",
+            "classification_policy": "tsi-01-trust-gap-v1",
+            "scan_mode": "repo_local_artifacts_only",
+            "read_only": True
+        }
+    }
+    validate_artifact(result, "pytest_trust_gap_audit_result")
+    return result
+
+
+__all__ = ["scan_preflight_artifacts", "classify_artifact", "run_pytest_trust_gap_audit"]

--- a/tests/test_artifact_boundary_workflow_pytest_enforcement.py
+++ b/tests/test_artifact_boundary_workflow_pytest_enforcement.py
@@ -11,6 +11,12 @@ def test_artifact_boundary_workflow_uses_contract_preflight_on_pull_request() ->
     assert 'python scripts/run_contract_preflight.py' in text
 
 
+def test_artifact_boundary_workflow_does_not_bypass_artifact_validation_on_preflight_exit_zero() -> None:
+    text = ARTIFACT_BOUNDARY_WORKFLOW.read_text(encoding='utf-8')
+    assert 'if [[ "$preflight_exit" -ne 0 ]]; then' in text
+    assert 'if [[ "$preflight_exit" -eq 0 ]]; then' not in text
+
+
 def test_artifact_boundary_workflow_fail_closes_on_missing_pytest_execution_record() -> None:
     text = ARTIFACT_BOUNDARY_WORKFLOW.read_text(encoding='utf-8')
     assert 'pytest_execution_record_ref' in text
@@ -19,8 +25,22 @@ def test_artifact_boundary_workflow_fail_closes_on_missing_pytest_execution_reco
     assert 'empty selected_targets' in text
 
 
+def test_artifact_boundary_workflow_fail_closes_on_missing_or_blocked_selection_integrity() -> None:
+    text = ARTIFACT_BOUNDARY_WORKFLOW.read_text(encoding='utf-8')
+    assert 'pytest_selection_integrity_result_ref' in text
+    assert 'missing pytest_selection_integrity_result_ref' in text
+    assert 'allow decision with blocked pytest selection integrity' in text
+
+
 def test_autofix_workflow_enforces_pytest_execution_record_for_allow_warn() -> None:
     text = AUTOFIX_WORKFLOW.read_text(encoding='utf-8')
     assert 'pytest_execution_record_ref' in text
     assert 'allow decision with executed=false' in text
     assert 'allow decision with empty selected_targets' in text
+
+
+def test_autofix_workflow_enforces_selection_integrity_for_allow_warn() -> None:
+    text = AUTOFIX_WORKFLOW.read_text(encoding='utf-8')
+    assert 'pytest_selection_integrity_result_ref' in text
+    assert 'missing pytest_selection_integrity_result_ref' in text
+    assert 'allow decision with blocked pytest selection integrity' in text

--- a/tests/test_contract_preflight.py
+++ b/tests/test_contract_preflight.py
@@ -2116,6 +2116,7 @@ def test_preflight_blocks_when_selection_integrity_rejects(monkeypatch, tmp_path
     assert code == 2
     report = json.loads((output_dir / "contract_preflight_report.json").read_text(encoding="utf-8"))
     assert any(code.startswith("PYTEST_SELECTION_") for code in report["invariant_violations"])
+    assert "PR_PYTEST_SELECTION_INTEGRITY_REQUIRED" in report["invariant_violations"]
 
 
 def test_preflight_writes_selection_integrity_artifact_ref(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_contract_preflight.py
+++ b/tests/test_contract_preflight.py
@@ -1077,7 +1077,7 @@ def test_main_governed_context_with_valid_wrapper_allows(tmp_path: Path, monkeyp
     report = json.loads((output_dir / "contract_preflight_report.json").read_text(encoding="utf-8"))
     assert report["pqx_required_context_enforcement"]["status"] == "allow"
     artifact = json.loads((output_dir / "contract_preflight_result_artifact.json").read_text(encoding="utf-8"))
-    assert artifact["schema_version"] == "1.3.0"
+    assert artifact["schema_version"] == "1.4.0"
     assert artifact["pqx_required_context_enforcement"]["status"] == "allow"
 
 
@@ -2011,14 +2011,15 @@ def test_pull_request_no_targeted_tests_uses_governed_fallback(tmp_path: Path, m
     monkeypatch.setattr(preflight, "_resolve_existing_pytest_targets", lambda paths: [str(paths[0])])
 
     code = preflight.main()
-    assert code == 0
+    assert code == 2
     report = json.loads((output_dir / "contract_preflight_report.json").read_text(encoding="utf-8"))
-    assert report["status"] == "passed"
+    assert report["status"] == "failed"
     assert report["pytest_execution"]["fallback_used"] is True
     assert report["pytest_execution"]["pytest_execution_count"] == 1
     assert report["pytest_execution"]["selected_targets"] == []
     assert report["pytest_execution"]["fallback_targets"] == ["tests/test_run_github_pr_autofix_contract_preflight.py"]
     assert report["pytest_execution"]["selection_reason_codes"] == ["PR_PYTEST_SELECTED_TARGETS_EMPTY"]
+    assert "PYTEST_SELECTION_FILTERING_DETECTED" in report["invariant_violations"]
     artifact = json.loads((output_dir / "contract_preflight_result_artifact.json").read_text(encoding="utf-8"))
     assert artifact["pytest_execution"]["pytest_execution_count"] == 1
     assert "selection_reason_codes" in artifact["pytest_execution"]
@@ -2086,3 +2087,61 @@ def test_pull_request_fails_closed_when_fallback_reports_success_without_executi
     assert code == 2
     report = json.loads((output_dir / "contract_preflight_report.json").read_text(encoding="utf-8"))
     assert "PR_PYTEST_EXECUTION_RECORD_REQUIRED" in report["invariant_violations"]
+
+
+def test_preflight_blocks_when_selection_integrity_rejects(monkeypatch, tmp_path: Path) -> None:
+    output_dir = tmp_path / "out"
+    monkeypatch.setattr(
+        preflight,
+        "_parse_args",
+        lambda: type(
+            "Args",
+            (),
+            {
+                "base_ref": "origin/main",
+                "head_ref": "HEAD",
+                "changed_path": ["scripts/run_contract_preflight.py"],
+                "output_dir": str(output_dir),
+                "hardening_flow": False,
+                "execution_context": "pqx_governed",
+                "pqx_wrapper_path": None,
+                "authority_evidence_ref": None,
+                "event_name": "pull_request",
+                "refresh_test_inventory_baseline": False,
+            },
+        )(),
+    )
+    monkeypatch.setattr(preflight, "run_targeted_pytests", lambda *_args, **_kwargs: [])
+    code = preflight.main()
+    assert code == 2
+    report = json.loads((output_dir / "contract_preflight_report.json").read_text(encoding="utf-8"))
+    assert any(code.startswith("PYTEST_SELECTION_") for code in report["invariant_violations"])
+
+
+def test_preflight_writes_selection_integrity_artifact_ref(monkeypatch, tmp_path: Path) -> None:
+    output_dir = tmp_path / "out"
+    monkeypatch.setattr(
+        preflight,
+        "_parse_args",
+        lambda: type(
+            "Args",
+            (),
+            {
+                "base_ref": "origin/main",
+                "head_ref": "HEAD",
+                "changed_path": ["tests/test_contract_preflight.py"],
+                "output_dir": str(output_dir),
+                "hardening_flow": False,
+                "execution_context": "pqx_governed",
+                "pqx_wrapper_path": None,
+                "authority_evidence_ref": None,
+                "event_name": "pull_request",
+                "refresh_test_inventory_baseline": False,
+            },
+        )(),
+    )
+    monkeypatch.setattr(preflight, "run_targeted_pytests", lambda paths, **kwargs: [] if paths else [])
+    _ = preflight.main()
+    artifact = json.loads((output_dir / "contract_preflight_result_artifact.json").read_text(encoding="utf-8"))
+    assert artifact["pytest_selection_integrity_result_ref"]
+    assert (output_dir / "pytest_selection_integrity_result.json").exists()

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -788,6 +788,14 @@ class ContractSchemaTests(unittest.TestCase):
             ["technical", "data", "schedule", "stakeholder", "process_legal", "coordination", "narrative"],
         )
 
+    def test_pytest_selection_integrity_result_example_validates(self) -> None:
+        instance = load_example("pytest_selection_integrity_result")
+        validate_artifact(instance, "pytest_selection_integrity_result")
+
+    def test_pytest_trust_gap_audit_result_example_validates(self) -> None:
+        instance = load_example("pytest_trust_gap_audit_result")
+        validate_artifact(instance, "pytest_trust_gap_audit_result")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_github_pr_autofix_contract_preflight.py
+++ b/tests/test_github_pr_autofix_contract_preflight.py
@@ -552,3 +552,14 @@ def test_selection_integrity_mismatch_classifies_non_repairable() -> None:
     assert diagnosis["failure_class"] == "pytest_selection_mismatch"
     plan = build_preflight_repair_plan_record(diagnosis_record=diagnosis)
     assert plan["eligibility_decision"] != "auto_repair_allowed"
+
+
+def test_pr_selection_integrity_required_invariant_classifies_as_selection_missing() -> None:
+    diagnosis = build_preflight_block_diagnosis_record(
+        report={
+            "invariant_violations": ["PR_PYTEST_SELECTION_INTEGRITY_REQUIRED"],
+            "normalized_failure": {"failure_class": "test_inventory_regression", "repairable": True},
+        },
+        preflight_artifact={"control_signal": {"strategy_gate_decision": "BLOCK"}, "generated_at": "2026"},
+    )
+    assert diagnosis["failure_class"] == "pytest_selection_missing"

--- a/tests/test_github_pr_autofix_contract_preflight.py
+++ b/tests/test_github_pr_autofix_contract_preflight.py
@@ -267,6 +267,9 @@ def test_missing_required_surface_mapping_autorepair_writes_override_file(tmp_pa
                     {
                         "control_signal": {"strategy_gate_decision": "ALLOW"},
                         "generated_at": "2026-04-13T00:00:00Z",
+                        "pytest_execution_record_ref": "outputs/contract_preflight/pytest_execution_record.json",
+                        "pytest_selection_integrity_result_ref": "outputs/contract_preflight/pytest_selection_integrity_result.json",
+                        "pytest_selection_integrity": {"selection_integrity_decision": "ALLOW"},
                     }
                 ),
                 encoding="utf-8",
@@ -365,7 +368,7 @@ def test_schema_violation_auto_repair_path_writes_terminal_success_outcome(tmp_p
     def _runner(cmd, cwd):
         if any("run_contract_preflight.py" in part for part in cmd):
             (out / "contract_preflight_result_artifact.json").write_text(
-                json.dumps({"control_signal": {"strategy_gate_decision": "ALLOW"}, "generated_at": "2026-04-13T00:00:00Z"}),
+                json.dumps({"control_signal": {"strategy_gate_decision": "ALLOW"}, "generated_at": "2026-04-13T00:00:00Z", "pytest_execution_record_ref": "outputs/contract_preflight/pytest_execution_record.json", "pytest_selection_integrity_result_ref": "outputs/contract_preflight/pytest_selection_integrity_result.json", "pytest_selection_integrity": {"selection_integrity_decision": "ALLOW"}}),
                 encoding="utf-8",
             )
         return _Res(cmd, 0)
@@ -523,3 +526,29 @@ def test_preflight_test_inventory_failure_is_auto_repairable_and_bounded() -> No
     )
     assert plan["eligibility_decision"] == "auto_repair_allowed"
     assert "docs/governance/pytest_pr_inventory_baseline.json" in plan["allowed_paths"]
+
+
+def test_selection_integrity_missing_artifact_classifies_repairable() -> None:
+    diagnosis = build_preflight_block_diagnosis_record(
+        report={
+            "invariant_violations": ["PYTEST_SELECTION_ARTIFACT_MISSING"],
+            "normalized_failure": {"failure_class": "test_inventory_regression", "repairable": True},
+        },
+        preflight_artifact={"control_signal": {"strategy_gate_decision": "BLOCK"}, "generated_at": "2026"},
+    )
+    assert diagnosis["failure_class"] == "pytest_selection_missing"
+    plan = build_preflight_repair_plan_record(diagnosis_record=diagnosis)
+    assert plan["eligibility_decision"] == "auto_repair_allowed"
+
+
+def test_selection_integrity_mismatch_classifies_non_repairable() -> None:
+    diagnosis = build_preflight_block_diagnosis_record(
+        report={
+            "invariant_violations": ["PYTEST_SELECTION_MISMATCH"],
+            "normalized_failure": {"failure_class": "test_inventory_regression", "repairable": False},
+        },
+        preflight_artifact={"control_signal": {"strategy_gate_decision": "BLOCK"}, "generated_at": "2026"},
+    )
+    assert diagnosis["failure_class"] == "pytest_selection_mismatch"
+    plan = build_preflight_repair_plan_record(diagnosis_record=diagnosis)
+    assert plan["eligibility_decision"] != "auto_repair_allowed"

--- a/tests/test_pqx_slice_runner.py
+++ b/tests/test_pqx_slice_runner.py
@@ -355,7 +355,7 @@ def _execution_impact_artifact(*, blocking: bool, indeterminate: bool, safe_to_e
 def _preflight_artifact(*, status: str, decision: str, masking_detected: bool = False, degraded: bool = False) -> dict:
     return {
         "artifact_type": "contract_preflight_result_artifact",
-        "schema_version": "1.3.0",
+        "schema_version": "1.4.0",
         "preflight_status": status,
         "changed_contracts": ["contracts/schemas/roadmap_eligibility_artifact.schema.json"],
         "impacted_producers": [
@@ -398,6 +398,22 @@ def _preflight_artifact(*, status: str, decision: str, masking_detected: bool = 
             "selection_reason_codes": [],
         },
         "pytest_execution_record_ref": "outputs/contract_preflight/pytest_execution_record.json",
+        "pytest_selection_integrity": {
+            "artifact_type": "pytest_selection_integrity_result",
+            "schema_version": "1.0.0",
+            "changed_paths": ["contracts/schemas/roadmap_eligibility_artifact.schema.json"],
+            "required_test_targets": ["tests/test_contract_preflight.py"],
+            "selected_test_targets": ["tests/test_contract_preflight.py"],
+            "missing_required_targets": [],
+            "selection_count": 1,
+            "minimum_selection_threshold": 1,
+            "threshold_satisfied": True,
+            "impacted_surface_count": 1,
+            "selection_integrity_decision": "ALLOW",
+            "blocking_reasons": [],
+            "generated_at": "2026-04-01T00:00:00Z"
+        },
+        "pytest_selection_integrity_result_ref": "outputs/contract_preflight/pytest_selection_integrity_result.json",
         "pqx_required_context_enforcement": {
             "classification": "governed_pqx_required",
             "execution_context": "pqx_governed",

--- a/tests/test_pytest_selection_integrity.py
+++ b/tests/test_pytest_selection_integrity.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from spectrum_systems.modules.runtime.pytest_selection_integrity import evaluate_pytest_selection_integrity
+
+
+def _policy_path(tmp_path: Path, *, threshold: int = 1, allow_equivalence: bool = False) -> Path:
+    policy = {
+        "artifact_type": "pytest_pr_selection_integrity_policy",
+        "schema_version": "1.0.0",
+        "policy_version": "1.0.0",
+        "minimum_selection_threshold": threshold,
+        "allow_bounded_equivalence": allow_equivalence,
+        "governed_surface_prefixes": ["scripts/", "spectrum_systems/", "contracts/", "tests/"],
+        "surface_rules": [
+            {
+                "path_prefix": "scripts/run_contract_preflight.py",
+                "required_test_targets": ["tests/test_contract_preflight.py"],
+            }
+        ],
+        "bounded_equivalence": [
+            {
+                "required_target": "tests/test_contract_preflight.py",
+                "equivalent_targets": ["tests/test_run_github_pr_autofix_contract_preflight.py"],
+            }
+        ],
+        "allowed_exceptions": [],
+    }
+    path = tmp_path / "policy.json"
+    path.write_text(json.dumps(policy), encoding="utf-8")
+    return path
+
+
+def test_blocks_with_empty_selection(tmp_path: Path) -> None:
+    result = evaluate_pytest_selection_integrity(
+        changed_paths=["scripts/run_contract_preflight.py"],
+        selected_test_targets=[],
+        required_test_targets=["tests/test_contract_preflight.py"],
+        pytest_execution_record={"executed": True, "selection_reason_codes": []},
+        policy_path=_policy_path(tmp_path),
+        generated_at="2026-04-14T00:00:00Z",
+    )
+    assert result.decision == "BLOCK"
+    assert "PYTEST_SELECTION_EMPTY" in result.blocking_reasons
+
+
+def test_blocks_when_required_targets_missing(tmp_path: Path) -> None:
+    result = evaluate_pytest_selection_integrity(
+        changed_paths=["scripts/run_contract_preflight.py"],
+        selected_test_targets=["tests/test_other.py"],
+        required_test_targets=["tests/test_contract_preflight.py"],
+        pytest_execution_record={"executed": True, "selection_reason_codes": []},
+        policy_path=_policy_path(tmp_path),
+        generated_at="2026-04-14T00:00:00Z",
+    )
+    assert result.decision == "BLOCK"
+    assert "PYTEST_SELECTION_MISMATCH" in result.blocking_reasons
+
+
+def test_blocks_when_threshold_not_met(tmp_path: Path) -> None:
+    result = evaluate_pytest_selection_integrity(
+        changed_paths=["scripts/run_contract_preflight.py"],
+        selected_test_targets=["tests/test_contract_preflight.py"],
+        required_test_targets=["tests/test_contract_preflight.py"],
+        pytest_execution_record={"executed": True, "selection_reason_codes": []},
+        policy_path=_policy_path(tmp_path, threshold=2),
+        generated_at="2026-04-14T00:00:00Z",
+    )
+    assert result.decision == "BLOCK"
+    assert "PYTEST_SELECTION_THRESHOLD_NOT_MET" in result.blocking_reasons
+
+
+def test_allows_bounded_equivalence_when_enabled(tmp_path: Path) -> None:
+    result = evaluate_pytest_selection_integrity(
+        changed_paths=["scripts/run_contract_preflight.py"],
+        selected_test_targets=["tests/test_run_github_pr_autofix_contract_preflight.py"],
+        required_test_targets=["tests/test_contract_preflight.py"],
+        pytest_execution_record={"executed": True, "selection_reason_codes": []},
+        policy_path=_policy_path(tmp_path, allow_equivalence=True),
+        generated_at="2026-04-14T00:00:00Z",
+    )
+    assert result.decision == "ALLOW"
+    assert result.blocking_reasons == []

--- a/tests/test_pytest_trust_gap_audit.py
+++ b/tests/test_pytest_trust_gap_audit.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from spectrum_systems.contracts import validate_artifact
+from spectrum_systems.modules.runtime.pytest_trust_gap_audit import classify_artifact, run_pytest_trust_gap_audit
+
+
+def test_missing_evidence_is_flagged() -> None:
+    artifact = {"artifact_type": "contract_preflight_result_artifact", "preflight_status": "passed", "control_signal": {"strategy_gate_decision": "ALLOW"}}
+    classified = classify_artifact(artifact)
+    assert "MISSING_PYTEST_EXECUTION_ARTIFACT" in classified["reason_codes"]
+
+
+def test_weak_evidence_is_flagged() -> None:
+    artifact = {
+        "artifact_type": "contract_preflight_result_artifact",
+        "preflight_status": "passed",
+        "control_signal": {"strategy_gate_decision": "ALLOW"},
+        "pytest_execution": {"event_name": "pull_request", "pytest_execution_count": 1, "selected_targets": ["tests/x.py"]},
+        "pytest_selection_integrity": {"selection_integrity_decision": "BLOCK"},
+    }
+    classified = classify_artifact(artifact)
+    assert classified["classification"] == "weak_evidence"
+    assert "PYTEST_SELECTION_INTEGRITY_NOT_ALLOW" in classified["reason_codes"]
+
+
+def test_clean_evidence_is_classified_clean() -> None:
+    artifact = {
+        "artifact_type": "contract_preflight_result_artifact",
+        "preflight_status": "passed",
+        "control_signal": {"strategy_gate_decision": "ALLOW"},
+        "pytest_execution": {"event_name": "pull_request", "pytest_execution_count": 1, "selected_targets": ["tests/x.py"]},
+        "pytest_selection_integrity": {"selection_integrity_decision": "ALLOW"},
+    }
+    classified = classify_artifact(artifact)
+    assert classified["classification"] == "clean_evidence"
+
+
+def test_audit_result_validates_contract() -> None:
+    result = run_pytest_trust_gap_audit(scanned_artifacts=[], audit_scope={"roots": ["outputs"], "artifact_globs": ["**/contract_preflight_result_artifact.json"], "max_artifacts": 20, "repo_root": "/repo"})
+    validate_artifact(result, "pytest_trust_gap_audit_result")

--- a/tests/test_test_inventory_integrity.py
+++ b/tests/test_test_inventory_integrity.py
@@ -156,3 +156,18 @@ def test_deterministic_artifact_generation(tmp_path: Path) -> None:
 
     assert first["failure_class"] == second["failure_class"]
     assert first["selected_nodeids"] == second["selected_nodeids"]
+
+
+def test_execution_only_without_selected_targets_fails_closed(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    baseline = repo / "docs" / "governance" / "baseline.json"
+    baseline.parent.mkdir(parents=True)
+    baseline.write_text(json.dumps({"expected_count": 1, "expected_nodeids": ["tests/test_sample.py::test_ok"]}), encoding="utf-8")
+    result = evaluate_test_inventory_integrity(
+        repo_root=repo,
+        baseline_path=baseline,
+        suite_targets=["tests/does_not_exist.py"],
+        execution_cwd=repo,
+    )
+    assert result.failure_class in {"collection_failure", "no_tests_discovered"}
+    assert result.blocking is True


### PR DESCRIPTION
### Motivation
- Strengthen PR preflight trust by ensuring pytest runs are not only executed but that the selected test targets meaningfully cover changed governed surfaces and meet a governed minimum threshold.
- Provide a deterministic, read-only audit to backtest recent preflight artifacts and flag suspect historical merges from the period with weaker pytest execution enforcement.

### Description
- Added a new evaluator module `spectrum_systems/modules/runtime/pytest_selection_integrity.py` and governed policy `docs/governance/pytest_pr_selection_integrity_policy.json` implementing fail-closed selection logic (thresholds, required-target mapping, bounded equivalence).
- Introduced the `pytest_selection_integrity_result` contract schema and example at `contracts/schemas/pytest_selection_integrity_result.schema.json` and `contracts/examples/pytest_selection_integrity_result.json`.
- Wired selection integrity into `scripts/run_contract_preflight.py` to compute, validate, emit (`outputs/contract_preflight/pytest_selection_integrity_result.json`) and integrate selection integrity into the `contract_preflight_result_artifact` (schema bumped to `1.4.0`).
- Extended preflight invariant reason codes and fail-closed checks to include: `PYTEST_SELECTION_EMPTY`, `PYTEST_REQUIRED_TARGETS_MISSING`, `PYTEST_SELECTION_THRESHOLD_NOT_MET`, `PYTEST_SELECTION_ARTIFACT_MISSING`, `PYTEST_SELECTION_ARTIFACT_INVALID`, `PYTEST_SELECTION_MISMATCH`, `PYTEST_SELECTION_FILTERING_DETECTED`.
- Hardened autofix logic in `spectrum_systems/modules/runtime/github_pr_autofix_contract_preflight.py` to classify selection-integrity failures deterministically, allow only bounded repairs, and require a rerun that contains valid execution + valid selection-integrity evidence before marking repair success.
- Added a deterministic read-only audit module `spectrum_systems/modules/runtime/pytest_trust_gap_audit.py` plus CLI `scripts/run_pytest_trust_gap_audit.py` producing `pytest_trust_gap_audit_result` artifacts and remediation queue examples.
- Updated contracts/schemas (`preflight_block_diagnosis_record`, `failure_repair_candidate_artifact`, `contract_preflight_result_artifact`) and examples to reflect new failure classes and artifact fields; updated `contracts/standards-manifest.json` to register new artifacts and bump versions.
- Extended workflow checks in `.github/workflows/artifact-boundary.yml` and `.github/workflows/pr-autofix-contract-preflight.yml` to require both `pytest_execution_record` and `pytest_selection_integrity_result` for ALLOW/WARN decisions and to validate selection integrity decision is `ALLOW`.
- Added unit tests for selection integrity and audit (`tests/test_pytest_selection_integrity.py`, `tests/test_pytest_trust_gap_audit.py`) and updated existing tests to reflect new artifact shape and blocking behavior.
- Added a PLAN-first file and a delivery review `docs/reviews/TSI-01_selection_integrity_and_audit_review.md` describing intent, files, policy, tests, validation and exact results.

### Testing
- Ran `python scripts/run_contract_preflight.py --help` and it exited successfully.
- Ran targeted pytest suites and full repo tests: `pytest` on affected test slices and `pytest tests/` where indicated; automated runs reported all tests passing for the modified suite contexts: `tests/test_contract_preflight.py` (updated expectations) and `tests/test_github_pr_autofix_contract_preflight.py` and related updated tests; final full-suite validation returned success (`6655 passed, 1 skipped` in the environment used).
- Ran `python scripts/run_contract_enforcement.py` and contract enforcement reported no failures.
- New/updated automated tests exercised: selection integrity decision logic, preflight BLOCKing when selection integrity is weak/missing, autofix classification and bounded repair semantics, audit classification for missing/weak/clean evidence, and regression guards preventing fake-green PRs from passing on execution-only evidence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de5308e3648329b39d8bb9d43b2865)