### PR TITLE
AUD-02: add required-check alignment audit and pytest trust-gap backtest

### DIFF
--- a/contracts/examples/pytest_execution_record.json
+++ b/contracts/examples/pytest_execution_record.json
@@ -3,7 +3,7 @@
   "schema_version": "1.1.0",
   "event_name": "pull_request",
   "workflow_name": "artifact-boundary",
-  "workflow_job": "contract-preflight",
+  "workflow_job": "pytest-pr",
   "executed": true,
   "pytest_command": "python -m pytest -q tests/test_contract_preflight.py",
   "selected_targets": [

--- a/contracts/examples/pytest_trust_gap_backtest_result.json
+++ b/contracts/examples/pytest_trust_gap_backtest_result.json
@@ -1,0 +1,72 @@
+{
+  "artifact_type": "pytest_trust_gap_backtest_result",
+  "schema_version": "1.0.0",
+  "audit_window": {
+    "roots": [
+      "outputs",
+      "artifacts",
+      "data"
+    ],
+    "artifact_globs": [
+      "**/contract_preflight_result_artifact.json"
+    ],
+    "max_artifacts": 50,
+    "repo_root": "/workspace/spectrum-systems"
+  },
+  "evaluated_runs": 3,
+  "suspect_runs": 2,
+  "run_classifications": [
+    {
+      "run_identifier": "outputs/history/run-001/contract_preflight_result_artifact.json",
+      "evidence_refs_used": [
+        "outputs/history/run-001/contract_preflight_result_artifact.json"
+      ],
+      "classification": "suspect_missing_selection_integrity_evidence",
+      "reasons": [
+        "MISSING_PYTEST_SELECTION_INTEGRITY_ARTIFACT",
+        "MISSING_PYTEST_SELECTION_INTEGRITY_RESULT_REF",
+        "MISSING_PYTEST_EXECUTION_RECORD_REF"
+      ],
+      "confidence_level": "high",
+      "recommended_follow_up": [
+        "Retrieve canonical pytest_selection_integrity_result and verify selection_integrity_decision=ALLOW."
+      ]
+    },
+    {
+      "run_identifier": "outputs/history/run-002/contract_preflight_result_artifact.json",
+      "evidence_refs_used": [
+        "outputs/history/run-002/contract_preflight_result_artifact.json"
+      ],
+      "classification": "insufficient_evidence_to_determine",
+      "reasons": [
+        "MISSING_PYTEST_EXECUTION_ARTIFACT",
+        "MISSING_PYTEST_SELECTION_INTEGRITY_ARTIFACT"
+      ],
+      "confidence_level": "low",
+      "recommended_follow_up": [
+        "Retrieve event_name and canonical preflight refs to classify run trustworthiness."
+      ]
+    },
+    {
+      "run_identifier": "outputs/history/run-003/contract_preflight_result_artifact.json",
+      "evidence_refs_used": [
+        "outputs/history/run-003/contract_preflight_result_artifact.json",
+        "outputs/contract_preflight/pytest_execution_record.json",
+        "outputs/contract_preflight/pytest_selection_integrity_result.json"
+      ],
+      "classification": "trustworthy",
+      "reasons": [],
+      "confidence_level": "high",
+      "recommended_follow_up": [
+        "No immediate action required."
+      ]
+    }
+  ],
+  "summary_counts": {
+    "insufficient_evidence_to_determine": 1,
+    "suspect_missing_selection_integrity_evidence": 1,
+    "trustworthy": 1
+  },
+  "final_decision": "BLOCK",
+  "generated_at": "2026-04-14T00:00:00Z"
+}

--- a/contracts/examples/required_check_alignment_audit_result.json
+++ b/contracts/examples/required_check_alignment_audit_result.json
@@ -1,0 +1,16 @@
+{
+  "artifact_type": "required_check_alignment_audit_result",
+  "schema_version": "1.0.0",
+  "expected_required_check": "PR / pytest",
+  "workflow_name": "artifact-boundary",
+  "authoritative_job_id": "pytest-pr",
+  "authoritative_display_name": "PR / pytest",
+  "local_policy_alignment_status": "aligned",
+  "live_github_alignment_status": "unknown",
+  "final_decision": "WARN",
+  "blocking_reasons": [],
+  "operator_actions_required": [
+    "Verify GitHub branch protection required status checks include exactly 'PR / pytest' and remove obsolete checks."
+  ],
+  "generated_at": "2026-04-14T00:00:00Z"
+}

--- a/contracts/schemas/pytest_trust_gap_backtest_result.schema.json
+++ b/contracts/schemas/pytest_trust_gap_backtest_result.schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/pytest_trust_gap_backtest_result.schema.json",
+  "title": "Pytest Trust Gap Backtest Result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "audit_window",
+    "evaluated_runs",
+    "suspect_runs",
+    "run_classifications",
+    "summary_counts",
+    "final_decision",
+    "generated_at"
+  ],
+  "properties": {
+    "artifact_type": {"const": "pytest_trust_gap_backtest_result"},
+    "schema_version": {"const": "1.0.0"},
+    "audit_window": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["roots", "artifact_globs", "max_artifacts", "repo_root"],
+      "properties": {
+        "roots": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+        "artifact_globs": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+        "max_artifacts": {"type": "integer", "minimum": 1},
+        "repo_root": {"type": "string", "minLength": 1}
+      }
+    },
+    "evaluated_runs": {"type": "integer", "minimum": 0},
+    "suspect_runs": {"type": "integer", "minimum": 0},
+    "run_classifications": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "run_identifier",
+          "evidence_refs_used",
+          "classification",
+          "reasons",
+          "confidence_level",
+          "recommended_follow_up"
+        ],
+        "properties": {
+          "run_identifier": {"type": "string", "minLength": 1},
+          "evidence_refs_used": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+          "classification": {
+            "type": "string",
+            "enum": [
+              "trustworthy",
+              "suspect_missing_pytest_execution_evidence",
+              "suspect_missing_selection_integrity_evidence",
+              "suspect_noncanonical_ref_acceptance",
+              "suspect_warn_pass_equivalence",
+              "suspect_degraded_ref_resolution",
+              "insufficient_evidence_to_determine"
+            ]
+          },
+          "reasons": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+          "confidence_level": {"type": "string", "enum": ["high", "medium", "low"]},
+          "recommended_follow_up": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true}
+        }
+      }
+    },
+    "summary_counts": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^(trustworthy|suspect_missing_pytest_execution_evidence|suspect_missing_selection_integrity_evidence|suspect_noncanonical_ref_acceptance|suspect_warn_pass_equivalence|suspect_degraded_ref_resolution|insufficient_evidence_to_determine)$": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "final_decision": {"type": "string", "enum": ["PASS", "WARN", "BLOCK"]},
+    "generated_at": {"type": "string", "format": "date-time"}
+  }
+}

--- a/contracts/schemas/required_check_alignment_audit_result.schema.json
+++ b/contracts/schemas/required_check_alignment_audit_result.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/required_check_alignment_audit_result.schema.json",
+  "title": "Required Check Alignment Audit Result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "expected_required_check",
+    "workflow_name",
+    "authoritative_job_id",
+    "authoritative_display_name",
+    "local_policy_alignment_status",
+    "live_github_alignment_status",
+    "final_decision",
+    "blocking_reasons",
+    "operator_actions_required",
+    "generated_at"
+  ],
+  "properties": {
+    "artifact_type": {"const": "required_check_alignment_audit_result"},
+    "schema_version": {"const": "1.0.0"},
+    "expected_required_check": {"type": "string", "minLength": 1},
+    "workflow_name": {"type": "string", "minLength": 1},
+    "authoritative_job_id": {"type": "string", "minLength": 1},
+    "authoritative_display_name": {"type": "string", "minLength": 1},
+    "local_policy_alignment_status": {
+      "type": "string",
+      "enum": ["aligned", "contradiction"]
+    },
+    "live_github_alignment_status": {
+      "type": "string",
+      "enum": ["aligned", "misaligned", "unknown"]
+    },
+    "final_decision": {
+      "type": "string",
+      "enum": ["PASS", "WARN", "BLOCK"]
+    },
+    "blocking_reasons": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1},
+      "uniqueItems": true
+    },
+    "operator_actions_required": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1},
+      "uniqueItems": true
+    },
+    "generated_at": {"type": "string", "format": "date-time"}
+  }
+}

--- a/contracts/standards-manifest.json
+++ b/contracts/standards-manifest.json
@@ -1,11 +1,11 @@
 {
   "artifact_type": "standards_manifest",
   "artifact_id": "STD-CONTRACTS",
-  "artifact_version": "1.3.134",
+  "artifact_version": "1.3.135",
   "schema_version": "1.3.99",
-  "standards_version": "1.0.84",
-  "record_id": "REC-STD-2026-04-14-TSI-01-SELECTION-INTEGRITY-AUDIT",
-  "run_id": "run-20260414T000000Z-tsi-01-selection-integrity-audit",
+  "standards_version": "1.0.85",
+  "record_id": "REC-STD-2026-04-14-AUD-02-REQUIRED-CHECK-ALIGNMENT-AND-TRUST-GAP-BACKTEST",
+  "run_id": "run-20260414T000000Z-aud-02-required-check-alignment-and-trust-gap-backtest",
   "created_at": "2026-04-14T00:00:00Z",
   "created_by": {
     "name": "Spectrum Systems Architecture Team",
@@ -15,7 +15,7 @@
     "contact": "architecture@spectrum-systems.test"
   },
   "source_repo": "nicklasorte/spectrum-systems",
-  "source_repo_version": "1.3.134",
+  "source_repo_version": "1.3.135",
   "input_artifacts": [
     {
       "artifact_id": "STD-CONTRACTS",
@@ -8830,6 +8830,32 @@
       "last_updated_in": "1.0.84",
       "example_path": "contracts/examples/pytest_trust_gap_audit_result.json",
       "notes": "TSI-01 deterministic read-only audit artifact for historical pytest trust-gap evidence."
+    },
+    {
+      "artifact_type": "pytest_trust_gap_backtest_result",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.135",
+      "last_updated_in": "1.3.135",
+      "example_path": "contracts/examples/pytest_trust_gap_backtest_result.json",
+      "notes": "AUD-02 deterministic read-only backtest artifact classifying recent PR/preflight trust-gap exposure and confidence."
+    },
+    {
+      "artifact_type": "required_check_alignment_audit_result",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.135",
+      "last_updated_in": "1.3.135",
+      "example_path": "contracts/examples/required_check_alignment_audit_result.json",
+      "notes": "AUD-02 deterministic required-status-check alignment artifact proving workflow/policy consistency and explicit unknown live branch-protection state."
     }
   ]
 }

--- a/docs/governance/required_pr_checks.json
+++ b/docs/governance/required_pr_checks.json
@@ -1,0 +1,7 @@
+{
+  "policy_version": "1.0.0",
+  "workflow": "artifact-boundary",
+  "authoritative_job_id": "pytest-pr",
+  "authoritative_display_name": "PR / pytest",
+  "required_status_check_name": "PR / pytest"
+}

--- a/docs/review-actions/PLAN-AUD-02-2026-04-14.md
+++ b/docs/review-actions/PLAN-AUD-02-2026-04-14.md
@@ -1,0 +1,53 @@
+# Plan — AUD-02 — 2026-04-14
+
+## Prompt type
+PLAN
+
+## Roadmap item
+AUD-02 — Required-check alignment audit + pytest trust-gap backtest hardening
+
+## Objective
+Add deterministic, fail-closed audit execution that verifies canonical required PR pytest check alignment and classifies recent trust-gap exposure from governed artifacts.
+
+## Declared files
+
+| File | Change type | Reason |
+| --- | --- | --- |
+| docs/governance/required_pr_checks.json | CREATE | Canonical governed declaration for required PR status check target. |
+| spectrum_systems/modules/runtime/required_check_alignment_audit.py | CREATE | Deterministic runtime audit logic for workflow/policy alignment and live-status unknown handling. |
+| scripts/run_required_check_alignment_audit.py | CREATE | Thin CLI entrypoint emitting required-check alignment audit artifact. |
+| contracts/schemas/required_check_alignment_audit_result.schema.json | CREATE | Contract for required-check alignment audit artifact. |
+| contracts/examples/required_check_alignment_audit_result.json | CREATE | Golden example for the required-check alignment audit artifact. |
+| spectrum_systems/modules/runtime/pytest_trust_gap_audit.py | MODIFY | Extend trust-gap audit classification model and deterministic backtest artifact fields. |
+| scripts/run_pytest_trust_gap_audit.py | MODIFY | Wire updated backtest scope/result structure and deterministic output shape. |
+| contracts/schemas/pytest_trust_gap_audit_result.schema.json | MODIFY | Update schema for richer backtest classifications and summary fields. |
+| contracts/examples/pytest_trust_gap_audit_result.json | MODIFY | Keep example aligned to updated schema and semantics. |
+| contracts/standards-manifest.json | MODIFY | Register new audit artifact contract and version updates. |
+| tests/test_required_check_alignment_audit.py | CREATE | Focused deterministic tests for pass/block/unknown/drift modes. |
+| tests/test_pytest_trust_gap_audit.py | MODIFY | Focused tests for new suspect and insufficient-evidence classifications. |
+| tests/test_contracts.py | MODIFY | Validate new contract example and updated trust-gap example conformance. |
+| docs/reviews/AUD-02_required_check_alignment_and_trust_gap_audit.md | CREATE | Structured review + delivery report with findings, uncertainty, and operator actions. |
+
+## Contracts touched
+- `required_check_alignment_audit_result` (new)
+- `pytest_trust_gap_audit_result` (updated fields/classifications)
+- `contracts/standards-manifest.json` version + contract registry entry updates
+
+## Tests that must pass after execution
+1. `python -m pytest -q tests/test_artifact_boundary_workflow_pytest_enforcement.py`
+2. `python -m pytest -q tests/test_contract_preflight.py`
+3. `python -m pytest -q tests/test_pytest_selection_integrity.py`
+4. `python -m pytest -q tests/test_required_check_alignment_audit.py`
+5. `python -m pytest -q tests/test_pytest_trust_gap_audit.py`
+6. `python -m pytest -q tests/test_contracts.py`
+7. `python scripts/run_contract_enforcement.py`
+8. `python scripts/run_required_check_alignment_audit.py`
+9. `python scripts/run_pytest_trust_gap_audit.py`
+
+## Scope exclusions
+- Do not change existing preflight gates or workflow enforcement semantics.
+- Do not add network calls or live GitHub API dependencies.
+- Do not refactor unrelated runtime modules or test suites.
+
+## Dependencies
+- Existing authoritative workflow job naming in `.github/workflows/artifact-boundary.yml` remains the source for expected check naming.

--- a/docs/reviews/AUD-02_required_check_alignment_and_trust_gap_audit.md
+++ b/docs/reviews/AUD-02_required_check_alignment_and_trust_gap_audit.md
@@ -1,0 +1,161 @@
+# AUD-02 Required Check Alignment and Trust Gap Audit
+
+## Prompt type
+REVIEW
+
+## 1. Intent
+Implement a surgical, deterministic audit layer that verifies the authoritative PR-visible pytest required check target (`PR / pytest`) and backtests recent local preflight artifacts for historical trust-gap exposure without weakening existing preflight trust controls.
+
+## 2. What was audited
+- Workflow authority surface: `.github/workflows/artifact-boundary.yml` (`pytest-pr`, display `PR / pytest`).
+- Governed required-check policy declaration: `docs/governance/required_pr_checks.json`.
+- Optional local required-check evidence surfaces (if present):
+  - `.github/branch_protection_rules.json`
+  - `.github/required_status_checks.json`
+- Optional live GitHub evidence payload (operator-supplied path).
+- Recent preflight artifacts discovered under bounded local roots:
+  - `outputs/**/contract_preflight_result_artifact.json`
+  - `artifacts/**/contract_preflight_result_artifact.json`
+  - `data/**/contract_preflight_result_artifact.json`
+
+## 3. Expected required status check
+- Workflow: `artifact-boundary`
+- Authoritative job id: `pytest-pr`
+- Authoritative display name: `PR / pytest`
+- Required status check name: `PR / pytest`
+
+## 4. Whether local repo policy aligns
+- Local governed declaration aligns with workflow authority (`docs/governance/required_pr_checks.json`).
+- Audit semantics fail closed on drift:
+  - policy/workflow/job/display mismatch => `BLOCK`
+  - local required-check evidence referencing obsolete `contract-preflight` => `BLOCK`
+
+## 5. Whether live GitHub protection could be proven
+- Current run outcome: **could not be proven from repo-local evidence alone**.
+- Audit emits `live_github_alignment_status=unknown` and `final_decision=WARN` unless explicit live evidence is supplied and aligned.
+- Unknown is never treated as pass-equivalent.
+
+## 6. Backtest window and evidence sources
+- Window: bounded local scan roots (`outputs`, `artifacts`, `data`) with deterministic max artifact cap.
+- Primary trust evidence: governed preflight artifacts and canonical refs:
+  - `pytest_execution`
+  - `pytest_execution_record_ref`
+  - `pytest_selection_integrity`
+  - `pytest_selection_integrity_result_ref`
+- Raw logs are not primary trust evidence.
+
+## 7. Suspect runs / findings
+- Classification categories implemented:
+  - `trustworthy`
+  - `suspect_missing_pytest_execution_evidence`
+  - `suspect_missing_selection_integrity_evidence`
+  - `suspect_noncanonical_ref_acceptance`
+  - `suspect_warn_pass_equivalence`
+  - `suspect_degraded_ref_resolution`
+  - `insufficient_evidence_to_determine`
+- Current local sample scan result (this run):
+  - evaluated runs: `0`
+  - suspect runs: `0`
+  - final decision: `PASS`
+- Deterministic output artifact path:
+  - `outputs/pytest_trust_gap_audit/pytest_trust_gap_backtest_result.json`
+
+## 8. Confidence limits
+- Backtest is intentionally bounded to local artifacts available in-repo.
+- Missing historical artifacts are classified as explicit uncertainty (`insufficient_evidence_to_determine`), not inferred as clean.
+- Live branch-protection configuration remains operator-owned unless provided as explicit evidence payload.
+
+## 9. Required operator actions
+1. Verify GitHub branch protection for target branches requires status check `PR / pytest`.
+2. Remove obsolete required checks (e.g., `contract-preflight`) if still configured in GitHub settings.
+3. Optionally export branch-protection required-check evidence as JSON and rerun:
+   - `python scripts/run_required_check_alignment_audit.py --live-github-evidence-path <path-to-json>`
+
+## 10. Final verdict
+- **Local governance and workflow surfaces are aligned.**
+- **Live GitHub branch-protection alignment is currently unknown without operator-supplied evidence.**
+- **Trust-gap backtest path is implemented with explicit suspect/uncertainty classification and deterministic artifact output.**
+
+---
+
+## Mandatory delivery contract report
+
+### 1. Intent
+Deliver AUD-02 required-check alignment and trust-gap backtest enforcement with deterministic governed artifacts and explicit unknown-state handling.
+
+### 2. Files added
+- `docs/review-actions/PLAN-AUD-02-2026-04-14.md`
+- `docs/governance/required_pr_checks.json`
+- `scripts/run_required_check_alignment_audit.py`
+- `spectrum_systems/modules/runtime/required_check_alignment_audit.py`
+- `contracts/schemas/required_check_alignment_audit_result.schema.json`
+- `contracts/examples/required_check_alignment_audit_result.json`
+- `contracts/schemas/pytest_trust_gap_backtest_result.schema.json`
+- `contracts/examples/pytest_trust_gap_backtest_result.json`
+- `tests/test_required_check_alignment_audit.py`
+
+### 3. Files modified
+- `scripts/run_pytest_trust_gap_audit.py`
+- `spectrum_systems/modules/runtime/pytest_trust_gap_audit.py`
+- `tests/test_pytest_trust_gap_audit.py`
+- `tests/test_contracts.py`
+- `contracts/examples/pytest_execution_record.json`
+- `contracts/standards-manifest.json`
+
+### 4. New artifacts/contracts introduced
+- `required_check_alignment_audit_result` (schema + example + runtime + CLI)
+- `pytest_trust_gap_backtest_result` (schema + example + runtime + CLI output)
+- Governed policy declaration for required PR check target: `docs/governance/required_pr_checks.json`
+
+### 5. Policy decisions
+- Canonical required status check is `PR / pytest`.
+- PASS requires positive proof of live alignment.
+- Unknown live alignment remains WARN + operator action required.
+- Drift/contradiction is BLOCK.
+
+### 6. Audit logic implemented
+- Workflow authority extraction from `.github/workflows/artifact-boundary.yml`.
+- Policy/workflow/job/display consistency verification.
+- Optional local and live required-check evidence comparison.
+- Deterministic final decisions: `PASS` / `WARN` / `BLOCK`.
+
+### 7. Backtest logic implemented
+- Bounded deterministic scan for local preflight artifacts.
+- Artifact-first classification using governed evidence refs.
+- Explicit suspect classes for missing execution, missing selection integrity, noncanonical refs, WARN/pass equivalence, degraded resolution, and insufficient evidence.
+- Deterministic summary counts and final decision.
+
+### 8. Tests added/updated
+- Added: `tests/test_required_check_alignment_audit.py`
+- Updated: `tests/test_pytest_trust_gap_audit.py`
+- Updated contract example validation coverage in `tests/test_contracts.py`
+
+### 9. Validation commands run
+1. `python -m pytest -q tests/test_artifact_boundary_workflow_pytest_enforcement.py`
+2. `python -m pytest -q tests/test_contract_preflight.py`
+3. `python -m pytest -q tests/test_pytest_selection_integrity.py`
+4. `python -m pytest -q tests/test_required_check_alignment_audit.py`
+5. `python -m pytest -q tests/test_pytest_trust_gap_audit.py`
+6. `python -m pytest -q tests/test_contracts.py`
+7. `python scripts/run_contract_enforcement.py`
+8. `python scripts/run_required_check_alignment_audit.py`
+9. `python scripts/run_pytest_trust_gap_audit.py`
+
+### 10. Exact results
+- All required pytest suites passed.
+- `run_contract_enforcement.py` passed with `failures=0 warnings=0 not_yet_enforceable=0`.
+- `run_required_check_alignment_audit.py` produced:
+  - `outputs/required_check_alignment_audit/required_check_alignment_audit_result.json`
+  - `final_decision=WARN` (live alignment unknown)
+- `run_pytest_trust_gap_audit.py` produced:
+  - `outputs/pytest_trust_gap_audit/pytest_trust_gap_backtest_result.json`
+  - `evaluated_runs=0`, `suspect_runs=0`, `final_decision=PASS`
+
+### 11. Operator actions still required
+- Confirm GitHub branch protection required check includes `PR / pytest`.
+- Remove obsolete required checks if configured.
+- Provide live branch-protection evidence JSON for PASS-grade proof when needed.
+
+### 12. Remaining risks
+- Repo-local audits cannot independently prove live GitHub settings without explicit exported evidence.
+- Historical backtest confidence depends on retention/completeness of local governed artifacts.

--- a/scripts/run_pytest_trust_gap_audit.py
+++ b/scripts/run_pytest_trust_gap_audit.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run deterministic pytest trust-gap audit over recent local preflight artifacts."""
+"""Run deterministic pytest trust-gap backtest over recent local preflight artifacts."""
 
 from __future__ import annotations
 
@@ -16,10 +16,10 @@ from spectrum_systems.modules.runtime.pytest_trust_gap_audit import run_pytest_t
 
 
 def _parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Run deterministic pytest trust-gap audit.")
+    parser = argparse.ArgumentParser(description="Run deterministic pytest trust-gap backtest.")
     parser.add_argument("--scan-root", action="append", default=[], help="Scan root (repeatable). Defaults to outputs/artifacts/data.")
     parser.add_argument("--max-artifacts", type=int, default=50, help="Maximum artifacts to evaluate.")
-    parser.add_argument("--output-dir", default="outputs/pytest_trust_gap_audit", help="Audit output directory.")
+    parser.add_argument("--output-dir", default="outputs/pytest_trust_gap_audit", help="Backtest output directory.")
     return parser.parse_args()
 
 
@@ -38,9 +38,9 @@ def main() -> int:
 
     output_dir = Path(args.output_dir) if Path(args.output_dir).is_absolute() else (REPO_ROOT / args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
-    result_path = output_dir / "pytest_trust_gap_audit_result.json"
+    result_path = output_dir / "pytest_trust_gap_backtest_result.json"
     result_path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    print(json.dumps({"result_path": str(result_path), "scanned_artifact_count": result["scanned_artifact_count"], "suspect_count": result["suspect_count"]}, indent=2, sort_keys=True))
+    print(json.dumps({"result_path": str(result_path), "evaluated_runs": result["evaluated_runs"], "suspect_runs": result["suspect_runs"], "final_decision": result["final_decision"]}, indent=2, sort_keys=True))
     return 0
 
 

--- a/scripts/run_required_check_alignment_audit.py
+++ b/scripts/run_required_check_alignment_audit.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Run deterministic required-check alignment audit for PR / pytest."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from spectrum_systems.modules.runtime.required_check_alignment_audit import run_required_check_alignment_audit  # noqa: E402
+
+
+DEFAULT_LOCAL_EVIDENCE_PATHS = [
+    ".github/branch_protection_rules.json",
+    ".github/required_status_checks.json",
+]
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run required-check alignment audit.")
+    parser.add_argument("--workflow-path", default=".github/workflows/artifact-boundary.yml")
+    parser.add_argument("--policy-path", default="docs/governance/required_pr_checks.json")
+    parser.add_argument("--local-evidence-path", action="append", default=[])
+    parser.add_argument("--live-github-evidence-path", default="")
+    parser.add_argument("--output-dir", default="outputs/required_check_alignment_audit")
+    return parser.parse_args()
+
+
+def _load_json(path: Path) -> dict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"not_object:{path}")
+    return payload
+
+
+def _load_workflow_payload(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    workflow_name_match = re.search(r"(?m)^name:\s*(.+?)\s*$", text)
+    workflow_name = workflow_name_match.group(1).strip() if workflow_name_match else "artifact-boundary"
+    job_name = ""
+    lines = text.splitlines()
+    inside_pytest_job = False
+    for line in lines:
+        if re.match(r"^\s{2}pytest-pr:\s*$", line):
+            inside_pytest_job = True
+            continue
+        if inside_pytest_job and re.match(r"^\s{2}[A-Za-z0-9_.-]+:\s*$", line):
+            break
+        if inside_pytest_job:
+            match = re.match(r"^\s{4}name:\s*(.+?)\s*$", line)
+            if match:
+                job_name = match.group(1).strip()
+                break
+    return {"name": workflow_name, "jobs": {"pytest-pr": {"name": job_name}}}
+
+
+def main() -> int:
+    args = _parse_args()
+    workflow_path = Path(args.workflow_path) if Path(args.workflow_path).is_absolute() else (REPO_ROOT / args.workflow_path)
+    policy_path = Path(args.policy_path) if Path(args.policy_path).is_absolute() else (REPO_ROOT / args.policy_path)
+
+    workflow_payload = _load_workflow_payload(workflow_path)
+    policy_payload = _load_json(policy_path)
+
+    candidate_local_paths = args.local_evidence_path or DEFAULT_LOCAL_EVIDENCE_PATHS
+    local_payloads: list[dict] = []
+    for raw_path in candidate_local_paths:
+        path = Path(raw_path) if Path(raw_path).is_absolute() else (REPO_ROOT / raw_path)
+        if path.is_file():
+            local_payloads.append(_load_json(path))
+
+    live_payload = None
+    if args.live_github_evidence_path:
+        live_path = Path(args.live_github_evidence_path)
+        if not live_path.is_absolute():
+            live_path = REPO_ROOT / args.live_github_evidence_path
+        if live_path.is_file():
+            live_payload = _load_json(live_path)
+
+    result = run_required_check_alignment_audit(
+        workflow_payload=workflow_payload,
+        required_policy_payload=policy_payload,
+        local_required_checks_payloads=local_payloads,
+        live_required_checks_payload=live_payload,
+    )
+
+    output_dir = Path(args.output_dir) if Path(args.output_dir).is_absolute() else (REPO_ROOT / args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    result_path = output_dir / "required_check_alignment_audit_result.json"
+    result_path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"result_path": str(result_path), "final_decision": result["final_decision"]}, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/spectrum_systems/modules/runtime/pytest_trust_gap_audit.py
+++ b/spectrum_systems/modules/runtime/pytest_trust_gap_audit.py
@@ -1,8 +1,9 @@
-"""Deterministic read-only audit for pytest trust gaps in recent preflight artifacts."""
+"""Deterministic read-only backtest for pytest trust gaps in local preflight artifacts."""
 
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -10,6 +11,10 @@ from spectrum_systems.contracts import validate_artifact
 
 TRUSTING_DECISIONS = {"ALLOW", "WARN"}
 KNOWN_PR_EVENTS = {"pull_request", "pull_request_target", "pull_request_review", "pull_request_review_comment"}
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def _read_json(path: Path) -> dict[str, Any]:
@@ -52,14 +57,29 @@ def _is_trusting(payload: dict[str, Any]) -> bool:
     return str(payload.get("preflight_status") or "").lower() == "passed"
 
 
+def _run_identifier(payload: dict[str, Any], artifact_path: str) -> str:
+    for key in ("run_id", "trace_id", "artifact_id"):
+        value = str(payload.get(key) or "").strip()
+        if value:
+            return value
+    return artifact_path
+
+
 def classify_artifact(payload: dict[str, Any]) -> dict[str, Any]:
-    path = str(payload.get("__artifact_path") or "unknown")
+    artifact_path = str(payload.get("__artifact_path") or "unknown")
+    run_identifier = _run_identifier(payload, artifact_path)
     reasons: list[str] = []
+    evidence_refs = [artifact_path]
+    recommended_follow_up: list[str] = []
+
     trusting = _is_trusting(payload)
     event_name = _event_name(payload)
     context = "pr" if event_name in KNOWN_PR_EVENTS else ("non_pr" if event_name else "unknown")
 
     execution = payload.get("pytest_execution")
+    record_ref = str(payload.get("pytest_execution_record_ref") or "").strip()
+    if record_ref:
+        evidence_refs.append(record_ref)
     if not isinstance(execution, dict):
         reasons.append("MISSING_PYTEST_EXECUTION_ARTIFACT")
     else:
@@ -70,57 +90,107 @@ def classify_artifact(payload: dict[str, Any]) -> dict[str, Any]:
             reasons.append("PYTEST_SELECTED_TARGETS_EMPTY")
 
     selection = payload.get("pytest_selection_integrity")
+    selection_ref = str(payload.get("pytest_selection_integrity_result_ref") or "").strip()
+    if selection_ref:
+        evidence_refs.append(selection_ref)
     if not isinstance(selection, dict):
         reasons.append("MISSING_PYTEST_SELECTION_INTEGRITY_ARTIFACT")
     else:
-        if str(selection.get("selection_integrity_decision") or "BLOCK") != "ALLOW":
+        decision = str(selection.get("selection_integrity_decision") or "BLOCK")
+        if decision != "ALLOW":
             reasons.append("PYTEST_SELECTION_INTEGRITY_NOT_ALLOW")
 
-    classification = "clean_evidence"
-    if reasons:
-        classification = "weak_evidence" if context != "unknown" else "missing_evidence"
-    if context == "unknown" and reasons:
-        classification = "unable_to_evaluate"
+    if context == "pr":
+        if not record_ref:
+            reasons.append("MISSING_PYTEST_EXECUTION_RECORD_REF")
+        elif record_ref != "outputs/contract_preflight/pytest_execution_record.json":
+            reasons.append("NONCANONICAL_PYTEST_EXECUTION_RECORD_REF")
+        if not selection_ref:
+            reasons.append("MISSING_PYTEST_SELECTION_INTEGRITY_RESULT_REF")
+        elif selection_ref != "outputs/contract_preflight/pytest_selection_integrity_result.json":
+            reasons.append("NONCANONICAL_PYTEST_SELECTION_INTEGRITY_RESULT_REF")
 
-    if trusting and reasons:
-        reasons.append("TRUSTED_OUTCOME_WITH_GAP")
+    classification = "trustworthy"
+    confidence = "high"
+
+    if context == "unknown" and not reasons:
+        classification = "insufficient_evidence_to_determine"
+        confidence = "low"
+        recommended_follow_up.append("Retrieve event_name and canonical preflight refs to classify run trustworthiness.")
+    if reasons:
+        if any(reason in reasons for reason in ["MISSING_PYTEST_EXECUTION_ARTIFACT", "MISSING_PYTEST_EXECUTION_RECORD_REF", "PYTEST_EXECUTION_COUNT_TOO_SMALL", "PYTEST_SELECTED_TARGETS_EMPTY"]):
+            classification = "suspect_missing_pytest_execution_evidence"
+            recommended_follow_up.append("Retrieve canonical pytest_execution_record and verify preflight-owned pytest execution count/targets.")
+        if any(reason in reasons for reason in ["MISSING_PYTEST_SELECTION_INTEGRITY_ARTIFACT", "MISSING_PYTEST_SELECTION_INTEGRITY_RESULT_REF", "PYTEST_SELECTION_INTEGRITY_NOT_ALLOW"]):
+            classification = "suspect_missing_selection_integrity_evidence"
+            recommended_follow_up.append("Retrieve canonical pytest_selection_integrity_result and verify selection_integrity_decision=ALLOW.")
+        if any(reason in reasons for reason in ["NONCANONICAL_PYTEST_EXECUTION_RECORD_REF", "NONCANONICAL_PYTEST_SELECTION_INTEGRITY_RESULT_REF"]):
+            classification = "suspect_noncanonical_ref_acceptance"
+            recommended_follow_up.append("Validate that only canonical outputs/contract_preflight refs are accepted in PR trust decisions.")
+
+        if trusting and str((payload.get("control_signal") or {}).get("strategy_gate_decision") or "").upper() == "WARN" and context == "pr":
+            reasons.append("WARN_TRUST_EQUIVALENCE")
+            classification = "suspect_warn_pass_equivalence"
+            recommended_follow_up.append("Review preflight decision handling to ensure WARN is not pass-equivalent for pull_request events.")
+
+        if context == "unknown":
+            classification = "insufficient_evidence_to_determine"
+            confidence = "low"
+            recommended_follow_up.append("Retrieve event_name and canonical preflight refs to classify run trustworthiness.")
+        elif classification == "trustworthy":
+            classification = "suspect_degraded_ref_resolution"
+            recommended_follow_up.append("Inspect ref normalization and changed-path resolution artifacts for degraded provenance.")
+
+    if classification == "trustworthy":
+        recommended_follow_up.append("No immediate action required.")
 
     return {
-        "artifact_path": path,
+        "run_identifier": run_identifier,
+        "evidence_refs_used": sorted(set(evidence_refs)),
         "classification": classification,
-        "context": context,
-        "trusting_outcome": trusting,
-        "reason_codes": sorted(set(reasons)),
+        "reasons": sorted(set(reasons)),
+        "confidence_level": confidence,
+        "recommended_follow_up": sorted(set(recommended_follow_up)),
     }
 
 
-def run_pytest_trust_gap_audit(*, scanned_artifacts: list[dict[str, Any]], audit_scope: dict[str, Any]) -> dict[str, Any]:
+def run_pytest_trust_gap_audit(*, scanned_artifacts: list[dict[str, Any]], audit_scope: dict[str, Any], generated_at: str | None = None) -> dict[str, Any]:
     classified = [classify_artifact(item) for item in scanned_artifacts]
-    classified = sorted(classified, key=lambda item: item["artifact_path"])
-    suspects = [item for item in classified if item["classification"] in {"weak_evidence", "missing_evidence", "unable_to_evaluate"}]
+    classified = sorted(classified, key=lambda item: item["run_identifier"])
+    suspect_classes = {
+        "suspect_missing_pytest_execution_evidence",
+        "suspect_missing_selection_integrity_evidence",
+        "suspect_noncanonical_ref_acceptance",
+        "suspect_warn_pass_equivalence",
+        "suspect_degraded_ref_resolution",
+        "insufficient_evidence_to_determine",
+    }
+    suspects = [item for item in classified if item["classification"] in suspect_classes]
 
-    generated_at = "1970-01-01T00:00:00Z"
-    timestamps = sorted({str(item.get("generated_at")) for item in scanned_artifacts if isinstance(item.get("generated_at"), str)})
-    if timestamps:
-        generated_at = timestamps[-1]
+    summary_counts: dict[str, int] = {}
+    for item in classified:
+        key = item["classification"]
+        summary_counts[key] = summary_counts.get(key, 0) + 1
+
+    if not suspects:
+        final_decision = "PASS"
+    elif any(item["classification"] != "insufficient_evidence_to_determine" for item in suspects):
+        final_decision = "BLOCK"
+    else:
+        final_decision = "WARN"
 
     result = {
-        "artifact_type": "pytest_trust_gap_audit_result",
+        "artifact_type": "pytest_trust_gap_backtest_result",
         "schema_version": "1.0.0",
-        "audit_scope": audit_scope,
-        "scanned_artifact_count": len(classified),
-        "suspect_count": len(suspects),
-        "suspect_runs": suspects,
-        "summary_reason_codes": sorted({code for item in suspects for code in item.get("reason_codes", [])}),
-        "generated_at": generated_at,
-        "trace": {
-            "producer": "spectrum_systems.modules.runtime.pytest_trust_gap_audit",
-            "classification_policy": "tsi-01-trust-gap-v1",
-            "scan_mode": "repo_local_artifacts_only",
-            "read_only": True
-        }
+        "audit_window": audit_scope,
+        "evaluated_runs": len(classified),
+        "suspect_runs": len(suspects),
+        "run_classifications": classified,
+        "summary_counts": dict(sorted(summary_counts.items())),
+        "final_decision": final_decision,
+        "generated_at": generated_at or _utc_now(),
     }
-    validate_artifact(result, "pytest_trust_gap_audit_result")
+    validate_artifact(result, "pytest_trust_gap_backtest_result")
     return result
 
 

--- a/spectrum_systems/modules/runtime/required_check_alignment_audit.py
+++ b/spectrum_systems/modules/runtime/required_check_alignment_audit.py
@@ -1,0 +1,140 @@
+"""Deterministic required PR check alignment audit."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from spectrum_systems.contracts import validate_artifact
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"not_object:{path}")
+    return payload
+
+
+def _extract_authoritative_job(workflow_payload: dict[str, Any]) -> tuple[str, str, str]:
+    jobs = workflow_payload.get("jobs")
+    if not isinstance(jobs, dict):
+        raise ValueError("workflow_missing_jobs")
+    pytest_job = jobs.get("pytest-pr")
+    if not isinstance(pytest_job, dict):
+        raise ValueError("workflow_missing_pytest_pr_job")
+    display_name = str(pytest_job.get("name") or "").strip()
+    if not display_name:
+        raise ValueError("workflow_missing_pytest_pr_name")
+    workflow_name = str(workflow_payload.get("name") or "").strip() or "artifact-boundary"
+    return workflow_name, "pytest-pr", display_name
+
+
+def run_required_check_alignment_audit(
+    *,
+    workflow_payload: dict[str, Any],
+    required_policy_payload: dict[str, Any],
+    local_required_checks_payloads: list[dict[str, Any]] | None = None,
+    live_required_checks_payload: dict[str, Any] | None = None,
+    generated_at: str | None = None,
+) -> dict[str, Any]:
+    workflow_name, authoritative_job_id, authoritative_display_name = _extract_authoritative_job(workflow_payload)
+    expected_required_check = authoritative_display_name
+
+    local_required_checks_payloads = local_required_checks_payloads or []
+
+    blocking_reasons: list[str] = []
+    operator_actions_required: list[str] = []
+
+    required_status_check_name = str(required_policy_payload.get("required_status_check_name") or "").strip()
+    policy_workflow = str(required_policy_payload.get("workflow") or "").strip()
+    policy_job_id = str(required_policy_payload.get("authoritative_job_id") or "").strip()
+    policy_display_name = str(required_policy_payload.get("authoritative_display_name") or "").strip()
+
+    if required_status_check_name != expected_required_check:
+        blocking_reasons.append("POLICY_REQUIRED_CHECK_NAME_MISMATCH")
+    if policy_workflow != workflow_name:
+        blocking_reasons.append("POLICY_WORKFLOW_MISMATCH")
+    if policy_job_id != authoritative_job_id:
+        blocking_reasons.append("POLICY_JOB_ID_MISMATCH")
+    if policy_display_name != authoritative_display_name:
+        blocking_reasons.append("POLICY_DISPLAY_NAME_MISMATCH")
+
+    local_policy_alignment_status = "aligned"
+    if blocking_reasons:
+        local_policy_alignment_status = "contradiction"
+
+    local_config_reasons: list[str] = []
+    for payload in local_required_checks_payloads:
+        checks = payload.get("required_status_checks")
+        if not isinstance(checks, list):
+            continue
+        normalized = {str(item).strip() for item in checks if str(item).strip()}
+        if not normalized:
+            continue
+        if expected_required_check not in normalized:
+            local_config_reasons.append("LOCAL_REQUIRED_CHECKS_MISSING_EXPECTED")
+        obsolete = {"contract-preflight"}
+        if obsolete & normalized:
+            local_config_reasons.append("LOCAL_REQUIRED_CHECKS_REFERENCE_OBSOLETE")
+
+    if local_config_reasons:
+        local_policy_alignment_status = "contradiction"
+        blocking_reasons.extend(local_config_reasons)
+
+    live_github_alignment_status = "unknown"
+    if live_required_checks_payload is not None:
+        checks = live_required_checks_payload.get("required_status_checks")
+        if isinstance(checks, list):
+            normalized = {str(item).strip() for item in checks if str(item).strip()}
+            if expected_required_check in normalized:
+                live_github_alignment_status = "aligned"
+            else:
+                live_github_alignment_status = "misaligned"
+                blocking_reasons.append("LIVE_GITHUB_REQUIRED_CHECK_MISSING_EXPECTED")
+            if "contract-preflight" in normalized:
+                live_github_alignment_status = "misaligned"
+                blocking_reasons.append("LIVE_GITHUB_REQUIRED_CHECK_REFERENCES_OBSOLETE")
+        else:
+            blocking_reasons.append("LIVE_GITHUB_REQUIRED_CHECKS_UNREADABLE")
+            live_github_alignment_status = "unknown"
+
+    if live_github_alignment_status == "unknown":
+        operator_actions_required.append(
+            "Verify GitHub branch protection required status checks include exactly 'PR / pytest' and remove obsolete checks."
+        )
+
+    blocking_reasons = sorted(set(blocking_reasons))
+    operator_actions_required = sorted(set(operator_actions_required))
+
+    if blocking_reasons:
+        final_decision = "BLOCK"
+    elif live_github_alignment_status == "aligned":
+        final_decision = "PASS"
+    else:
+        final_decision = "WARN"
+
+    result = {
+        "artifact_type": "required_check_alignment_audit_result",
+        "schema_version": "1.0.0",
+        "expected_required_check": expected_required_check,
+        "workflow_name": workflow_name,
+        "authoritative_job_id": authoritative_job_id,
+        "authoritative_display_name": authoritative_display_name,
+        "local_policy_alignment_status": local_policy_alignment_status,
+        "live_github_alignment_status": live_github_alignment_status,
+        "final_decision": final_decision,
+        "blocking_reasons": blocking_reasons,
+        "operator_actions_required": operator_actions_required,
+        "generated_at": generated_at or _utc_now(),
+    }
+    validate_artifact(result, "required_check_alignment_audit_result")
+    return result
+
+
+__all__ = ["run_required_check_alignment_audit"]

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -796,6 +796,14 @@ class ContractSchemaTests(unittest.TestCase):
         instance = load_example("pytest_trust_gap_audit_result")
         validate_artifact(instance, "pytest_trust_gap_audit_result")
 
+    def test_pytest_trust_gap_backtest_result_example_validates(self) -> None:
+        instance = load_example("pytest_trust_gap_backtest_result")
+        validate_artifact(instance, "pytest_trust_gap_backtest_result")
+
+    def test_required_check_alignment_audit_result_example_validates(self) -> None:
+        instance = load_example("required_check_alignment_audit_result")
+        validate_artifact(instance, "required_check_alignment_audit_result")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_pytest_trust_gap_audit.py
+++ b/tests/test_pytest_trust_gap_audit.py
@@ -4,37 +4,52 @@ from spectrum_systems.contracts import validate_artifact
 from spectrum_systems.modules.runtime.pytest_trust_gap_audit import classify_artifact, run_pytest_trust_gap_audit
 
 
-def test_missing_evidence_is_flagged() -> None:
-    artifact = {"artifact_type": "contract_preflight_result_artifact", "preflight_status": "passed", "control_signal": {"strategy_gate_decision": "ALLOW"}}
-    classified = classify_artifact(artifact)
-    assert "MISSING_PYTEST_EXECUTION_ARTIFACT" in classified["reason_codes"]
-
-
-def test_weak_evidence_is_flagged() -> None:
+def test_backtest_classifies_missing_execution_evidence() -> None:
     artifact = {
         "artifact_type": "contract_preflight_result_artifact",
         "preflight_status": "passed",
         "control_signal": {"strategy_gate_decision": "ALLOW"},
-        "pytest_execution": {"event_name": "pull_request", "pytest_execution_count": 1, "selected_targets": ["tests/x.py"]},
-        "pytest_selection_integrity": {"selection_integrity_decision": "BLOCK"},
-    }
-    classified = classify_artifact(artifact)
-    assert classified["classification"] == "weak_evidence"
-    assert "PYTEST_SELECTION_INTEGRITY_NOT_ALLOW" in classified["reason_codes"]
-
-
-def test_clean_evidence_is_classified_clean() -> None:
-    artifact = {
-        "artifact_type": "contract_preflight_result_artifact",
-        "preflight_status": "passed",
-        "control_signal": {"strategy_gate_decision": "ALLOW"},
-        "pytest_execution": {"event_name": "pull_request", "pytest_execution_count": 1, "selected_targets": ["tests/x.py"]},
         "pytest_selection_integrity": {"selection_integrity_decision": "ALLOW"},
     }
     classified = classify_artifact(artifact)
-    assert classified["classification"] == "clean_evidence"
+    assert classified["classification"] == "insufficient_evidence_to_determine"
+    assert "MISSING_PYTEST_EXECUTION_ARTIFACT" in classified["reasons"]
 
 
-def test_audit_result_validates_contract() -> None:
-    result = run_pytest_trust_gap_audit(scanned_artifacts=[], audit_scope={"roots": ["outputs"], "artifact_globs": ["**/contract_preflight_result_artifact.json"], "max_artifacts": 20, "repo_root": "/repo"})
-    validate_artifact(result, "pytest_trust_gap_audit_result")
+def test_backtest_classifies_missing_selection_integrity_evidence_for_pr() -> None:
+    artifact = {
+        "artifact_type": "contract_preflight_result_artifact",
+        "preflight_status": "passed",
+        "control_signal": {"strategy_gate_decision": "ALLOW"},
+        "pytest_execution": {"event_name": "pull_request", "pytest_execution_count": 1, "selected_targets": ["tests/x.py"]},
+        "pytest_execution_record_ref": "outputs/contract_preflight/pytest_execution_record.json",
+    }
+    classified = classify_artifact(artifact)
+    assert classified["classification"] == "suspect_missing_selection_integrity_evidence"
+    assert "MISSING_PYTEST_SELECTION_INTEGRITY_ARTIFACT" in classified["reasons"]
+
+
+def test_backtest_classifies_insufficient_evidence_explicitly() -> None:
+    artifact = {
+        "artifact_type": "contract_preflight_result_artifact",
+        "control_signal": {"strategy_gate_decision": "ALLOW"},
+        "pytest_execution": {"pytest_execution_count": 1, "selected_targets": ["tests/x.py"]},
+        "pytest_selection_integrity": {"selection_integrity_decision": "ALLOW"},
+    }
+    classified = classify_artifact(artifact)
+    assert classified["classification"] == "insufficient_evidence_to_determine"
+    assert classified["confidence_level"] == "low"
+
+
+def test_backtest_result_validates_contract() -> None:
+    result = run_pytest_trust_gap_audit(
+        scanned_artifacts=[],
+        audit_scope={
+            "roots": ["outputs"],
+            "artifact_globs": ["**/contract_preflight_result_artifact.json"],
+            "max_artifacts": 20,
+            "repo_root": "/repo",
+        },
+        generated_at="2026-04-14T00:00:00Z",
+    )
+    validate_artifact(result, "pytest_trust_gap_backtest_result")

--- a/tests/test_required_check_alignment_audit.py
+++ b/tests/test_required_check_alignment_audit.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from spectrum_systems.contracts import validate_artifact
+from spectrum_systems.modules.runtime.required_check_alignment_audit import run_required_check_alignment_audit
+
+
+WORKFLOW = {
+    "name": "artifact-boundary",
+    "jobs": {
+        "pytest-pr": {
+            "name": "PR / pytest"
+        }
+    },
+}
+
+
+def test_required_check_alignment_passes_when_live_evidence_matches() -> None:
+    result = run_required_check_alignment_audit(
+        workflow_payload=WORKFLOW,
+        required_policy_payload={
+            "workflow": "artifact-boundary",
+            "authoritative_job_id": "pytest-pr",
+            "authoritative_display_name": "PR / pytest",
+            "required_status_check_name": "PR / pytest",
+        },
+        live_required_checks_payload={"required_status_checks": ["PR / pytest"]},
+        generated_at="2026-04-14T00:00:00Z",
+    )
+    assert result["final_decision"] == "PASS"
+    assert result["live_github_alignment_status"] == "aligned"
+    validate_artifact(result, "required_check_alignment_audit_result")
+
+
+def test_required_check_alignment_blocks_on_obsolete_local_policy_reference() -> None:
+    result = run_required_check_alignment_audit(
+        workflow_payload=WORKFLOW,
+        required_policy_payload={
+            "workflow": "artifact-boundary",
+            "authoritative_job_id": "pytest-pr",
+            "authoritative_display_name": "PR / pytest",
+            "required_status_check_name": "PR / pytest",
+        },
+        local_required_checks_payloads=[{"required_status_checks": ["contract-preflight"]}],
+        generated_at="2026-04-14T00:00:00Z",
+    )
+    assert result["final_decision"] == "BLOCK"
+    assert "LOCAL_REQUIRED_CHECKS_REFERENCE_OBSOLETE" in result["blocking_reasons"]
+
+
+def test_required_check_alignment_warns_when_live_settings_cannot_be_proven() -> None:
+    result = run_required_check_alignment_audit(
+        workflow_payload=WORKFLOW,
+        required_policy_payload={
+            "workflow": "artifact-boundary",
+            "authoritative_job_id": "pytest-pr",
+            "authoritative_display_name": "PR / pytest",
+            "required_status_check_name": "PR / pytest",
+        },
+        generated_at="2026-04-14T00:00:00Z",
+    )
+    assert result["final_decision"] == "WARN"
+    assert result["live_github_alignment_status"] == "unknown"
+    assert result["operator_actions_required"]
+
+
+def test_required_check_alignment_detects_policy_workflow_drift() -> None:
+    result = run_required_check_alignment_audit(
+        workflow_payload=WORKFLOW,
+        required_policy_payload={
+            "workflow": "artifact-boundary-legacy",
+            "authoritative_job_id": "pytest-pr",
+            "authoritative_display_name": "PR / pytest",
+            "required_status_check_name": "PR / pytest",
+        },
+        generated_at="2026-04-14T00:00:00Z",
+    )
+    assert result["final_decision"] == "BLOCK"
+    assert "POLICY_WORKFLOW_MISMATCH" in result["blocking_reasons"]


### PR DESCRIPTION
### Motivation
- Provide a deterministic, repo-native audit that proves the repository is configured to require the authoritative PR-visible pytest status check (`PR / pytest`) and that backtests recent PR/preflight evidence for trust-gap exposure. 
- Preserve the existing artifact-first, fail-closed trust path and avoid assuming live GitHub branch-protection state when it cannot be proven from repo-local evidence. 
- Surface explicit, deterministic artifacts and operator actions so historical PRs merged before hardening can be classified honestly. 

### Description
- Added a governed policy surface at `docs/governance/required_pr_checks.json` and a runtime+CLI audit `spectrum_systems/modules/runtime/required_check_alignment_audit.py` / `scripts/run_required_check_alignment_audit.py` that extracts authoritative check identity from `.github/workflows/artifact-boundary.yml` and emits a `required_check_alignment_audit_result` artifact with `PASS`/`WARN`/`BLOCK` semantics. 
- Extended the pytest trust-gap audit into a deterministic backtest path with `spectrum_systems/modules/runtime/pytest_trust_gap_audit.py` and `scripts/run_pytest_trust_gap_audit.py` that scans bounded local preflight artifacts and emits a `pytest_trust_gap_backtest_result` artifact with per-run classifications, confidence, and recommended follow-up. 
- Added contract-first schemas and examples (`contracts/schemas/*.schema.json`, `contracts/examples/*`), registered new artifacts in `contracts/standards-manifest.json`, and added focused tests and a plan file; included a structured review/delivery report at `docs/reviews/AUD-02_required_check_alignment_and_trust_gap_audit.md`. 
- The audits intentionally do not call GitHub APIs by default: live branch-protection evidence may be provided via an operator-supplied JSON file and is treated as external evidence; missing live evidence is reported as `unknown` and mapped to `WARN` (never `PASS`). 

### Testing
- Ran focused unit tests: `pytest tests/test_required_check_alignment_audit.py` and `pytest tests/test_pytest_trust_gap_audit.py`, both suites passed (`8 passed` total across them). 
- Ran broader suites used by the runtime: `pytest tests/test_artifact_boundary_workflow_pytest_enforcement.py`, `pytest tests/test_pytest_selection_integrity.py`, `pytest tests/test_contract_preflight.py`, and `pytest tests/test_contracts.py`, all passed (all tests reported green). 
- Executed runtime validations: `python scripts/run_contract_enforcement.py` completed with `failures=0 warnings=0 not_yet_enforceable=0`, `python scripts/run_required_check_alignment_audit.py` produced `required_check_alignment_audit_result.json` with `final_decision=WARN` (live state unknown), and `python scripts/run_pytest_trust_gap_audit.py` produced `pytest_trust_gap_backtest_result.json` (evaluated_runs and suspect_runs reported deterministically).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de786c19a08329afe16a8f20ddccf9)