### PR TITLE
PYX-02: make governed pytest a first-class PR-visible check

### DIFF
--- a/.github/workflows/artifact-boundary.yml
+++ b/.github/workflows/artifact-boundary.yml
@@ -60,7 +60,8 @@ jobs:
       - name: Validate orchestration boundaries and artifact-bus schema
         run: python scripts/validate_orchestration_boundaries.py
 
-  contract-preflight:
+  pytest-pr:
+    name: PR / pytest
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -92,7 +93,7 @@ jobs:
             echo "head_ref=HEAD" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Run contract preflight gate
+      - name: Run governed pytest preflight gate
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
@@ -278,7 +279,7 @@ PY
       - enforce-artifact-boundary
       - validate-module-architecture
       - validate-orchestration-boundaries
-      - contract-preflight
+      - pytest-pr
       - system-registry-guard
     runs-on: ubuntu-latest
     steps:

--- a/docs/review-actions/PLAN-PYX-02-2026-04-14.md
+++ b/docs/review-actions/PLAN-PYX-02-2026-04-14.md
@@ -7,18 +7,29 @@ BUILD
 PYX-02
 
 ## Objective
-Restore mandatory pull_request pytest execution in the real preflight enforcement seam and fail closed when execution evidence is missing, non-authoritative, or inconsistent.
+Make governed pytest enforcement a distinct and stable pull-request-visible check without weakening artifact-first fail-closed trust enforcement.
 
-## Scope
-1. Trace and document the live PR workflow execution chain and root cause in `docs/reviews/PYX-02_pr_pytest_execution_path_review.md`.
-2. Harden canonical preflight runtime (`scripts/run_contract_preflight.py`) to emit deterministic pytest execution evidence artifact and block PR trust when evidence invariants fail.
-3. Update workflow enforcement (`.github/workflows/artifact-boundary.yml`) to validate preflight-owned pytest execution evidence artifact before allowing trusted outcomes.
-4. Add/extend contract schemas/examples for pytest execution evidence and preflight artifact linkage.
-5. Add focused tests for workflow path assertions and fail-closed preflight behavior.
-6. Update standards manifest registrations/version for any new contract artifacts.
+## Declared files
 
-## Validation
-- `pytest tests/test_contract_preflight.py`
-- `pytest tests/test_artifact_boundary_workflow_pytest_enforcement.py`
-- `pytest tests/test_contracts.py tests/test_contract_enforcement.py tests/test_contract_bootstrap.py`
-- `python scripts/run_contract_enforcement.py`
+| File | Change type | Reason |
+| --- | --- | --- |
+| .github/workflows/artifact-boundary.yml | MODIFY | Promote governed preflight pytest enforcement job to an explicit PR-visible pytest check name while preserving canonical enforcement logic. |
+| tests/test_artifact_boundary_workflow_pytest_enforcement.py | MODIFY | Assert workflow visibility semantics and stable required-check naming for the explicit pytest PR job. |
+| docs/reviews/PYX-02_visible_pytest_pr_check_review.md | CREATE | Record root cause, exact job/check naming, and operator guidance for required status checks. |
+
+## Contracts touched
+None.
+
+## Tests that must pass after execution
+1. `python -m pytest -q tests/test_artifact_boundary_workflow_pytest_enforcement.py`
+2. `python -m pytest -q tests/test_contract_preflight.py`
+3. `python -m pytest -q tests/test_pytest_selection_integrity.py`
+4. `python scripts/run_contract_enforcement.py`
+
+## Scope exclusions
+- Do not weaken or bypass artifact-boundary or contract-preflight trust checks.
+- Do not redesign preflight runtime logic in `scripts/run_contract_preflight.py` unless strictly required.
+- Do not replace artifact-based trust with log-based assertions.
+
+## Dependencies
+- Existing preflight and artifact-boundary trust seams already merged in current branch.

--- a/docs/reviews/PYX-02_visible_pytest_pr_check_review.md
+++ b/docs/reviews/PYX-02_visible_pytest_pr_check_review.md
@@ -1,0 +1,65 @@
+# PYX-02 — Visible pytest PR check review
+
+## 1. Intent
+Establish pytest as a first-class, explicit, stable pull-request check on the GitHub merge surface while preserving artifact-first, fail-closed enforcement through the existing governed contract preflight path.
+
+## 2. Root cause of missing PR-visible pytest signal
+The workflow had a dedicated `contract-preflight` job that performed authoritative pytest execution and selection-integrity trust checks, but the PR UI signal was operator-ambiguous because:
+- the authoritative job name was not pytest-explicit, and
+- a separate non-authoritative redundancy job (`run-pytest`) existed with a pytest-facing label, which diluted operator clarity about which check was trust-authoritative.
+
+## 3. Files added
+- `docs/reviews/PYX-02_visible_pytest_pr_check_review.md`
+
+## 4. Files modified
+- `.github/workflows/artifact-boundary.yml`
+- `tests/test_artifact_boundary_workflow_pytest_enforcement.py`
+
+## 5. Exact workflow/job names before and after
+Workflow name (unchanged):
+- `artifact-boundary`
+
+Before:
+- `contract-preflight` (authoritative preflight/pytest trust enforcement)
+- `run-pytest` (non-authoritative redundancy)
+
+After:
+- `pytest-pr` with explicit display name `PR / pytest` (authoritative preflight/pytest trust enforcement)
+- `run-pytest` (non-authoritative redundancy), now explicitly dependent on `pytest-pr`
+
+## 6. How single-source-of-truth trust enforcement was preserved
+- No trust logic was duplicated into a weaker standalone path.
+- The same governed preflight execution path (`scripts/run_contract_preflight.py`) remains the authority.
+- The explicit pytest-visible PR check is a rename/relabel of the authoritative preflight job surface, not an independent lightweight pytest runner.
+- Existing fail-closed assertions remain intact in that job for:
+  - missing `pytest_execution_record_ref`
+  - missing/blocked `pytest_selection_integrity_result_ref`
+  - non-canonical artifact refs
+  - provenance/linkage mismatches
+  - PR `WARN` non-pass semantics
+
+## 7. Which status check should be marked required
+Configure the required status check as:
+- **`PR / pytest`**
+
+This is the explicit, stable, operator-visible check name for governed pytest trust enforcement on pull requests.
+
+## 8. Tests added/updated
+Updated:
+- `tests/test_artifact_boundary_workflow_pytest_enforcement.py`
+  - added assertions that the workflow defines explicit job id `pytest-pr`
+  - added assertion for stable visible job name `PR / pytest`
+  - added assertion that downstream redundancy job depends on `pytest-pr` and no longer references `contract-preflight`
+
+## 9. Validation commands run
+1. `python -m pytest -q tests/test_artifact_boundary_workflow_pytest_enforcement.py`
+2. `python -m pytest -q tests/test_contract_preflight.py`
+3. `python -m pytest -q tests/test_pytest_selection_integrity.py`
+4. `python scripts/run_contract_enforcement.py`
+
+## 10. Exact results
+- All four required validation commands passed in the local execution environment.
+
+## 11. Remaining risks
+- Branch protection in GitHub must be updated to require `PR / pytest`; until that setting is changed, operator visibility is improved but protection policy may still target an old check name.
+- If GitHub job display naming conventions change, required-check configuration should continue targeting the explicit job name surfaced by workflow runs.

--- a/tests/test_artifact_boundary_workflow_pytest_enforcement.py
+++ b/tests/test_artifact_boundary_workflow_pytest_enforcement.py
@@ -11,6 +11,19 @@ def test_artifact_boundary_workflow_uses_contract_preflight_on_pull_request() ->
     assert 'python scripts/run_contract_preflight.py' in text
 
 
+def test_artifact_boundary_workflow_defines_explicit_pytest_pr_job_name() -> None:
+    text = ARTIFACT_BOUNDARY_WORKFLOW.read_text(encoding='utf-8')
+    assert 'pytest-pr:' in text
+    assert 'name: PR / pytest' in text
+    assert 'Run governed pytest preflight gate' in text
+
+
+def test_artifact_boundary_redundant_pytest_job_depends_on_explicit_pytest_pr_job() -> None:
+    text = ARTIFACT_BOUNDARY_WORKFLOW.read_text(encoding='utf-8')
+    assert '- pytest-pr' in text
+    assert '- contract-preflight' not in text
+
+
 def test_artifact_boundary_workflow_does_not_bypass_artifact_validation_on_preflight_exit_zero() -> None:
     text = ARTIFACT_BOUNDARY_WORKFLOW.read_text(encoding='utf-8')
     assert 'if [[ "$preflight_exit" -ne 0 ]]; then' in text


### PR DESCRIPTION
### Motivation
- The PR UI lacked a clear, operator-visible pytest status despite authoritative pytest enforcement living in the preflight job, causing ambiguity about which check is trust-authoritative. 
- The change must preserve artifact-first, fail-closed trust (no weakening, no duplicate lightweight checks, and no reliance on logs). 
- Provide a stable check name that operators can mark as a required status check in branch protection.

### Description
- Renamed the authoritative preflight job in `.github/workflows/artifact-boundary.yml` from the implicit `contract-preflight` surface to job id `pytest-pr` with display name `PR / pytest`, while keeping the same governed call to `python scripts/run_contract_preflight.py`. 
- Rewired the non-authoritative redundancy job `run-pytest` to depend on `pytest-pr` rather than the old job id so ordering is preserved without creating a second source of truth. 
- Updated `tests/test_artifact_boundary_workflow_pytest_enforcement.py` to assert the explicit job id `pytest-pr`, visible name `PR / pytest`, and the dependency wiring. 
- Added operator review artifact `docs/reviews/PYX-02_visible_pytest_pr_check_review.md` and the plan file `docs/review-actions/PLAN-PYX-02-2026-04-14.md` documenting intent, root cause, required status-check name, and preservation of single-source-of-truth enforcement.

### Testing
- Ran `python -m pytest -q tests/test_artifact_boundary_workflow_pytest_enforcement.py` and it passed (`9 passed`). 
- Ran `python -m pytest -q tests/test_contract_preflight.py` and it passed (`75 passed`). 
- Ran `python -m pytest -q tests/test_pytest_selection_integrity.py` and it passed (`5 passed`). 
- Ran `python scripts/run_contract_enforcement.py` and it completed successfully with summary `failures=0 warnings=0 not_yet_enforceable=0`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de7460196c8329a700010d644a38a0)