### PR TITLE
RTX-02: Harden PR trust seam — enforce canonical pytest refs, provenance, and fail-closed WARN/degraded behavior

### DIFF
--- a/.github/workflows/artifact-boundary.yml
+++ b/.github/workflows/artifact-boundary.yml
@@ -168,23 +168,51 @@ if os.environ.get("GITHUB_EVENT_NAME") == "pull_request":
     record = json.loads(record_path.read_text(encoding="utf-8"))
     executed = bool(record.get("executed", False))
     selected_targets = record.get("selected_targets") or []
-    if decision in {"ALLOW", "WARN"} and count < 1:
+    if decision == "WARN":
+        raise SystemExit("workflow/preflight trust mismatch: WARN is not pass-equivalent for pull_request")
+    if decision == "ALLOW" and count < 1:
         raise SystemExit("workflow/preflight trust mismatch: PR allow without preflight-owned pytest execution")
-    if decision in {"ALLOW", "WARN"} and not executed:
+    if decision == "ALLOW" and not executed:
         raise SystemExit("workflow/preflight trust mismatch: PR allow with executed=false")
-    if decision in {"ALLOW", "WARN"} and not selected_targets:
+    if decision == "ALLOW" and not selected_targets:
         raise SystemExit("workflow/preflight trust mismatch: PR allow with empty selected_targets")
+    if record_ref != "outputs/contract_preflight/pytest_execution_record.json":
+        raise SystemExit("workflow/preflight trust mismatch: non-canonical pytest_execution_record_ref")
+    required_execution_provenance = [
+        "source_commit_sha",
+        "source_head_ref",
+        "workflow_run_id",
+        "producer_script",
+        "produced_at",
+        "artifact_hash",
+    ]
+    if any(not str(record.get(field) or "").strip() for field in required_execution_provenance):
+        raise SystemExit("workflow/preflight trust mismatch: missing pytest_execution_record provenance fields")
     selection_ref = str(payload.get("pytest_selection_integrity_result_ref") or "").strip()
     selection = payload.get("pytest_selection_integrity") or {}
     if not selection_ref:
         raise SystemExit("workflow/preflight trust mismatch: missing pytest_selection_integrity_result_ref")
+    if selection_ref != "outputs/contract_preflight/pytest_selection_integrity_result.json":
+        raise SystemExit("workflow/preflight trust mismatch: non-canonical pytest_selection_integrity_result_ref")
     selection_path = Path(selection_ref)
     if not selection_path.is_file():
         raise SystemExit(f"workflow/preflight trust mismatch: missing pytest_selection_integrity_result artifact at {selection_ref}")
     selection_from_ref = json.loads(selection_path.read_text(encoding="utf-8"))
-    if str(selection_from_ref.get("selection_integrity_decision") or "BLOCK") != "ALLOW" and decision in {"ALLOW", "WARN"}:
+    required_selection_provenance = required_execution_provenance + [
+        "source_pytest_execution_record_ref",
+        "source_pytest_execution_record_hash",
+    ]
+    if any(not str(selection_from_ref.get(field) or "").strip() for field in required_selection_provenance):
+        raise SystemExit("workflow/preflight trust mismatch: missing pytest_selection_integrity_result provenance fields")
+    if str(selection_from_ref.get("source_pytest_execution_record_ref") or "") != record_ref:
+        raise SystemExit("workflow/preflight trust mismatch: selection provenance record ref mismatch")
+    if str(selection_from_ref.get("source_pytest_execution_record_hash") or "") != str(record.get("artifact_hash") or ""):
+        raise SystemExit("workflow/preflight trust mismatch: selection provenance record hash mismatch")
+    if str(selection_from_ref.get("source_commit_sha") or "") != str(record.get("source_commit_sha") or ""):
+        raise SystemExit("workflow/preflight trust mismatch: selection provenance commit mismatch")
+    if str(selection_from_ref.get("selection_integrity_decision") or "BLOCK") != "ALLOW" and decision == "ALLOW":
         raise SystemExit("workflow/preflight trust mismatch: allow decision with blocked pytest selection integrity")
-    if selection and str(selection.get("selection_integrity_decision") or "BLOCK") != "ALLOW" and decision in {"ALLOW", "WARN"}:
+    if selection and str(selection.get("selection_integrity_decision") or "BLOCK") != "ALLOW" and decision == "ALLOW":
         raise SystemExit("workflow/preflight trust mismatch: allow decision with in-artifact blocked pytest selection integrity")
 PY
 

--- a/.github/workflows/pr-autofix-contract-preflight.yml
+++ b/.github/workflows/pr-autofix-contract-preflight.yml
@@ -144,26 +144,54 @@ jobs:
           record = json.loads(record_path.read_text(encoding="utf-8"))
           executed = bool(record.get("executed", False))
           selected_targets = record.get("selected_targets") or []
-          if initial in {"ALLOW", "WARN"} and pytest_count < 1:
+          if initial == "WARN":
+              raise SystemExit("workflow/preflight trust mismatch: WARN is not pass-equivalent for pull_request")
+          if initial == "ALLOW" and pytest_count < 1:
               raise SystemExit("workflow/preflight trust mismatch: allow decision missing preflight-owned pytest execution")
-          if initial in {"ALLOW", "WARN"} and not executed:
+          if initial == "ALLOW" and not executed:
               raise SystemExit("workflow/preflight trust mismatch: allow decision with executed=false")
-          if initial in {"ALLOW", "WARN"} and not selected_targets:
+          if initial == "ALLOW" and not selected_targets:
               raise SystemExit("workflow/preflight trust mismatch: allow decision with empty selected_targets")
+          if record_ref != "outputs/contract_preflight/pytest_execution_record.json":
+              raise SystemExit("workflow/preflight trust mismatch: non-canonical pytest_execution_record_ref")
+          required_execution_provenance = [
+              "source_commit_sha",
+              "source_head_ref",
+              "workflow_run_id",
+              "producer_script",
+              "produced_at",
+              "artifact_hash",
+          ]
+          if any(not str(record.get(field) or "").strip() for field in required_execution_provenance):
+              raise SystemExit("workflow/preflight trust mismatch: missing pytest_execution_record provenance fields")
           selection_ref = str(payload.get("pytest_selection_integrity_result_ref") or "").strip()
           selection = payload.get("pytest_selection_integrity") or {}
           if not selection_ref:
               raise SystemExit("workflow/preflight trust mismatch: missing pytest_selection_integrity_result_ref")
+          if selection_ref != "outputs/contract_preflight/pytest_selection_integrity_result.json":
+              raise SystemExit("workflow/preflight trust mismatch: non-canonical pytest_selection_integrity_result_ref")
           selection_path = Path(selection_ref)
           if not selection_path.exists():
               raise SystemExit(f"workflow/preflight trust mismatch: missing pytest_selection_integrity_result artifact at {selection_ref}")
           selection_from_ref = json.loads(selection_path.read_text(encoding="utf-8"))
-          if initial in {"ALLOW", "WARN"} and str(selection_from_ref.get("selection_integrity_decision") or "BLOCK") != "ALLOW":
+          required_selection_provenance = required_execution_provenance + [
+              "source_pytest_execution_record_ref",
+              "source_pytest_execution_record_hash",
+          ]
+          if any(not str(selection_from_ref.get(field) or "").strip() for field in required_selection_provenance):
+              raise SystemExit("workflow/preflight trust mismatch: missing pytest_selection_integrity_result provenance fields")
+          if str(selection_from_ref.get("source_pytest_execution_record_ref") or "") != record_ref:
+              raise SystemExit("workflow/preflight trust mismatch: selection provenance record ref mismatch")
+          if str(selection_from_ref.get("source_pytest_execution_record_hash") or "") != str(record.get("artifact_hash") or ""):
+              raise SystemExit("workflow/preflight trust mismatch: selection provenance record hash mismatch")
+          if str(selection_from_ref.get("source_commit_sha") or "") != str(record.get("source_commit_sha") or ""):
+              raise SystemExit("workflow/preflight trust mismatch: selection provenance commit mismatch")
+          if initial == "ALLOW" and str(selection_from_ref.get("selection_integrity_decision") or "BLOCK") != "ALLOW":
               raise SystemExit("workflow/preflight trust mismatch: allow decision with blocked pytest selection integrity")
-          if initial in {"ALLOW", "WARN"} and str(selection.get("selection_integrity_decision") or "BLOCK") != "ALLOW":
+          if initial == "ALLOW" and str(selection.get("selection_integrity_decision") or "BLOCK") != "ALLOW":
               raise SystemExit("workflow/preflight trust mismatch: allow decision with in-artifact blocked pytest selection integrity")
           if initial != "BLOCK":
-              raise SystemExit(0 if initial in {"ALLOW", "WARN"} else 2)
+              raise SystemExit(0 if initial == "ALLOW" else 2)
           outcome_path = out / "preflight_recovery_outcome_record.json"
           if not outcome_path.exists():
               raise SystemExit("BLOCK without preflight_recovery_outcome_record")

--- a/contracts/examples/contract_preflight_result_artifact.json
+++ b/contracts/examples/contract_preflight_result_artifact.json
@@ -1,6 +1,6 @@
 {
   "artifact_type": "contract_preflight_result_artifact",
-  "schema_version": "1.4.0",
+  "schema_version": "1.5.0",
   "preflight_status": "passed",
   "changed_contracts": [
     "contracts/schemas/roadmap_eligibility_artifact.schema.json"
@@ -90,9 +90,15 @@
     "provenance_ref": "contracts/standards-manifest.json"
   },
   "pytest_execution_record_ref": "outputs/contract_preflight/pytest_execution_record.json",
+  "pytest_artifact_linkage": {
+    "pytest_execution_record_ref": "outputs/contract_preflight/pytest_execution_record.json",
+    "pytest_execution_record_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "pytest_selection_integrity_result_ref": "outputs/contract_preflight/pytest_selection_integrity_result.json",
+    "pytest_selection_integrity_result_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  },
   "pytest_selection_integrity": {
     "artifact_type": "pytest_selection_integrity_result",
-    "schema_version": "1.0.0",
+    "schema_version": "1.1.0",
     "changed_paths": [
       "contracts/schemas/roadmap_eligibility_artifact.schema.json"
     ],
@@ -109,7 +115,15 @@
     "impacted_surface_count": 1,
     "selection_integrity_decision": "ALLOW",
     "blocking_reasons": [],
-    "generated_at": "2026-04-14T00:00:00Z"
+    "generated_at": "2026-04-14T00:00:00Z",
+    "source_commit_sha": "0123456789abcdef0123456789abcdef01234567",
+    "source_head_ref": "refs/pull/123/head",
+    "workflow_run_id": "1234567890",
+    "producer_script": "scripts/run_contract_preflight.py",
+    "produced_at": "2026-04-14T00:00:00Z",
+    "source_pytest_execution_record_ref": "outputs/contract_preflight/pytest_execution_record.json",
+    "source_pytest_execution_record_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "artifact_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
   },
   "pytest_selection_integrity_result_ref": "outputs/contract_preflight/pytest_selection_integrity_result.json"
 }

--- a/contracts/examples/pytest_execution_record.json
+++ b/contracts/examples/pytest_execution_record.json
@@ -1,6 +1,6 @@
 {
   "artifact_type": "pytest_execution_record",
-  "schema_version": "1.0.0",
+  "schema_version": "1.1.0",
   "event_name": "pull_request",
   "workflow_name": "artifact-boundary",
   "workflow_job": "contract-preflight",
@@ -28,5 +28,11 @@
     }
   ],
   "timestamp": "2026-04-14T00:00:00Z",
-  "failure_reason": null
+  "failure_reason": null,
+  "source_commit_sha": "0123456789abcdef0123456789abcdef01234567",
+  "source_head_ref": "refs/pull/123/head",
+  "workflow_run_id": "1234567890",
+  "producer_script": "scripts/run_contract_preflight.py",
+  "produced_at": "2026-04-14T00:00:00Z",
+  "artifact_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 }

--- a/contracts/examples/pytest_selection_integrity_result.json
+++ b/contracts/examples/pytest_selection_integrity_result.json
@@ -1,6 +1,6 @@
 {
   "artifact_type": "pytest_selection_integrity_result",
-  "schema_version": "1.0.0",
+  "schema_version": "1.1.0",
   "changed_paths": [
     "scripts/run_contract_preflight.py",
     "tests/test_contract_preflight.py"
@@ -19,5 +19,13 @@
   "impacted_surface_count": 2,
   "selection_integrity_decision": "ALLOW",
   "blocking_reasons": [],
-  "generated_at": "2026-04-14T00:00:00Z"
+  "generated_at": "2026-04-14T00:00:00Z",
+  "source_commit_sha": "0123456789abcdef0123456789abcdef01234567",
+  "source_head_ref": "refs/pull/123/head",
+  "workflow_run_id": "1234567890",
+  "producer_script": "scripts/run_contract_preflight.py",
+  "produced_at": "2026-04-14T00:00:00Z",
+  "source_pytest_execution_record_ref": "outputs/contract_preflight/pytest_execution_record.json",
+  "source_pytest_execution_record_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "artifact_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 }

--- a/contracts/schemas/contract_preflight_result_artifact.schema.json
+++ b/contracts/schemas/contract_preflight_result_artifact.schema.json
@@ -27,7 +27,8 @@
     "trace",
     "pytest_execution_record_ref",
     "pytest_selection_integrity",
-    "pytest_selection_integrity_result_ref"
+    "pytest_selection_integrity_result_ref",
+    "pytest_artifact_linkage"
   ],
   "properties": {
     "artifact_type": {
@@ -35,7 +36,7 @@
     },
     "schema_version": {
       "type": "string",
-      "const": "1.4.0"
+      "const": "1.5.0"
     },
     "preflight_status": {
       "type": "string",
@@ -202,7 +203,7 @@
     },
     "pytest_execution_record_ref": {
       "type": "string",
-      "minLength": 1
+      "const": "outputs/contract_preflight/pytest_execution_record.json"
     },
     "pqx_required_context_enforcement": {
       "type": "object",
@@ -289,7 +290,6 @@
           "type": "string",
           "enum": [
             "ALLOW",
-            "WARN",
             "FREEZE",
             "BLOCK"
           ]
@@ -304,6 +304,34 @@
         },
         "degraded_detection": {
           "type": "boolean"
+        }
+      }
+    },
+    "pytest_artifact_linkage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "pytest_execution_record_ref",
+        "pytest_execution_record_hash",
+        "pytest_selection_integrity_result_ref",
+        "pytest_selection_integrity_result_hash"
+      ],
+      "properties": {
+        "pytest_execution_record_ref": {
+          "type": "string",
+          "const": "outputs/contract_preflight/pytest_execution_record.json"
+        },
+        "pytest_execution_record_hash": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "pytest_selection_integrity_result_ref": {
+          "type": "string",
+          "const": "outputs/contract_preflight/pytest_selection_integrity_result.json"
+        },
+        "pytest_selection_integrity_result_hash": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
         }
       }
     },
@@ -393,14 +421,22 @@
         "impacted_surface_count",
         "selection_integrity_decision",
         "blocking_reasons",
-        "generated_at"
+        "generated_at",
+        "source_commit_sha",
+        "source_head_ref",
+        "workflow_run_id",
+        "producer_script",
+        "produced_at",
+        "source_pytest_execution_record_ref",
+        "source_pytest_execution_record_hash",
+        "artifact_hash"
       ],
       "properties": {
         "artifact_type": {
           "const": "pytest_selection_integrity_result"
         },
         "schema_version": {
-          "const": "1.0.0"
+          "const": "1.1.0"
         },
         "changed_paths": {
           "type": "array",
@@ -467,12 +503,44 @@
         "generated_at": {
           "type": "string",
           "format": "date-time"
+        },
+        "source_commit_sha": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_head_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "workflow_run_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "producer_script": {
+          "type": "string",
+          "const": "scripts/run_contract_preflight.py"
+        },
+        "produced_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "source_pytest_execution_record_ref": {
+          "type": "string",
+          "const": "outputs/contract_preflight/pytest_execution_record.json"
+        },
+        "source_pytest_execution_record_hash": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "artifact_hash": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
         }
       }
     },
     "pytest_selection_integrity_result_ref": {
       "type": "string",
-      "minLength": 1
+      "const": "outputs/contract_preflight/pytest_selection_integrity_result.json"
     }
   }
 }

--- a/contracts/schemas/pytest_execution_record.schema.json
+++ b/contracts/schemas/pytest_execution_record.schema.json
@@ -25,11 +25,17 @@
     "execution_count",
     "execution_entries",
     "timestamp",
-    "failure_reason"
+    "failure_reason",
+    "source_commit_sha",
+    "source_head_ref",
+    "workflow_run_id",
+    "producer_script",
+    "produced_at",
+    "artifact_hash"
   ],
   "properties": {
     "artifact_type": {"const": "pytest_execution_record"},
-    "schema_version": {"const": "1.0.0"},
+    "schema_version": {"const": "1.1.0"},
     "event_name": {"type": "string", "minLength": 1},
     "workflow_name": {"type": ["string", "null"]},
     "workflow_job": {"type": ["string", "null"]},
@@ -59,6 +65,12 @@
       }
     },
     "timestamp": {"type": "string", "format": "date-time"},
-    "failure_reason": {"type": ["string", "null"]}
+    "failure_reason": {"type": ["string", "null"]},
+    "source_commit_sha": {"type": "string", "minLength": 1},
+    "source_head_ref": {"type": "string", "minLength": 1},
+    "workflow_run_id": {"type": "string", "minLength": 1},
+    "producer_script": {"type": "string", "const": "scripts/run_contract_preflight.py"},
+    "produced_at": {"type": "string", "format": "date-time"},
+    "artifact_hash": {"type": "string", "pattern": "^[a-f0-9]{64}$"}
   }
 }

--- a/contracts/schemas/pytest_selection_integrity_result.schema.json
+++ b/contracts/schemas/pytest_selection_integrity_result.schema.json
@@ -17,11 +17,19 @@
     "impacted_surface_count",
     "selection_integrity_decision",
     "blocking_reasons",
-    "generated_at"
+    "generated_at",
+    "source_commit_sha",
+    "source_head_ref",
+    "workflow_run_id",
+    "producer_script",
+    "produced_at",
+    "source_pytest_execution_record_ref",
+    "source_pytest_execution_record_hash",
+    "artifact_hash"
   ],
   "properties": {
     "artifact_type": {"const": "pytest_selection_integrity_result"},
-    "schema_version": {"const": "1.0.0"},
+    "schema_version": {"const": "1.1.0"},
     "changed_paths": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
     "required_test_targets": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
     "selected_test_targets": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
@@ -47,6 +55,14 @@
       },
       "uniqueItems": true
     },
-    "generated_at": {"type": "string", "format": "date-time"}
+    "generated_at": {"type": "string", "format": "date-time"},
+    "source_commit_sha": {"type": "string", "minLength": 1},
+    "source_head_ref": {"type": "string", "minLength": 1},
+    "workflow_run_id": {"type": "string", "minLength": 1},
+    "producer_script": {"type": "string", "const": "scripts/run_contract_preflight.py"},
+    "produced_at": {"type": "string", "format": "date-time"},
+    "source_pytest_execution_record_ref": {"type": "string", "const": "outputs/contract_preflight/pytest_execution_record.json"},
+    "source_pytest_execution_record_hash": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "artifact_hash": {"type": "string", "pattern": "^[a-f0-9]{64}$"}
   }
 }

--- a/contracts/standards-manifest.json
+++ b/contracts/standards-manifest.json
@@ -1230,15 +1230,15 @@
     {
       "artifact_type": "contract_preflight_result_artifact",
       "artifact_class": "coordination",
-      "schema_version": "1.2.0",
+      "schema_version": "1.5.0",
       "status": "stable",
       "intended_consumers": [
         "spectrum-systems"
       ],
       "introduced_in": "1.3.9",
-      "last_updated_in": "1.3.21",
+      "last_updated_in": "1.3.201",
       "example_path": "contracts/examples/contract_preflight_result_artifact.json",
-      "notes": "Governed contract preflight result artifact carrying BLOCK/FREEZE/WARN/ALLOW strategy-gate mapping, PQX required-context enforcement result, and impact repair guidance for PQX pre-execution control."
+      "notes": "Governed contract preflight result artifact carrying ALLOW/BLOCK/FREEZE strategy-gate mapping, canonical pytest artifact linkage hashes, and PQX required-context enforcement for PR trust-seam fail-closed control."
     },
     {
       "artifact_type": "control_arbitration_policy",
@@ -5996,15 +5996,15 @@
     {
       "artifact_type": "pytest_execution_record",
       "artifact_class": "coordination",
-      "schema_version": "1.0.0",
+      "schema_version": "1.1.0",
       "status": "stable",
       "intended_consumers": [
         "spectrum-systems"
       ],
       "introduced_in": "1.3.133",
-      "last_updated_in": "1.3.133",
+      "last_updated_in": "1.3.201",
       "example_path": "contracts/examples/pytest_execution_record.json",
-      "notes": "PYX-02 canonical preflight-owned pytest execution evidence artifact for pull_request trust gating fail-closed checks."
+      "notes": "PYX-02 canonical preflight-owned pytest execution evidence artifact with required same-run provenance binding fields for pull_request trust gating fail-closed checks."
     },
     {
       "artifact_type": "qos_backpressure_signal",
@@ -8808,15 +8808,15 @@
     {
       "artifact_type": "pytest_selection_integrity_result",
       "artifact_class": "coordination",
-      "schema_version": "1.0.0",
+      "schema_version": "1.1.0",
       "status": "stable",
       "intended_consumers": [
         "spectrum-systems"
       ],
       "introduced_in": "1.0.84",
-      "last_updated_in": "1.0.84",
+      "last_updated_in": "1.3.201",
       "example_path": "contracts/examples/pytest_selection_integrity_result.json",
-      "notes": "TSI-01 governed fail-closed PR pytest selection integrity evidence artifact."
+      "notes": "TSI-01 governed fail-closed PR pytest selection integrity evidence artifact with deterministic linkage to canonical pytest_execution_record provenance."
     },
     {
       "artifact_type": "pytest_trust_gap_audit_result",

--- a/docs/review-actions/PLAN-RTX-02-2026-04-14.md
+++ b/docs/review-actions/PLAN-RTX-02-2026-04-14.md
@@ -1,0 +1,52 @@
+# Plan — RTX-02 — 2026-04-14
+
+## Prompt type
+PLAN
+
+## Roadmap item
+RTX-02 — PR trust seam mandatory hardening closure
+
+## Objective
+Close RTX-01 mandatory PR trust seam findings by enforcing canonical artifact refs + provenance binding, making PR WARN non-pass-equivalent, and fail-closing degraded PR path resolution coverage.
+
+## Declared files
+| File | Change type | Reason |
+| --- | --- | --- |
+| scripts/run_contract_preflight.py | MODIFY | Enforce canonical artifact refs/provenance binding, PR WARN blocking, and degraded PR path-resolution fail-closed invariants |
+| .github/workflows/artifact-boundary.yml | MODIFY | Enforce canonical ref path and provenance checks at workflow trust seam |
+| .github/workflows/pr-autofix-contract-preflight.yml | MODIFY | Enforce canonical ref path and provenance checks in autofix workflow trust seam |
+| spectrum_systems/modules/runtime/pytest_selection_integrity.py | MODIFY | Add provenance binding fields to selection integrity artifact payload |
+| spectrum_systems/modules/runtime/preflight_failure_normalizer.py | MODIFY | Normalize new invariant reason codes |
+| contracts/schemas/pytest_execution_record.schema.json | MODIFY | Add mandatory provenance binding fields for execution artifact |
+| contracts/schemas/pytest_selection_integrity_result.schema.json | MODIFY | Add mandatory provenance binding fields for selection artifact |
+| contracts/schemas/contract_preflight_result_artifact.schema.json | MODIFY | Add deterministic linkage/provenance fields and strict decision enum |
+| contracts/examples/pytest_execution_record.json | MODIFY | Keep example aligned with updated schema |
+| contracts/examples/pytest_selection_integrity_result.json | MODIFY | Keep example aligned with updated schema |
+| contracts/examples/contract_preflight_result_artifact.json | MODIFY | Keep example aligned with updated schema and trust semantics |
+| contracts/standards-manifest.json | MODIFY | Version-bump updated contracts per contract authority rules |
+| tests/test_contract_preflight.py | MODIFY | Add hardening tests for mandatory findings and invariants |
+| tests/test_artifact_boundary_workflow_pytest_enforcement.py | MODIFY | Assert workflow-level canonical ref and PR WARN blocking checks |
+| tests/test_pytest_selection_integrity.py | MODIFY | Assert provenance fields in selection integrity payload |
+| tests/test_preflight_failure_normalizer.py | MODIFY | Assert normalization for new invariant codes |
+| docs/reviews/RTX-02_pr_trust_seam_hardening_review.md | CREATE | Mandatory structured implementation report |
+
+## Contracts touched
+- `contracts/schemas/pytest_execution_record.schema.json` (version bump)
+- `contracts/schemas/pytest_selection_integrity_result.schema.json` (version bump)
+- `contracts/schemas/contract_preflight_result_artifact.schema.json` (version bump)
+- `contracts/standards-manifest.json` updates for above
+
+## Tests that must pass after execution
+1. `python -m pytest -q tests/test_artifact_boundary_workflow_pytest_enforcement.py`
+2. `python -m pytest -q tests/test_contract_preflight.py`
+3. `python -m pytest -q tests/test_pytest_selection_integrity.py`
+4. `python -m pytest -q tests/test_preflight_failure_normalizer.py`
+5. `python scripts/run_contract_enforcement.py`
+
+## Scope exclusions
+- Do not introduce new subsystems or non-repo-native trust frameworks.
+- Do not weaken existing fail-closed gates.
+- Do not refactor unrelated modules, schemas, or workflow topology.
+
+## Dependencies
+- RTX-01 findings document (`docs/reviews/RTX-01_pr_trust_seam_red_team_review.md`) as mandatory input.

--- a/docs/reviews/RTX-02_pr_trust_seam_hardening_review.md
+++ b/docs/reviews/RTX-02_pr_trust_seam_hardening_review.md
@@ -1,0 +1,118 @@
+# RTX-02 PR Trust Seam Hardening Review
+
+## 1. Intent
+Close the three mandatory RTX-01 PR trust seam findings with surgical fail-closed hardening in the existing preflight/workflow seam.
+
+## 2. Root cause by mandatory finding
+
+### Finding 1: Untrusted `*_ref` artifact paths accepted without canonical path / provenance binding
+- Root cause: workflow trust checks only verified file existence and did not constrain references to canonical preflight-owned locations.
+- Root cause: pytest trust artifacts lacked mandatory same-run provenance fields and deterministic linkage.
+
+### Finding 2: PR WARN decisions treated as pass-equivalent
+- Root cause: both workflow seam and preflight strategy mapping accepted WARN as pass-equivalent under pull_request context.
+
+### Finding 3: Ref-failure fallback narrowed governed detection to `contracts/`
+- Root cause: fallback logic in changed-path resolution considered only `contracts/` and permitted degraded PR outcomes without invariant-level PR block semantics.
+
+## 3. Files changed
+- `.github/workflows/artifact-boundary.yml`
+- `.github/workflows/pr-autofix-contract-preflight.yml`
+- `scripts/run_contract_preflight.py`
+- `spectrum_systems/modules/runtime/pytest_selection_integrity.py`
+- `spectrum_systems/modules/runtime/preflight_failure_normalizer.py`
+- `contracts/schemas/pytest_execution_record.schema.json`
+- `contracts/schemas/pytest_selection_integrity_result.schema.json`
+- `contracts/schemas/contract_preflight_result_artifact.schema.json`
+- `contracts/examples/pytest_execution_record.json`
+- `contracts/examples/pytest_selection_integrity_result.json`
+- `contracts/examples/contract_preflight_result_artifact.json`
+- `contracts/standards-manifest.json`
+- `tests/test_artifact_boundary_workflow_pytest_enforcement.py`
+- `tests/test_contract_preflight.py`
+- `tests/test_pytest_selection_integrity.py`
+- `tests/test_preflight_failure_normalizer.py`
+- `docs/review-actions/PLAN-RTX-02-2026-04-14.md`
+- `docs/reviews/RTX-02_pr_trust_seam_hardening_review.md`
+
+## 4. Exact hardening implemented
+
+### A. Canonical artifact refs + provenance binding
+- PR trust seam now enforces canonical refs only:
+  - `outputs/contract_preflight/pytest_execution_record.json`
+  - `outputs/contract_preflight/pytest_selection_integrity_result.json`
+- Added required provenance fields to `pytest_execution_record` and `pytest_selection_integrity_result`:
+  - `source_commit_sha`
+  - `source_head_ref`
+  - `workflow_run_id`
+  - `producer_script`
+  - `produced_at`
+  - `artifact_hash`
+- Added deterministic linkage on selection artifact:
+  - `source_pytest_execution_record_ref`
+  - `source_pytest_execution_record_hash`
+- Added deterministic linkage bundle to `contract_preflight_result_artifact`:
+  - `pytest_artifact_linkage` with canonical refs + hashes.
+- Workflow seam now blocks on:
+  - non-canonical refs
+  - missing provenance fields
+  - provenance link/hash mismatch
+  - commit binding mismatch
+
+### B. PR WARN must not pass
+- Workflow checks now fail closed when decision is WARN in PR context.
+- Preflight signal mapping now blocks WARN for PR context explicitly.
+- Strategy schema no longer allows WARN in `contract_preflight_result_artifact` decision enum.
+- Push behavior remains explicit in signal mapping and tests.
+
+### C. Degraded ref/path resolution fail-closed on PR
+- Governed fallback surface expanded to include:
+  - `contracts/`
+  - `scripts/`
+  - `spectrum_systems/`
+  - `.github/workflows/`
+  - `docs/governance/`
+- Degraded PR detection modes now block with explicit invariant codes.
+- Added invariant reason codes:
+  - `NON_EXHAUSTIVE_GOVERNED_PATH_RESOLUTION`
+  - `DEGRADED_REF_RESOLUTION_PR_BLOCK`
+  - `GOVERNED_SURFACE_DIFF_INCOMPLETE`
+
+## 5. New invariants added
+- `PR_PYTEST_EXECUTION_REF_NON_CANONICAL`
+- `PR_PYTEST_SELECTION_REF_NON_CANONICAL`
+- `PR_PYTEST_EXECUTION_PROVENANCE_MISSING`
+- `PR_PYTEST_SELECTION_PROVENANCE_MISSING`
+- `PR_PYTEST_PROVENANCE_LINK_MISMATCH`
+- `PR_PYTEST_PROVENANCE_HASH_MISMATCH`
+- `PR_PYTEST_PROVENANCE_COMMIT_MISMATCH`
+- `NON_EXHAUSTIVE_GOVERNED_PATH_RESOLUTION`
+- `DEGRADED_REF_RESOLUTION_PR_BLOCK`
+- `GOVERNED_SURFACE_DIFF_INCOMPLETE`
+
+## 6. Tests added/updated
+- Added workflow seam assertions for canonical ref/provenance enforcement and WARN blocking.
+- Added PR control-signal tests proving WARN block semantics and explicit push handling.
+- Added degraded PR path-resolution block invariant test.
+- Added provenance payload tests for selection-integrity artifact.
+- Updated contract preflight tests for canonical refs and v1.5.0/v1.1.0 schema behavior.
+
+## 7. Validation commands run
+1. `python -m pytest -q tests/test_artifact_boundary_workflow_pytest_enforcement.py`
+2. `python -m pytest -q tests/test_contract_preflight.py`
+3. `python -m pytest -q tests/test_pytest_selection_integrity.py`
+4. `python -m pytest -q tests/test_preflight_failure_normalizer.py`
+5. `python scripts/run_contract_enforcement.py`
+
+## 8. Results
+- All listed validation commands passed.
+
+## 9. Remaining risks
+- Non-PR historical consumers that parse legacy WARN semantics may require downstream alignment if they assume WARN emission.
+- Existing external tooling that consumes old schema versions (`1.0.0`/`1.4.0`) must pin or upgrade to the updated schemas and manifest entries.
+
+## 10. Final verdict
+RTX-01 mandatory findings are closed for the live PR trust seam:
+- PR trust no longer accepts unbound/non-canonical refs.
+- WARN is no longer pass-equivalent in PR trust.
+- Degraded PR path resolution no longer narrows silently to contracts-only and now fails closed with explicit invariant reason codes.

--- a/scripts/run_contract_preflight.py
+++ b/scripts/run_contract_preflight.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 from datetime import datetime, timezone
+import hashlib
 import json
 import os
 import subprocess
@@ -138,6 +139,16 @@ _GOVERNED_PR_FALLBACK_PYTEST_TARGETS = [
     "tests/test_eval_dataset_registry.py",
     "tests/test_contracts.py",
 ]
+_CANONICAL_PREFLIGHT_OUTPUT_PREFIX = "outputs/contract_preflight/"
+_CANONICAL_PYTEST_EXECUTION_REF = f"{_CANONICAL_PREFLIGHT_OUTPUT_PREFIX}pytest_execution_record.json"
+_CANONICAL_PYTEST_SELECTION_REF = f"{_CANONICAL_PREFLIGHT_OUTPUT_PREFIX}pytest_selection_integrity_result.json"
+_GOVERNED_CHANGED_PATH_PREFIXES = (
+    "contracts/",
+    "scripts/",
+    "spectrum_systems/",
+    ".github/workflows/",
+    "docs/governance/",
+)
 
 _REQUIRED_SURFACE_TEST_OVERRIDES: dict[str, list[str]] = {
     "scripts/run_autonomous_validation_run.py": ["tests/test_run_autonomous_validation_run.py"],
@@ -245,6 +256,36 @@ def _utc_now() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+def _hash_payload(payload: dict[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _build_common_provenance(*, source_head_ref: str) -> dict[str, Any]:
+    source_commit_sha = (
+        str(os.environ.get("GITHUB_SHA") or "").strip()
+        or source_head_ref
+        or str(os.environ.get("GIT_COMMIT") or "").strip()
+        or "unknown"
+    )
+    return {
+        "source_commit_sha": source_commit_sha,
+        "source_head_ref": source_head_ref or "unknown",
+        "workflow_run_id": str(os.environ.get("GITHUB_RUN_ID") or "local"),
+        "producer_script": "scripts/run_contract_preflight.py",
+        "produced_at": _utc_now(),
+    }
+
+
+def _is_governed_changed_path(path: str) -> bool:
+    return any(path.startswith(prefix) for prefix in _GOVERNED_CHANGED_PATH_PREFIXES)
+
+
+def _validate_canonical_ref_path(*, ref: str, expected_suffix: str) -> bool:
+    normalized = ref.replace("\\", "/").lstrip("./")
+    return normalized == expected_suffix
+
+
 def _resolve_wrapper_path(repo_root: Path, wrapper_path_value: str) -> Path:
     wrapper_path = Path(wrapper_path_value)
     if not wrapper_path.is_absolute():
@@ -285,10 +326,14 @@ def _attempt_build_missing_wrapper(
 
 
 def _all_governed_paths(repo_root: Path) -> list[str]:
-    governed = []
-    governed.extend(str(path.relative_to(repo_root)) for path in sorted((repo_root / "contracts" / "schemas").glob("*.schema.json")))
-    governed.extend(str(path.relative_to(repo_root)) for path in sorted((repo_root / "contracts" / "examples").glob("*.json")))
-    governed.extend(str(path.relative_to(repo_root)) for path in sorted((repo_root / "contracts").glob("*.schema.json")))
+    governed: list[str] = []
+    for prefix in _GOVERNED_CHANGED_PATH_PREFIXES:
+        root = repo_root / prefix
+        if not root.exists():
+            continue
+        for path in sorted(root.rglob("*")):
+            if path.is_file():
+                governed.append(str(path.relative_to(repo_root)))
     return sorted(set(governed))
 
 
@@ -385,7 +430,7 @@ def detect_changed_paths(repo_root: Path, base_ref: str, head_ref: str, explicit
 
     # D: safe local fallback paths.
     local_changes = _local_workspace_changes(repo_root)
-    local_governed = [path for path in local_changes if path.startswith("contracts/")]
+    local_governed = [path for path in local_changes if _is_governed_changed_path(path)]
     if local_governed:
         return ChangedPathDetectionResult(
             changed_paths=sorted(set(local_governed)),
@@ -395,13 +440,13 @@ def detect_changed_paths(repo_root: Path, base_ref: str, head_ref: str, explicit
             warnings=warnings + ["using git status porcelain fallback"],
         )
     if local_changes:
-        warnings.append("local workspace fallback had no governed contract paths; continuing to deeper fallback")
+        warnings.append("local workspace fallback had no governed surface paths; continuing to deeper fallback")
 
     refs_attempted.append("working_tree_vs_HEAD")
     working_tree = _run(["git", "diff", "--name-only", "HEAD"], cwd=repo_root)
     if working_tree.returncode == 0:
         paths = sorted({line.strip() for line in working_tree.stdout.splitlines() if line.strip()})
-        governed_paths = [path for path in paths if path.startswith("contracts/")]
+        governed_paths = [path for path in paths if _is_governed_changed_path(path)]
         if governed_paths:
             return ChangedPathDetectionResult(
                 changed_paths=sorted(set(governed_paths)),
@@ -411,7 +456,7 @@ def detect_changed_paths(repo_root: Path, base_ref: str, head_ref: str, explicit
                 warnings=warnings + ["using working tree diff fallback"],
             )
         if paths:
-            warnings.append("working tree fallback had no governed contract paths; degrading to full governed scan")
+            warnings.append("working tree fallback had no governed surface paths; degrading to full governed scan")
     else:
         warnings.append(f"working tree fallback unavailable: {working_tree.combined_output}")
 
@@ -423,7 +468,7 @@ def detect_changed_paths(repo_root: Path, base_ref: str, head_ref: str, explicit
             changed_path_detection_mode="degraded_full_governed_scan",
             refs_attempted=refs_attempted,
             fallback_used=True,
-            warnings=warnings + ["changed-path detection degraded; running full governed contract scan"],
+            warnings=warnings + ["changed-path detection degraded; running full governed surface scan"],
         )
 
     # Canonical resolver fallback for explicit insufficient-context metadata surface.
@@ -734,6 +779,7 @@ def run_targeted_pytests(paths: list[str], *, execution_log: list[dict[str, Any]
 def build_pytest_execution_record(
     *,
     event_name: str,
+    source_head_ref: str,
     execution_log: list[dict[str, Any]],
     selected_targets: list[str],
     fallback_targets: list[str],
@@ -770,9 +816,9 @@ def build_pytest_execution_record(
 
     workflow_name = str(os.environ.get("GITHUB_WORKFLOW", "")).strip()
     workflow_job = str(os.environ.get("GITHUB_JOB", "")).strip()
-    return {
+    payload = {
         "artifact_type": "pytest_execution_record",
-        "schema_version": "1.0.0",
+        "schema_version": "1.1.0",
         "event_name": event_name,
         "workflow_name": workflow_name or None,
         "workflow_job": workflow_job or None,
@@ -792,6 +838,9 @@ def build_pytest_execution_record(
         "timestamp": _utc_now(),
         "failure_reason": failure_reason,
     }
+    payload.update(_build_common_provenance(source_head_ref=source_head_ref))
+    payload["artifact_hash"] = _hash_payload(payload)
+    return payload
 
 
 def detect_masked_failures(failures: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -1191,7 +1240,7 @@ def evaluate_trust_spine_cohesion(changed_paths: list[str], output_dir: Path) ->
     return result
 
 
-def map_preflight_control_signal(*, report: dict[str, Any], hardening_flow: bool) -> dict[str, Any]:
+def map_preflight_control_signal(*, report: dict[str, Any], hardening_flow: bool, event_name: str = "") -> dict[str, Any]:
     changed_path_detection = report.get("changed_path_detection", {})
     detection_mode = str(changed_path_detection.get("changed_path_detection_mode", "unknown"))
     preflight_mode = str(changed_path_detection.get("preflight_mode", "explicit_or_local_inspection"))
@@ -1237,6 +1286,13 @@ def map_preflight_control_signal(*, report: dict[str, Any], hardening_flow: bool
             "changed_path_detection_mode": detection_mode,
             "degraded_detection": degraded,
         }
+    if pqx_policy_warning and event_name == "pull_request":
+        return {
+            "strategy_gate_decision": "BLOCK",
+            "rationale": "PR trust seam requires ALLOW-only pass semantics; WARN is fail-closed",
+            "changed_path_detection_mode": detection_mode,
+            "degraded_detection": degraded,
+        }
     if pqx_policy_warning:
         return {
             "strategy_gate_decision": "ALLOW",
@@ -1260,10 +1316,17 @@ def map_preflight_control_signal(*, report: dict[str, Any], hardening_flow: bool
             "changed_path_detection_mode": detection_mode,
             "degraded_detection": degraded,
         }
+    if status == "passed" and degraded and event_name == "pull_request":
+        return {
+            "strategy_gate_decision": "BLOCK",
+            "rationale": "PR trust seam blocks degraded path resolution outcomes",
+            "changed_path_detection_mode": detection_mode,
+            "degraded_detection": degraded,
+        }
     if status == "passed" and degraded:
         return {
-            "strategy_gate_decision": "WARN",
-            "rationale": "preflight passed under degraded full governed scan mode",
+            "strategy_gate_decision": "BLOCK",
+            "rationale": "preflight passed under degraded full governed scan mode; fail-closed required",
             "changed_path_detection_mode": detection_mode,
             "degraded_detection": degraded,
         }
@@ -1290,7 +1353,11 @@ def build_preflight_result_artifact(
     hardening_flow: bool,
 ) -> dict[str, Any]:
     detection = report.get("changed_path_detection", {})
-    control_signal = map_preflight_control_signal(report=report, hardening_flow=hardening_flow)
+    control_signal = map_preflight_control_signal(
+        report=report,
+        hardening_flow=hardening_flow,
+        event_name=str(report.get("pytest_execution", {}).get("event_name", "")),
+    )
     required_context = report.get("pqx_required_context_enforcement")
     if not isinstance(required_context, dict):
         required_context = {
@@ -1307,7 +1374,7 @@ def build_preflight_result_artifact(
         }
     return {
         "artifact_type": "contract_preflight_result_artifact",
-        "schema_version": "1.4.0",
+        "schema_version": "1.5.0",
         "preflight_status": report.get("status", "failed"),
         "changed_contracts": report.get("changed_contracts", []),
         "impacted_producers": report.get("impact", {}).get("producers", []),
@@ -1328,6 +1395,12 @@ def build_preflight_result_artifact(
         "pytest_execution_record_ref": report.get("pytest_execution_record_ref"),
         "pytest_selection_integrity": report.get("pytest_selection_integrity", {}),
         "pytest_selection_integrity_result_ref": report.get("pytest_selection_integrity_result_ref"),
+        "pytest_artifact_linkage": {
+            "pytest_execution_record_ref": _CANONICAL_PYTEST_EXECUTION_REF,
+            "pytest_execution_record_hash": str((report.get("pytest_execution_record") or {}).get("artifact_hash") or ""),
+            "pytest_selection_integrity_result_ref": _CANONICAL_PYTEST_SELECTION_REF,
+            "pytest_selection_integrity_result_hash": str((report.get("pytest_selection_integrity") or {}).get("artifact_hash") or ""),
+        },
         "pqx_required_context_enforcement": {
             "classification": str(required_context.get("classification", "exploration_only_or_non_governed")),
             "execution_context": str(required_context.get("execution_context", "unspecified")),
@@ -1862,6 +1935,7 @@ def main() -> int:
     }
     pytest_execution_record = build_pytest_execution_record(
         event_name=str(ref_context.event_name or ""),
+        source_head_ref=str(ref_context.head_ref or ""),
         execution_log=pytest_execution_log,
         selected_targets=selected_pytest_targets,
         fallback_targets=fallback_pytest_targets,
@@ -1871,11 +1945,20 @@ def main() -> int:
         selection_reason_codes=pytest_selection_reason_codes,
     )
     validate_artifact(pytest_execution_record, "pytest_execution_record")
+    report["pytest_execution_record"] = pytest_execution_record
     pytest_execution_record_path = output_dir / "pytest_execution_record.json"
     pytest_execution_record_path.write_text(json.dumps(pytest_execution_record, indent=2) + "\n", encoding="utf-8")
-    report["pytest_execution_record_ref"] = str(pytest_execution_record_path)
+    report["pytest_execution_record_ref"] = _CANONICAL_PYTEST_EXECUTION_REF
+    pytest_execution_record_hash = str(pytest_execution_record.get("artifact_hash") or "")
 
     required_targets_for_integrity = sorted(set(smoke_targets + forced_targets)) if "smoke_targets" in locals() and "forced_targets" in locals() else []
+    selection_provenance = _build_common_provenance(source_head_ref=str(ref_context.head_ref or ""))
+    selection_provenance.update(
+        {
+            "source_pytest_execution_record_ref": _CANONICAL_PYTEST_EXECUTION_REF,
+            "source_pytest_execution_record_hash": pytest_execution_record_hash,
+        }
+    )
     try:
         selection_eval = evaluate_pytest_selection_integrity(
             changed_paths=detection.changed_paths,
@@ -1884,12 +1967,13 @@ def main() -> int:
             pytest_execution_record=pytest_execution_record,
             policy_path=_PYTEST_SELECTION_INTEGRITY_POLICY_PATH,
             generated_at=_utc_now(),
+            provenance=selection_provenance,
         )
         report["pytest_selection_integrity"] = selection_eval.payload
     except PytestSelectionIntegrityError:
         report["pytest_selection_integrity"] = {
             "artifact_type": "pytest_selection_integrity_result",
-            "schema_version": "1.0.0",
+            "schema_version": "1.1.0",
             "changed_paths": sorted(set(detection.changed_paths)),
             "required_test_targets": required_targets_for_integrity,
             "selected_test_targets": sorted(set(selected_pytest_targets + fallback_pytest_targets)),
@@ -1901,7 +1985,15 @@ def main() -> int:
             "selection_integrity_decision": "BLOCK",
             "blocking_reasons": ["PYTEST_SELECTION_ARTIFACT_INVALID"],
             "generated_at": _utc_now(),
+            "source_commit_sha": selection_provenance["source_commit_sha"],
+            "source_head_ref": selection_provenance["source_head_ref"],
+            "workflow_run_id": selection_provenance["workflow_run_id"],
+            "producer_script": selection_provenance["producer_script"],
+            "produced_at": selection_provenance["produced_at"],
+            "source_pytest_execution_record_ref": selection_provenance["source_pytest_execution_record_ref"],
+            "source_pytest_execution_record_hash": selection_provenance["source_pytest_execution_record_hash"],
         }
+        report["pytest_selection_integrity"]["artifact_hash"] = _hash_payload(report["pytest_selection_integrity"])
     selection_integrity_valid = True
     try:
         validate_artifact(report["pytest_selection_integrity"], "pytest_selection_integrity_result")
@@ -1911,7 +2003,7 @@ def main() -> int:
         report["invariant_violations"] = sorted(set(report.get("invariant_violations", []) + ["PYTEST_SELECTION_ARTIFACT_INVALID"]))
         report["pytest_selection_integrity"] = {
             "artifact_type": "pytest_selection_integrity_result",
-            "schema_version": "1.0.0",
+            "schema_version": "1.1.0",
             "changed_paths": sorted(set(detection.changed_paths)),
             "required_test_targets": required_targets_for_integrity,
             "selected_test_targets": sorted(set(selected_pytest_targets + fallback_pytest_targets)),
@@ -1923,13 +2015,23 @@ def main() -> int:
             "selection_integrity_decision": "BLOCK",
             "blocking_reasons": ["PYTEST_SELECTION_ARTIFACT_INVALID"],
             "generated_at": _utc_now(),
+            "source_commit_sha": selection_provenance["source_commit_sha"],
+            "source_head_ref": selection_provenance["source_head_ref"],
+            "workflow_run_id": selection_provenance["workflow_run_id"],
+            "producer_script": selection_provenance["producer_script"],
+            "produced_at": selection_provenance["produced_at"],
+            "source_pytest_execution_record_ref": selection_provenance["source_pytest_execution_record_ref"],
+            "source_pytest_execution_record_hash": selection_provenance["source_pytest_execution_record_hash"],
         }
+        report["pytest_selection_integrity"]["artifact_hash"] = _hash_payload(report["pytest_selection_integrity"])
+    if report.get("pytest_selection_integrity", {}).get("artifact_hash") in {"", None}:
+        report["pytest_selection_integrity"]["artifact_hash"] = _hash_payload(report["pytest_selection_integrity"])
     selection_integrity_path = output_dir / "pytest_selection_integrity_result.json"
     if selection_integrity_valid:
         selection_integrity_path.write_text(json.dumps(report["pytest_selection_integrity"], indent=2) + "\n", encoding="utf-8")
-        report["pytest_selection_integrity_result_ref"] = str(selection_integrity_path)
+        report["pytest_selection_integrity_result_ref"] = _CANONICAL_PYTEST_SELECTION_REF
     else:
-        report["pytest_selection_integrity_result_ref"] = None
+        report["pytest_selection_integrity_result_ref"] = _CANONICAL_PYTEST_SELECTION_REF
 
     if is_pull_request_event:
         if not bool(pytest_execution_record.get("executed", False)):
@@ -1959,6 +2061,76 @@ def main() -> int:
             report["recommended_repair_areas"] = sorted(
                 set(report.get("recommended_repair_areas", []) + ["restore deterministic PR pytest selection integrity coverage"])
             )
+        execution_ref = str(report.get("pytest_execution_record_ref") or "").strip()
+        selection_ref = str(report.get("pytest_selection_integrity_result_ref") or "").strip()
+        if not _validate_canonical_ref_path(ref=execution_ref, expected_suffix=_CANONICAL_PYTEST_EXECUTION_REF):
+            report["status"] = "failed"
+            report["invariant_violations"] = sorted(
+                set(report.get("invariant_violations", []) + ["PR_PYTEST_EXECUTION_REF_NON_CANONICAL"])
+            )
+        if not _validate_canonical_ref_path(ref=selection_ref, expected_suffix=_CANONICAL_PYTEST_SELECTION_REF):
+            report["status"] = "failed"
+            report["invariant_violations"] = sorted(
+                set(report.get("invariant_violations", []) + ["PR_PYTEST_SELECTION_REF_NON_CANONICAL"])
+            )
+        execution_provenance_fields = [
+            "source_commit_sha",
+            "source_head_ref",
+            "workflow_run_id",
+            "producer_script",
+            "produced_at",
+            "artifact_hash",
+        ]
+        if any(not str(pytest_execution_record.get(field) or "").strip() for field in execution_provenance_fields):
+            report["status"] = "failed"
+            report["invariant_violations"] = sorted(
+                set(report.get("invariant_violations", []) + ["PR_PYTEST_EXECUTION_PROVENANCE_MISSING"])
+            )
+        selection_provenance_fields = execution_provenance_fields + [
+            "source_pytest_execution_record_ref",
+            "source_pytest_execution_record_hash",
+        ]
+        if any(not str(selection_integrity.get(field) or "").strip() for field in selection_provenance_fields):
+            report["status"] = "failed"
+            report["invariant_violations"] = sorted(
+                set(report.get("invariant_violations", []) + ["PR_PYTEST_SELECTION_PROVENANCE_MISSING"])
+            )
+        if str(selection_integrity.get("source_pytest_execution_record_ref") or "") != execution_ref:
+            report["status"] = "failed"
+            report["invariant_violations"] = sorted(
+                set(report.get("invariant_violations", []) + ["PR_PYTEST_PROVENANCE_LINK_MISMATCH"])
+            )
+        if str(selection_integrity.get("source_pytest_execution_record_hash") or "") != str(pytest_execution_record.get("artifact_hash") or ""):
+            report["status"] = "failed"
+            report["invariant_violations"] = sorted(
+                set(report.get("invariant_violations", []) + ["PR_PYTEST_PROVENANCE_HASH_MISMATCH"])
+            )
+        if str(selection_integrity.get("source_commit_sha") or "") != str(pytest_execution_record.get("source_commit_sha") or ""):
+            report["status"] = "failed"
+            report["invariant_violations"] = sorted(
+                set(report.get("invariant_violations", []) + ["PR_PYTEST_PROVENANCE_COMMIT_MISMATCH"])
+            )
+        detection_mode = str(report.get("changed_path_detection", {}).get("changed_path_detection_mode", ""))
+        degraded_modes = {
+            "local_workspace_status",
+            "working_tree_diff_head",
+            "degraded_full_governed_scan",
+            "detection_failed_no_governed_paths",
+            "base_to_current_head_fallback",
+            "github_ref_context_fallback",
+        }
+        if detection_mode in degraded_modes:
+            report["status"] = "failed"
+            report["invariant_violations"] = sorted(
+                set(report.get("invariant_violations", []) + ["DEGRADED_REF_RESOLUTION_PR_BLOCK"])
+            )
+            if detection_mode != "degraded_full_governed_scan":
+                report["invariant_violations"] = sorted(
+                    set(
+                        report.get("invariant_violations", [])
+                        + ["NON_EXHAUSTIVE_GOVERNED_PATH_RESOLUTION", "GOVERNED_SURFACE_DIFF_INCOMPLETE"]
+                    )
+                )
 
     if report["control_surface_enforcement"] and report["control_surface_enforcement"].get("enforcement_status") == "BLOCK":
         report["status"] = "failed"
@@ -2041,7 +2213,11 @@ def main() -> int:
             set(report.get("recommended_repair_areas", []) + ["run governed PR pytest execution before ALLOW"])
         )
 
-    control_signal = map_preflight_control_signal(report=report, hardening_flow=bool(args.hardening_flow))
+    control_signal = map_preflight_control_signal(
+        report=report,
+        hardening_flow=bool(args.hardening_flow),
+        event_name=str(ref_context.event_name or ""),
+    )
     decision = str(control_signal.get("strategy_gate_decision", "BLOCK"))
     report["status"] = "failed" if decision in {"BLOCK", "FREEZE"} else "passed"
     classification_exception: str | None = None

--- a/spectrum_systems/modules/runtime/preflight_failure_normalizer.py
+++ b/spectrum_systems/modules/runtime/preflight_failure_normalizer.py
@@ -23,6 +23,13 @@ def normalize_preflight_failure(report: dict[str, Any]) -> dict[str, Any]:
                 "PR_PYTEST_EXECUTION_REQUIRED",
                 "PREFLIGHT_PASS_WITHOUT_PYTEST_EXECUTION",
                 "PR_PYTEST_EXECUTION_RECORD_REQUIRED",
+                "PR_PYTEST_EXECUTION_REF_NON_CANONICAL",
+                "PR_PYTEST_SELECTION_REF_NON_CANONICAL",
+                "PR_PYTEST_EXECUTION_PROVENANCE_MISSING",
+                "PR_PYTEST_SELECTION_PROVENANCE_MISSING",
+                "PR_PYTEST_PROVENANCE_LINK_MISMATCH",
+                "PR_PYTEST_PROVENANCE_HASH_MISMATCH",
+                "PR_PYTEST_PROVENANCE_COMMIT_MISMATCH",
             }
             & set(report.get("invariant_violations", []))
         ),
@@ -36,6 +43,9 @@ def normalize_preflight_failure(report: dict[str, Any]) -> dict[str, Any]:
                 "PYTEST_SELECTION_MISMATCH",
                 "PYTEST_SELECTION_FILTERING_DETECTED",
                 "PR_PYTEST_SELECTION_INTEGRITY_REQUIRED",
+                "DEGRADED_REF_RESOLUTION_PR_BLOCK",
+                "NON_EXHAUSTIVE_GOVERNED_PATH_RESOLUTION",
+                "GOVERNED_SURFACE_DIFF_INCOMPLETE",
             }
             & set(report.get("invariant_violations", []))
         ),

--- a/spectrum_systems/modules/runtime/pytest_selection_integrity.py
+++ b/spectrum_systems/modules/runtime/pytest_selection_integrity.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import hashlib
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -72,6 +73,7 @@ def evaluate_pytest_selection_integrity(
     pytest_execution_record: dict[str, Any] | None,
     policy_path: Path,
     generated_at: str,
+    provenance: dict[str, Any] | None = None,
 ) -> SelectionIntegrityEvaluation:
     """Evaluate fail-closed selection integrity evidence for preflight."""
     policy = _load_policy(policy_path)
@@ -138,7 +140,7 @@ def evaluate_pytest_selection_integrity(
     decision = "ALLOW" if not reasons else "BLOCK"
     payload = {
         "artifact_type": "pytest_selection_integrity_result",
-        "schema_version": "1.0.0",
+        "schema_version": "1.1.0",
         "changed_paths": changed_paths_norm,
         "required_test_targets": effective_required,
         "selected_test_targets": selected_targets_norm,
@@ -151,6 +153,22 @@ def evaluate_pytest_selection_integrity(
         "blocking_reasons": reasons,
         "generated_at": generated_at,
     }
+    if isinstance(provenance, dict):
+        payload.update(
+            {
+                "source_commit_sha": str(provenance.get("source_commit_sha") or "unknown"),
+                "source_head_ref": str(provenance.get("source_head_ref") or "unknown"),
+                "workflow_run_id": str(provenance.get("workflow_run_id") or "local"),
+                "producer_script": str(provenance.get("producer_script") or "scripts/run_contract_preflight.py"),
+                "produced_at": str(provenance.get("produced_at") or generated_at),
+                "source_pytest_execution_record_ref": str(provenance.get("source_pytest_execution_record_ref") or ""),
+                "source_pytest_execution_record_hash": str(provenance.get("source_pytest_execution_record_hash") or ""),
+            }
+        )
+        payload["artifact_hash"] = str(provenance.get("artifact_hash") or "")
+    if not str(payload.get("artifact_hash") or "").strip():
+        canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        payload["artifact_hash"] = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
     return SelectionIntegrityEvaluation(
         status="passed" if decision == "ALLOW" else "failed",
         decision=decision,

--- a/tests/test_artifact_boundary_workflow_pytest_enforcement.py
+++ b/tests/test_artifact_boundary_workflow_pytest_enforcement.py
@@ -32,9 +32,21 @@ def test_artifact_boundary_workflow_fail_closes_on_missing_or_blocked_selection_
     assert 'allow decision with blocked pytest selection integrity' in text
 
 
+def test_artifact_boundary_workflow_enforces_canonical_refs_and_provenance() -> None:
+    text = ARTIFACT_BOUNDARY_WORKFLOW.read_text(encoding='utf-8')
+    assert 'WARN is not pass-equivalent for pull_request' in text
+    assert 'non-canonical pytest_execution_record_ref' in text
+    assert 'missing pytest_execution_record provenance fields' in text
+    assert 'non-canonical pytest_selection_integrity_result_ref' in text
+    assert 'selection provenance record ref mismatch' in text
+
+
 def test_autofix_workflow_enforces_pytest_execution_record_for_allow_warn() -> None:
     text = AUTOFIX_WORKFLOW.read_text(encoding='utf-8')
     assert 'pytest_execution_record_ref' in text
+    assert 'WARN is not pass-equivalent for pull_request' in text
+    assert 'non-canonical pytest_execution_record_ref' in text
+    assert 'missing pytest_execution_record provenance fields' in text
     assert 'allow decision with executed=false' in text
     assert 'allow decision with empty selected_targets' in text
 
@@ -42,5 +54,8 @@ def test_autofix_workflow_enforces_pytest_execution_record_for_allow_warn() -> N
 def test_autofix_workflow_enforces_selection_integrity_for_allow_warn() -> None:
     text = AUTOFIX_WORKFLOW.read_text(encoding='utf-8')
     assert 'pytest_selection_integrity_result_ref' in text
+    assert 'non-canonical pytest_selection_integrity_result_ref' in text
+    assert 'selection provenance record ref mismatch' in text
+    assert 'selection provenance record hash mismatch' in text
     assert 'missing pytest_selection_integrity_result_ref' in text
     assert 'allow decision with blocked pytest selection integrity' in text

--- a/tests/test_contract_preflight.py
+++ b/tests/test_contract_preflight.py
@@ -9,6 +9,9 @@ from spectrum_systems.modules.runtime.pqx_execution_policy import (
     classify_changed_paths as classify_pqx_policy_changed_paths,
     evaluate_pqx_execution_policy,
 )
+from spectrum_systems.modules.runtime.pytest_selection_integrity import (
+    evaluate_pytest_selection_integrity as evaluate_pytest_selection_integrity_runtime,
+)
 
 
 def _governed_wrapper_payload(changed_paths: list[str] | None = None) -> dict[str, object]:
@@ -332,8 +335,8 @@ def test_detect_changed_paths_skips_non_governed_working_tree_fallback(monkeypat
     monkeypatch.setattr(preflight, "_all_governed_paths", lambda _repo: ["contracts/schemas/roadmap_eligibility_artifact.schema.json"])
 
     detected = preflight.detect_changed_paths(repo_root=Path("."), base_ref="origin/main", head_ref="HEAD", explicit=[])
-    assert detected.changed_path_detection_mode == "degraded_full_governed_scan"
-    assert detected.changed_paths == ["contracts/schemas/roadmap_eligibility_artifact.schema.json"]
+    assert detected.changed_path_detection_mode == "working_tree_diff_head"
+    assert detected.changed_paths == ["scripts/run_contract_preflight.py"]
 
 
 def test_masking_detection_labels_contract_masking() -> None:
@@ -465,14 +468,14 @@ def test_main_report_includes_changed_path_fallback_metadata(tmp_path: Path, mon
     monkeypatch.setattr(preflight, "run_targeted_pytests", lambda *_args, **_kwargs: [])
 
     code = preflight.main()
-    assert code == 0
+    assert code == 2
 
     report = json.loads((output_dir / "contract_preflight_report.json").read_text(encoding="utf-8"))
     assert report["changed_path_detection"]["changed_path_detection_mode"] == "degraded_full_governed_scan"
     assert report["changed_path_detection"]["fallback_used"] is True
     preflight_artifact = json.loads((output_dir / "contract_preflight_result_artifact.json").read_text(encoding="utf-8"))
     assert preflight_artifact["artifact_type"] == "contract_preflight_result_artifact"
-    assert preflight_artifact["control_signal"]["strategy_gate_decision"] == "WARN"
+    assert preflight_artifact["control_signal"]["strategy_gate_decision"] == "BLOCK"
     assert preflight_artifact["control_surface_gap_status"] == "not_run"
     assert preflight_artifact["control_surface_gap_blocking"] is False
 
@@ -1077,7 +1080,7 @@ def test_main_governed_context_with_valid_wrapper_allows(tmp_path: Path, monkeyp
     report = json.loads((output_dir / "contract_preflight_report.json").read_text(encoding="utf-8"))
     assert report["pqx_required_context_enforcement"]["status"] == "allow"
     artifact = json.loads((output_dir / "contract_preflight_result_artifact.json").read_text(encoding="utf-8"))
-    assert artifact["schema_version"] == "1.4.0"
+    assert artifact["schema_version"] == "1.5.0"
     assert artifact["pqx_required_context_enforcement"]["status"] == "allow"
 
 
@@ -2023,7 +2026,7 @@ def test_pull_request_no_targeted_tests_uses_governed_fallback(tmp_path: Path, m
     artifact = json.loads((output_dir / "contract_preflight_result_artifact.json").read_text(encoding="utf-8"))
     assert artifact["pytest_execution"]["pytest_execution_count"] == 1
     assert "selection_reason_codes" in artifact["pytest_execution"]
-    assert artifact["pytest_execution_record_ref"] == str(output_dir / "pytest_execution_record.json")
+    assert artifact["pytest_execution_record_ref"] == "outputs/contract_preflight/pytest_execution_record.json"
     execution_record = json.loads((output_dir / "pytest_execution_record.json").read_text(encoding="utf-8"))
     assert execution_record["executed"] is True
     assert execution_record["exit_code"] == 0
@@ -2144,5 +2147,94 @@ def test_preflight_writes_selection_integrity_artifact_ref(monkeypatch, tmp_path
     monkeypatch.setattr(preflight, "run_targeted_pytests", lambda paths, **kwargs: [] if paths else [])
     _ = preflight.main()
     artifact = json.loads((output_dir / "contract_preflight_result_artifact.json").read_text(encoding="utf-8"))
-    assert artifact["pytest_selection_integrity_result_ref"]
+    assert artifact["pytest_selection_integrity_result_ref"] == "outputs/contract_preflight/pytest_selection_integrity_result.json"
     assert (output_dir / "pytest_selection_integrity_result.json").exists()
+
+
+def test_pr_warn_control_signal_blocks_fail_closed() -> None:
+    report = {"status": "passed", "changed_path_detection": {}, "pqx_execution_policy": {"status": "warn"}}
+    result = preflight.map_preflight_control_signal(report=report, hardening_flow=False, event_name="pull_request")
+    assert result["strategy_gate_decision"] == "BLOCK"
+
+
+def test_push_warn_control_signal_remains_explicit() -> None:
+    report = {"status": "passed", "changed_path_detection": {}, "pqx_execution_policy": {"status": "warn"}}
+    result = preflight.map_preflight_control_signal(report=report, hardening_flow=False, event_name="push")
+    assert result["strategy_gate_decision"] == "ALLOW"
+
+
+def test_pr_degraded_ref_resolution_blocks_with_invariants(tmp_path: Path, monkeypatch) -> None:
+    output_dir = tmp_path / "out"
+    monkeypatch.setattr(
+        preflight,
+        "_parse_args",
+        lambda: type(
+            "Args",
+            (),
+            {
+                "base_ref": "origin/main",
+                "head_ref": "missing-head",
+                "event_name": "pull_request",
+                "changed_path": [],
+                "output_dir": str(output_dir),
+                "hardening_flow": False,
+                "execution_context": "pqx_governed",
+                "pqx_wrapper_path": None,
+                "authority_evidence_ref": None,
+                "refresh_test_inventory_baseline": False,
+            },
+        )(),
+    )
+    monkeypatch.setattr(
+        preflight,
+        "detect_changed_paths",
+        lambda *_args, **_kwargs: preflight.ChangedPathDetectionResult(
+            changed_paths=["scripts/run_contract_preflight.py"],
+            changed_path_detection_mode="local_workspace_status",
+            refs_attempted=["origin/main..missing-head"],
+            fallback_used=True,
+            warnings=["using git status porcelain fallback"],
+        ),
+    )
+    monkeypatch.setattr(preflight, "run_targeted_pytests", lambda *_args, **_kwargs: [])
+    assert preflight.main() == 2
+    report = json.loads((output_dir / "contract_preflight_report.json").read_text(encoding="utf-8"))
+    assert "DEGRADED_REF_RESOLUTION_PR_BLOCK" in report["invariant_violations"]
+    assert "NON_EXHAUSTIVE_GOVERNED_PATH_RESOLUTION" in report["invariant_violations"]
+    assert "GOVERNED_SURFACE_DIFF_INCOMPLETE" in report["invariant_violations"]
+
+
+def test_pr_blocks_on_execution_provenance_mismatch(tmp_path: Path, monkeypatch) -> None:
+    output_dir = tmp_path / "out"
+    monkeypatch.setattr(
+        preflight,
+        "_parse_args",
+        lambda: type(
+            "Args",
+            (),
+            {
+                "base_ref": "origin/main",
+                "head_ref": "HEAD",
+                "event_name": "pull_request",
+                "changed_path": ["README.md"],
+                "output_dir": str(output_dir),
+                "hardening_flow": False,
+                "execution_context": "pqx_governed",
+                "pqx_wrapper_path": None,
+                "authority_evidence_ref": None,
+                "refresh_test_inventory_baseline": False,
+            },
+        )(),
+    )
+    monkeypatch.setattr(preflight, "run_targeted_pytests", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(preflight, "_resolve_existing_pytest_targets", lambda _paths: ["tests/test_contract_preflight.py"])
+
+    def _fake_eval(**kwargs):
+        payload = evaluate_pytest_selection_integrity_runtime(**kwargs).payload
+        payload["source_commit_sha"] = "forged"
+        return type("Eval", (), {"payload": payload})()
+
+    monkeypatch.setattr(preflight, "evaluate_pytest_selection_integrity", _fake_eval)
+    assert preflight.main() == 2
+    report = json.loads((output_dir / "contract_preflight_report.json").read_text(encoding="utf-8"))
+    assert "PR_PYTEST_PROVENANCE_COMMIT_MISMATCH" in report["invariant_violations"]

--- a/tests/test_preflight_failure_normalizer.py
+++ b/tests/test_preflight_failure_normalizer.py
@@ -35,3 +35,9 @@ def test_execution_record_required_maps_to_inventory_regression() -> None:
     report = {"invariant_violations": ["PR_PYTEST_EXECUTION_RECORD_REQUIRED"]}
     result = normalize_preflight_failure(report)
     assert result["failure_class"] == "test_inventory_regression"
+
+
+def test_degraded_ref_resolution_pr_block_maps_to_inventory_regression() -> None:
+    report = {"invariant_violations": ["DEGRADED_REF_RESOLUTION_PR_BLOCK"]}
+    result = normalize_preflight_failure(report)
+    assert result["failure_class"] == "test_inventory_regression"

--- a/tests/test_pytest_selection_integrity.py
+++ b/tests/test_pytest_selection_integrity.py
@@ -83,3 +83,27 @@ def test_allows_bounded_equivalence_when_enabled(tmp_path: Path) -> None:
     )
     assert result.decision == "ALLOW"
     assert result.blocking_reasons == []
+
+
+def test_payload_includes_provenance_binding_fields(tmp_path: Path) -> None:
+    result = evaluate_pytest_selection_integrity(
+        changed_paths=["scripts/run_contract_preflight.py"],
+        selected_test_targets=["tests/test_contract_preflight.py"],
+        required_test_targets=["tests/test_contract_preflight.py"],
+        pytest_execution_record={"executed": True, "selection_reason_codes": []},
+        policy_path=_policy_path(tmp_path),
+        generated_at="2026-04-14T00:00:00Z",
+        provenance={
+            "source_commit_sha": "abc123",
+            "source_head_ref": "refs/pull/1/head",
+            "workflow_run_id": "123",
+            "producer_script": "scripts/run_contract_preflight.py",
+            "produced_at": "2026-04-14T00:00:00Z",
+            "source_pytest_execution_record_ref": "outputs/contract_preflight/pytest_execution_record.json",
+            "source_pytest_execution_record_hash": "a" * 64,
+            "artifact_hash": "b" * 64,
+        },
+    )
+    assert result.payload["schema_version"] == "1.1.0"
+    assert result.payload["source_pytest_execution_record_ref"] == "outputs/contract_preflight/pytest_execution_record.json"
+    assert result.payload["artifact_hash"] == "b" * 64


### PR DESCRIPTION
### Motivation
- Close the three mandatory RTX-01 PR trust-seam findings by preventing unbound/forged artifact refs, removing WARN as a PR pass-equivalent, and ensuring degraded/ref-failure path-resolution fails closed for PRs. 
- The preflight/workflow seam previously accepted loose `*_ref` paths, lacked same-run provenance binding, treated `WARN` as pass-equivalent for PRs, and narrowed degraded fallback to `contracts/` which risked seam drift. 

### Description
- Enforce canonical preflight-owned pytest artifact paths and same-run provenance/linkage checks by validating canonical refs `outputs/contract_preflight/pytest_execution_record.json` and `outputs/contract_preflight/pytest_selection_integrity_result.json` in runtime and workflows. 
- Add provenance fields and deterministic artifact hashing to pytest artifacts and selection results (`source_commit_sha`, `source_head_ref`, `workflow_run_id`, `producer_script`, `produced_at`, `artifact_hash`) and require cross-artifact linkage (`source_pytest_execution_record_ref`, `source_pytest_execution_record_hash`) in `pytest_selection_integrity_result` and the preflight result. 
- Make PR semantics fail-closed for warnings: `WARN` is no longer pass-equivalent for `pull_request` and PR control mapping only treats `ALLOW` as pass; workflow checks were updated in `artifact-boundary.yml` and `pr-autofix-contract-preflight.yml`. 
- Expand governed changed-path fallback to include `contracts/`, `scripts/`, `spectrum_systems/`, `.github/workflows/`, and `docs/governance/`, and fail-closed when exhaustive governed-surface coverage cannot be proven, emitting explicit invariant reason codes such as `DEGRADED_REF_RESOLUTION_PR_BLOCK`, `NON_EXHAUSTIVE_GOVERNED_PATH_RESOLUTION`, and `GOVERNED_SURFACE_DIFF_INCOMPLETE`. 
- Bumped and hardened contracts and examples: `pytest_execution_record` → `1.1.0`, `pytest_selection_integrity_result` → `1.1.0`, `contract_preflight_result_artifact` → `1.5.0`, updated `contracts/standards-manifest.json`, examples, runtime producers (`scripts/run_contract_preflight.py`) and selection logic (`spectrum_systems/modules/runtime/pytest_selection_integrity.py`). 
- Added and updated tests to prove canonical-ref blocking, provenance mismatch blocking, PR WARN blocking, degraded PR path-resolution blocking, and preserved valid ALLOW path; also updated preflight failure normalizer to map new invariants. 

### Testing
- Ran `python -m pytest -q tests/test_artifact_boundary_workflow_pytest_enforcement.py`, which passed. 
- Ran `python -m pytest -q tests/test_contract_preflight.py`, which passed. 
- Ran `python -m pytest -q tests/test_pytest_selection_integrity.py`, which passed. 
- Ran `python -m pytest -q tests/test_preflight_failure_normalizer.py`, which passed. 
- Ran `python scripts/run_contract_enforcement.py` for manifest/contract checks, which exited successfully with zero failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de68ba2bf08329b3bae859f846ca37)