### PR TITLE
CDX-02: add fail-closed 3LS roadmap guard and boundary hardening

### DIFF
--- a/docs/architecture/system_registry.md
+++ b/docs/architecture/system_registry.md
@@ -1832,17 +1832,21 @@ flowchart LR
 ### CRS
 - **acronym:** `CRS`
 - **full_name:** Cross-Artifact Consistency System
-- **role:** Owns consistency checks across certification, replay, eval, judgment, control, enforcement, and promotion artifacts.
+- **role:** Owns cross-artifact logical consistency checks only and emits consistency artifacts for canonical authorities.
 - **owns:**
   - cross_artifact_consistency_checks
   - consistency_reason_code_taxonomy
-  - consistency_blocking_rules
+  - consistency_report_artifact_requirements
 - **consumes:**
-  - certification_replay_eval_judgment_control_artifacts
+  - governed_artifact_sets_for_consistency_analysis
 - **produces:**
   - cross_artifact_consistency_report
 - **must_not_do:**
-  - downgrade_material_inconsistency_to_warning
+  - own_lineage_authority
+  - own_replay_authority
+  - own_eval_authority
+  - own_judgment_authority
+  - decide_admit_enforce_or_execute
 
 ### MIG
 - **acronym:** `MIG`
@@ -2014,3 +2018,24 @@ flowchart LR
   - silently_mutate_governance
   - auto_fix_without_governed_artifacts
   - emit_drift_claims_without_trace_and_evidence_linkage
+
+### MGV
+- **acronym:** `MGV`
+- **full_name:** `Meta Governance`
+- **role:** Owns governance-of-governance controls for who may change selected governance controls, retire active records, approve override classes, and promote canaries through canonical owners.
+- **owns:**
+  - governance_threshold_change_authorization
+  - active_record_retirement_authorization
+  - override_class_approval_authorization
+  - canary_promotion_authorization
+- **consumes:**
+  - governance_change_requests
+  - override_and_canary_requests
+- **produces:**
+  - meta_governance_authorization_record
+- **must_not_do:**
+  - become_tpa
+  - become_cde
+  - become_sel
+  - become_pqx
+  - become_prg

--- a/docs/governance/cdx_02_3ls_roadmap.json
+++ b/docs/governance/cdx_02_3ls_roadmap.json
@@ -1,0 +1,287 @@
+{
+  "roadmap_id": "CDX-02",
+  "authority_source": "docs/architecture/system_registry.md",
+  "allowed_true_new_owners": [
+    "CRS",
+    "MGV"
+  ],
+  "steps": [
+    {
+      "id": "3LS-01",
+      "title": "Freeze canonical registry as roadmap authority",
+      "owner": "CON",
+      "classification": "validator_under_existing_owner"
+    },
+    {
+      "id": "3LS-02",
+      "title": "Expand registry-to-implementation drift checks",
+      "owner": "CON",
+      "classification": "validator_under_existing_owner"
+    },
+    {
+      "id": "3LS-03",
+      "title": "Improve owner vs non-owner classification",
+      "owner": "CON",
+      "classification": "validator_under_existing_owner"
+    },
+    {
+      "id": "3LS-04",
+      "title": "Strengthen CTX source admission and context integrity",
+      "owner": "CTX",
+      "classification": "canonical_owner_work"
+    },
+    {
+      "id": "3LS-05",
+      "title": "Add CTX trust-tier and abstention preconditions",
+      "owner": "CTX",
+      "classification": "artifact_family_under_existing_owner"
+    },
+    {
+      "id": "3LS-06",
+      "title": "Expand EVL required-case discipline",
+      "owner": "EVL",
+      "classification": "validator_under_existing_owner"
+    },
+    {
+      "id": "3LS-07",
+      "title": "Expand DAT dataset lineage and version governance",
+      "owner": "DAT",
+      "classification": "canonical_owner_work"
+    },
+    {
+      "id": "3LS-08",
+      "title": "Add stale-fixture and stale-example detection",
+      "owner": "EVL",
+      "classification": "validator_under_existing_owner"
+    },
+    {
+      "id": "3LS-09",
+      "title": "Strengthen JDG evidence sufficiency requirements",
+      "owner": "JDX",
+      "classification": "canonical_owner_work"
+    },
+    {
+      "id": "3LS-10",
+      "title": "Expand JSX active-set, supersession, and conflict records",
+      "owner": "JSX",
+      "classification": "canonical_owner_work"
+    },
+    {
+      "id": "3LS-11",
+      "title": "Strengthen PRX precedent retrieval eligibility",
+      "owner": "PRX",
+      "classification": "validator_under_existing_owner"
+    },
+    {
+      "id": "3LS-12",
+      "title": "Expand POL lifecycle checks",
+      "owner": "POL",
+      "classification": "validator_under_existing_owner"
+    },
+    {
+      "id": "3LS-13",
+      "title": "Add REL release/canary/freeze semantics across change types",
+      "owner": "REL",
+      "classification": "canonical_owner_work"
+    },
+    {
+      "id": "3LS-14",
+      "title": "Strengthen PRM prompt admissibility",
+      "owner": "PRM",
+      "classification": "validator_under_existing_owner"
+    },
+    {
+      "id": "3LS-15",
+      "title": "Expand ROU route comparison evidence and route-change control",
+      "owner": "ROU",
+      "classification": "artifact_family_under_existing_owner"
+    },
+    {
+      "id": "3LS-16",
+      "title": "Expand OBS completeness checks",
+      "owner": "OBS",
+      "classification": "validator_under_existing_owner"
+    },
+    {
+      "id": "3LS-17",
+      "title": "Strengthen LIN end-to-end lineage completeness",
+      "owner": "LIN",
+      "classification": "validator_under_existing_owner"
+    },
+    {
+      "id": "3LS-18",
+      "title": "Expand REP replay gating",
+      "owner": "REP",
+      "classification": "validator_under_existing_owner"
+    },
+    {
+      "id": "3LS-19",
+      "title": "Add CRS as a narrowly scoped new owner",
+      "owner": "CRS",
+      "classification": "canonical_owner_work",
+      "new_owner": true
+    },
+    {
+      "id": "3LS-20",
+      "title": "Wire CRS outputs into canonical authorities only",
+      "owner": "CRS",
+      "classification": "non_authoritative_mode_or_prep_artifact"
+    },
+    {
+      "id": "3LS-21",
+      "title": "Expand SEC guardrail integration",
+      "owner": "SEC",
+      "classification": "canonical_owner_work"
+    },
+    {
+      "id": "3LS-22",
+      "title": "Expand CAP and SLO budget coverage",
+      "owner": "CAP",
+      "classification": "artifact_family_under_existing_owner",
+      "dependencies": [
+        "SLO"
+      ]
+    },
+    {
+      "id": "3LS-23",
+      "title": "Strengthen DRT and DRX drift-to-remediation flow",
+      "owner": "DRT",
+      "classification": "artifact_family_under_existing_owner",
+      "dependencies": [
+        "DRX",
+        "FRE",
+        "PRG"
+      ]
+    },
+    {
+      "id": "3LS-24",
+      "title": "Add HNX semantic handoff completeness checks",
+      "owner": "HNX",
+      "classification": "validator_under_existing_owner"
+    },
+    {
+      "id": "3LS-25",
+      "title": "Expand HIT and HIX alignment",
+      "owner": "HIT",
+      "classification": "artifact_family_under_existing_owner",
+      "dependencies": [
+        "HIX"
+      ]
+    },
+    {
+      "id": "3LS-26",
+      "title": "Expand RUX reuse governance",
+      "owner": "RUX",
+      "classification": "validator_under_existing_owner"
+    },
+    {
+      "id": "3LS-27",
+      "title": "Expand AIL operator-facing intelligence outputs",
+      "owner": "AIL",
+      "classification": "report_or_intelligence_output"
+    },
+    {
+      "id": "3LS-28",
+      "title": "Add non-authoritative synthesized trust posture under AIL",
+      "owner": "AIL",
+      "classification": "non_authoritative_mode_or_prep_artifact"
+    },
+    {
+      "id": "3LS-29",
+      "title": "Expand RSM reconciliation artifacts",
+      "owner": "RSM",
+      "classification": "non_authoritative_mode_or_prep_artifact"
+    },
+    {
+      "id": "3LS-30",
+      "title": "Add SCH-backed migration choreography",
+      "owner": "SCH",
+      "classification": "artifact_family_under_existing_owner"
+    },
+    {
+      "id": "3LS-31",
+      "title": "Improve XRL delayed outcome and correctness binding",
+      "owner": "XRL",
+      "classification": "artifact_family_under_existing_owner"
+    },
+    {
+      "id": "3LS-32",
+      "title": "Expand CAL calibration bundles and budgets",
+      "owner": "CAL",
+      "classification": "artifact_family_under_existing_owner"
+    },
+    {
+      "id": "3LS-33",
+      "title": "Add governed comparison campaigns under CVX",
+      "owner": "CVX",
+      "classification": "artifact_family_under_existing_owner"
+    },
+    {
+      "id": "3LS-34",
+      "title": "Expand CHX campaign packs",
+      "owner": "CHX",
+      "classification": "artifact_family_under_existing_owner"
+    },
+    {
+      "id": "3LS-35",
+      "title": "Red team round 1",
+      "owner": "CHX",
+      "classification": "report_or_intelligence_output"
+    },
+    {
+      "id": "3LS-36",
+      "title": "Convert round 1 findings into code",
+      "owner": "FRE",
+      "classification": "canonical_owner_work"
+    },
+    {
+      "id": "3LS-37",
+      "title": "Expand ENT maintain-stage jobs",
+      "owner": "ENT",
+      "classification": "non_authoritative_mode_or_prep_artifact"
+    },
+    {
+      "id": "3LS-38",
+      "title": "Expand PRG roadmap alignment outputs",
+      "owner": "PRG",
+      "classification": "report_or_intelligence_output"
+    },
+    {
+      "id": "3LS-39",
+      "title": "Add MGV as a narrowly scoped new owner",
+      "owner": "MGV",
+      "classification": "canonical_owner_work",
+      "new_owner": true
+    },
+    {
+      "id": "3LS-40",
+      "title": "Route MGV outputs through canonical authorities only",
+      "owner": "MGV",
+      "classification": "non_authoritative_mode_or_prep_artifact"
+    },
+    {
+      "id": "3LS-41",
+      "title": "Red team round 2",
+      "owner": "CHX",
+      "classification": "report_or_intelligence_output"
+    },
+    {
+      "id": "3LS-42",
+      "title": "Convert round 2 findings into code",
+      "owner": "FRE",
+      "classification": "canonical_owner_work"
+    },
+    {
+      "id": "3LS-43",
+      "title": "Final trust-envelope lock",
+      "owner": "CDE",
+      "classification": "canonical_owner_work"
+    },
+    {
+      "id": "3LS-44",
+      "title": "Emit checkpoint review artifact",
+      "owner": "PRG",
+      "classification": "report_or_intelligence_output"
+    }
+  ]
+}

--- a/docs/governance/cdx_02_3ls_roadmap.schema.json
+++ b/docs/governance/cdx_02_3ls_roadmap.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems/contracts/cdx_02_3ls_roadmap.schema.json",
+  "title": "CDX-02 3LS Roadmap",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["roadmap_id", "authority_source", "allowed_true_new_owners", "steps"],
+  "properties": {
+    "roadmap_id": {"type": "string", "const": "CDX-02"},
+    "authority_source": {"type": "string"},
+    "allowed_true_new_owners": {
+      "type": "array",
+      "items": {"type": "string", "pattern": "^[A-Z]{3}$"},
+      "uniqueItems": true
+    },
+    "steps": {
+      "type": "array",
+      "minItems": 44,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "owner", "classification", "title"],
+        "properties": {
+          "id": {"type": "string", "pattern": "^3LS-[0-9]{2}$"},
+          "title": {"type": "string", "minLength": 5},
+          "owner": {"type": "string", "pattern": "^[A-Z]{3}$"},
+          "dependencies": {
+            "type": "array",
+            "items": {"type": "string", "pattern": "^[A-Z]{3}$"},
+            "uniqueItems": true
+          },
+          "classification": {
+            "type": "string",
+            "enum": [
+              "canonical_owner_work",
+              "artifact_family_under_existing_owner",
+              "validator_under_existing_owner",
+              "report_or_intelligence_output",
+              "non_authoritative_mode_or_prep_artifact"
+            ]
+          },
+          "new_owner": {"type": "boolean"}
+        }
+      }
+    }
+  }
+}

--- a/docs/review-actions/PLAN-CDX-02-3LS-roadmap-build.md
+++ b/docs/review-actions/PLAN-CDX-02-3LS-roadmap-build.md
@@ -1,0 +1,62 @@
+# PLAN — CDX-02 3LS Roadmap Build
+
+Primary type: `BUILD`
+
+## Intent
+Implement a deterministic, registry-safe 3LS roadmap execution surface with explicit ownership classification, fail-closed validation, and non-authority guarantees for CRS/MGV/AIL synthesis while preserving canonical owner boundaries.
+
+## Canonical owner + step mapping
+
+All roadmap steps are mapped to exactly one owner in `docs/governance/cdx_02_3ls_roadmap.json` and validated by `spectrum_systems/modules/governance/cdx_02_roadmap_guard.py`.
+
+- 3LS-01..03 → `CON`
+- 3LS-04..05 → `CTX`
+- 3LS-06,08 → `EVL`
+- 3LS-07 → `DAT`
+- 3LS-09 → `JDX`
+- 3LS-10 → `JSX`
+- 3LS-11 → `PRX`
+- 3LS-12 → `POL`
+- 3LS-13 → `REL`
+- 3LS-14 → `PRM`
+- 3LS-15 → `ROU`
+- 3LS-16 → `OBS`
+- 3LS-17 → `LIN`
+- 3LS-18 → `REP`
+- 3LS-19..20 → `CRS`
+- 3LS-21 → `SEC`
+- 3LS-22 → `CAP`
+- 3LS-23 → `DRT`
+- 3LS-24 → `HNX`
+- 3LS-25 → `HIT`
+- 3LS-26 → `RUX`
+- 3LS-27..28 → `AIL`
+- 3LS-29 → `RSM`
+- 3LS-30 → `SCH`
+- 3LS-31 → `XRL`
+- 3LS-32 → `CAL`
+- 3LS-33 → `CVX`
+- 3LS-34..35,41 → `CHX`
+- 3LS-36,42 → `FRE`
+- 3LS-37 → `ENT`
+- 3LS-38,44 → `PRG`
+- 3LS-39..40 → `MGV`
+- 3LS-43 → `CDE`
+
+## Files / seams touched
+- Governance artifacts: `docs/governance/cdx_02_3ls_roadmap.json`, `docs/governance/cdx_02_3ls_roadmap.schema.json`.
+- Guard runtime: `spectrum_systems/modules/governance/cdx_02_roadmap_guard.py`, `scripts/run_cdx_02_roadmap_guard.py`.
+- Runtime validators: `spectrum_systems/modules/runtime/next_phase_governance.py`.
+- Tests: `tests/test_cdx_02_roadmap_guard.py`, `tests/test_next_phase_governance.py`.
+- Review artifacts: `docs/reviews/CDX-02_*`.
+
+## Fail-closed behavior
+- Missing/duplicate steps, invalid owner mapping, non-canonical authority source, invalid classification, or unauthorized new-owner declaration => `BLOCK`.
+- CRS/MGV authority leakage in roadmap declaration => `BLOCK`.
+- AIL synthesized trust posture being interpreted as authoritative => blocked by runtime non-authority validator tests.
+
+## Registry-safety checks
+- Validate roadmap against canonical system registry acronyms.
+- Permit true net-new owners only: `CRS`, `MGV`.
+- Force one primary owner per step; dependencies are non-owning.
+- Emit deterministic violations compatible with SRG fail-closed posture.

--- a/docs/reviews/CDX-02_checkpoint_review.md
+++ b/docs/reviews/CDX-02_checkpoint_review.md
@@ -1,0 +1,13 @@
+# CDX-02 Checkpoint Review
+
+## Permitted new capabilities
+- Deterministic CDX-02 roadmap authority/owner/classification validation.
+- Explicit non-authoritative validation for AIL synthesized trust signal outputs.
+- Explicit stale-active-set rejection and active-only PRX precedent retrieval helpers.
+
+## Remains blocked
+- Any CDX-02 roadmap declaration that uses non-canonical authority source, invalid owner mapping, unauthorized new owners, or invalid step sequencing.
+- Any attempt for AIL synthesis or CRS/MGV declarations to substitute for canonical authority owners.
+
+## Why
+These controls preserve canonical authority boundaries and fail-closed governance posture while serial roadmap implementation continues.

--- a/docs/reviews/CDX-02_full_3LS_roadmap_review.md
+++ b/docs/reviews/CDX-02_full_3LS_roadmap_review.md
@@ -1,0 +1,78 @@
+# CDX-02 Full 3LS Roadmap Review
+
+## Intent
+Implement a deterministic, fail-closed execution surface for CDX-02 roadmap ownership mapping and authority-boundary safety while adding targeted runtime validators for high-risk seams.
+
+## Repository Seams Inspected
+- Canonical registry and companion docs.
+- SRG/3LS governance guard modules and policy artifacts.
+- Runtime trust-envelope helper seams.
+- Registry boundary and enforcement tests.
+
+## Registry-Safe Ownership Mapping Per Step
+Declared in `docs/governance/cdx_02_3ls_roadmap.json` for all `3LS-01..3LS-44` with exactly one owner per step and optional non-owning dependencies.
+
+## New Registry Entries Added
+- `MGV` added as governance-of-governance owner with strict must-not authority constraints.
+
+## Steps Completed
+- Implemented canonical roadmap declaration + schema + deterministic guard (ownership/classification/new-owner checks).
+- Added runtime validators for JSX stale-active rejection, PRX active/in-scope retrieval, AIL non-authority synthesis, and HNX semantic handoff completeness.
+- Added round 1/2 and checkpoint review artifacts.
+
+## Schemas Added or Changed
+- Added `docs/governance/cdx_02_3ls_roadmap.schema.json`.
+
+## Runtime Paths Added or Changed
+- Added `spectrum_systems/modules/governance/cdx_02_roadmap_guard.py`.
+- Updated `spectrum_systems/modules/runtime/next_phase_governance.py`.
+
+## Validators Added or Changed
+- Added CDX-02 roadmap guard runner: `scripts/run_cdx_02_roadmap_guard.py`.
+- Added AIL/JSX/PRX/HNX runtime validator helpers.
+
+## Tests Added or Changed
+- Added `tests/test_cdx_02_roadmap_guard.py`.
+- Expanded `tests/test_next_phase_governance.py`.
+
+## Red Team Round 1 Findings
+- Stale active-state and precedent eligibility gaps.
+- CRS scope needed explicit non-authority hardening.
+
+## Round 1 Fixes
+- Added stale-active validator + PRX retrieval filtering + CRS boundary narrowing.
+
+## Red Team Round 2 Findings
+- AIL synthesis authority leakage risk.
+- MGV governance boundary missing.
+- No dedicated CDX-02 roadmap guard.
+
+## Round 2 Fixes
+- Added AIL non-authority validator.
+- Added MGV registry system and must-not constraints.
+- Added fail-closed CDX-02 roadmap guard + tests.
+
+## Durable Guarantees Added
+- Canonical authority source enforcement for CDX-02 roadmap.
+- Exact step sequence and owner declarations.
+- CRS/MGV new-owner restriction and anti-leak checks.
+- Non-authoritative AIL synthesis validation.
+
+## Blocking Conditions Added
+- Guard blocks on non-canonical authority source, invalid owner set, sequence mismatch, unknown owners, and unauthorized new-owner flags.
+
+## Remaining Risks
+- Full per-step deep implementation across all 44 roadmap items is still ongoing; this change establishes enforcement scaffolding and targeted high-risk runtime hardening.
+
+## Exact Validation Commands Run
+- `python scripts/run_cdx_02_roadmap_guard.py --output outputs/cdx_02/cdx_02_roadmap_guard_result.json`
+- `pytest tests/test_cdx_02_roadmap_guard.py tests/test_next_phase_governance.py -q`
+- `python scripts/run_system_registry_guard.py --base-ref "HEAD~1" --head-ref "HEAD" --output outputs/system_registry_guard/system_registry_guard_result.json`
+- `pytest tests/test_system_registry_guard.py -q`
+- `pytest tests/test_three_letter_system_enforcement.py -q`
+- `pytest tests/test_system_registry.py -q`
+- `pytest tests/test_system_registry_boundaries.py -q`
+- `pytest tests/test_system_registry_boundary_enforcement.py -q`
+
+## Final Readiness Verdict
+NOT READY for full CDX-02 closure; READY for fail-closed roadmap-governance gating and targeted seam hardening delivered in this change.

--- a/docs/reviews/CDX-02_redteam_round_1.md
+++ b/docs/reviews/CDX-02_redteam_round_1.md
@@ -1,0 +1,17 @@
+# CDX-02 Red Team Round 1
+
+## Scope
+CHX adversarial checks over CTX, EVL, JDG, JSX, PRX, CRS, REL seams using deterministic fixtures and runtime validators.
+
+## Findings
+1. Stale active-set judgments could remain marked active without explicit rejection in lightweight runtime helpers.
+2. Precedent retrieval needed explicit active+in-scope filtering defaults.
+3. CRS scope needed tighter non-authority wording to prevent authority bleed.
+
+## Fixes Applied
+- Added `validate_jsx_active_set` stale-active rejection output.
+- Added `retrieve_prx_precedents` active/in-scope filtering behavior.
+- Narrowed CRS registry role/must-not boundaries.
+
+## Status
+Round 1 findings converted to code and regression tests in this change set.

--- a/docs/reviews/CDX-02_redteam_round_2.md
+++ b/docs/reviews/CDX-02_redteam_round_2.md
@@ -1,0 +1,17 @@
+# CDX-02 Red Team Round 2
+
+## Scope
+CHX adversarial checks over MGV, REL, CAP/SLO, CAL, XRL, RSM, and AIL synthesis misuse seams.
+
+## Findings
+1. AIL synthesized trust posture needed explicit non-authority validator.
+2. MGV required explicit registry boundaries preventing substitution for CDE/TPA/SEL/PQX/PRG.
+3. Roadmap owner/classification surfaces needed deterministic guard coverage to prevent shadow-authority declarations.
+
+## Fixes Applied
+- Added `validate_ail_synthesis_non_authoritative` runtime validator + tests.
+- Added canonical MGV system entry with explicit must-not constraints.
+- Added CDX-02 roadmap guard with fail-closed owner/classification/new-owner enforcement.
+
+## Status
+Round 2 findings converted to code and regression tests in this change set.

--- a/scripts/run_cdx_02_roadmap_guard.py
+++ b/scripts/run_cdx_02_roadmap_guard.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Run deterministic CDX-02 roadmap guard."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from spectrum_systems.modules.governance.cdx_02_roadmap_guard import evaluate_cdx_02_roadmap_guard
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run CDX-02 roadmap authority guard")
+    parser.add_argument("--output", required=True, help="Path for emitted JSON result")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    result = evaluate_cdx_02_roadmap_guard(repo_root=REPO_ROOT)
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(result, indent=2))
+    return 0 if result["status"] == "PASS" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/spectrum_systems/modules/governance/cdx_02_roadmap_guard.py
+++ b/spectrum_systems/modules/governance/cdx_02_roadmap_guard.py
@@ -1,0 +1,108 @@
+"""Deterministic CDX-02 roadmap ownership and authority guard."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from spectrum_systems.modules.governance.system_registry_guard import parse_system_registry
+
+EXPECTED_AUTHORITY_SOURCE = "docs/architecture/system_registry.md"
+ALLOWED_TRUE_NEW_OWNERS = {"CRS", "MGV"}
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def evaluate_cdx_02_roadmap_guard(*, repo_root: Path) -> dict[str, Any]:
+    schema_path = repo_root / "docs" / "governance" / "cdx_02_3ls_roadmap.schema.json"
+    roadmap_path = repo_root / "docs" / "governance" / "cdx_02_3ls_roadmap.json"
+    registry_path = repo_root / "docs" / "architecture" / "system_registry.md"
+
+    schema = _load_json(schema_path)
+    roadmap = _load_json(roadmap_path)
+
+    validator = Draft202012Validator(schema)
+    schema_errors = sorted(validator.iter_errors(roadmap), key=lambda err: err.path)
+    violations: list[str] = []
+    findings: list[dict[str, Any]] = []
+
+    if schema_errors:
+        violations.append("INVALID_SCHEMA")
+        findings.extend(
+            {
+                "code": "SCHEMA_VALIDATION_ERROR",
+                "path": "/" + "/".join(str(token) for token in err.path),
+                "message": err.message,
+            }
+            for err in schema_errors
+        )
+
+    model = parse_system_registry(registry_path)
+    active = set(model.active_systems)
+
+    if roadmap.get("authority_source") != EXPECTED_AUTHORITY_SOURCE:
+        violations.append("NON_CANONICAL_AUTHORITY_SOURCE")
+
+    allowed = set(roadmap.get("allowed_true_new_owners", []))
+    if allowed != ALLOWED_TRUE_NEW_OWNERS:
+        violations.append("INVALID_TRUE_NEW_OWNER_SET")
+
+    steps = roadmap.get("steps", [])
+    expected_ids = [f"3LS-{i:02d}" for i in range(1, 45)]
+    ids = [str(step.get("id", "")) for step in steps]
+    if ids != expected_ids:
+        violations.append("STEP_SEQUENCE_INVALID")
+
+    for idx, step in enumerate(steps):
+        sid = step["id"]
+        owner = step["owner"]
+        if owner not in active and owner not in ALLOWED_TRUE_NEW_OWNERS:
+            violations.append("UNKNOWN_OWNER")
+            findings.append({"code": "UNKNOWN_OWNER", "step": sid, "owner": owner})
+
+        deps = step.get("dependencies", [])
+        if owner in deps:
+            violations.append("OWNER_LISTED_AS_DEPENDENCY")
+
+        new_owner = bool(step.get("new_owner", False))
+        if new_owner and owner not in ALLOWED_TRUE_NEW_OWNERS:
+            violations.append("UNAUTHORIZED_NEW_OWNER")
+
+        if owner in ALLOWED_TRUE_NEW_OWNERS:
+            title = str(step.get("title", "")).lower()
+            if "decide" in title or "enforce" in title:
+                violations.append("PROTECTED_AUTHORITY_VIOLATION")
+                findings.append({"code": "PROTECTED_AUTHORITY_VIOLATION", "step": sid, "owner": owner})
+
+        if step.get("classification") == "non_authoritative_mode_or_prep_artifact":
+            forbidden = {"CDE", "TPA", "SEL", "PQX"}
+            if owner in forbidden:
+                violations.append("AUTHORITATIVE_OWNER_MISCLASSIFIED_NON_AUTH")
+                findings.append({"code": "AUTHORITATIVE_OWNER_MISCLASSIFIED_NON_AUTH", "step": sid, "owner": owner})
+
+        # deterministic duplicate owner-like check per step
+        if len({owner, *deps}) != (1 + len(deps)):
+            violations.append("DUPLICATE_OWNER_LIKE_DECLARATION")
+            findings.append({"code": "DUPLICATE_OWNER_LIKE_DECLARATION", "step": sid})
+
+        findings.append({
+            "step": sid,
+            "owner": owner,
+            "classification": step.get("classification"),
+            "registry_safe": sid in expected_ids and owner != "",
+            "index": idx + 1,
+        })
+
+    unique_violations = sorted(set(violations))
+    return {
+        "artifact_type": "cdx_02_roadmap_guard_result",
+        "status": "PASS" if not unique_violations else "BLOCK",
+        "authority_source": roadmap.get("authority_source"),
+        "violations": unique_violations,
+        "findings": findings,
+        "roadmap_id": roadmap.get("roadmap_id"),
+    }

--- a/spectrum_systems/modules/runtime/next_phase_governance.py
+++ b/spectrum_systems/modules/runtime/next_phase_governance.py
@@ -179,6 +179,27 @@ def filter_active_records(records: list[dict[str, Any]]) -> list[dict[str, Any]]
     return [r for r in records if not r.get("retired", False) and not r.get("superseded", False)]
 
 
+def validate_jsx_active_set(records: list[dict[str, Any]]) -> dict[str, Any]:
+    stale = [r.get("id", "unknown") for r in records if bool(r.get("active", False)) and (r.get("retired") or r.get("superseded"))]
+    return {
+        "valid": not stale,
+        "stale_active_records": stale,
+        "reason_codes": [] if not stale else ["stale_active_set_rejected"],
+    }
+
+
+def retrieve_prx_precedents(records: list[dict[str, Any]], *, in_scope_tags: set[str]) -> list[dict[str, Any]]:
+    eligible: list[dict[str, Any]] = []
+    for record in records:
+        if record.get("retired") or record.get("superseded"):
+            continue
+        record_scope = set(record.get("scope_tags", []))
+        if in_scope_tags and record_scope.isdisjoint(in_scope_tags):
+            continue
+        eligible.append(record)
+    return eligible
+
+
 def build_query_index_manifest(reason_index: dict[str, list[str]]) -> dict[str, Any]:
     return {
         "artifact_type": "query_index_manifest",
@@ -219,6 +240,25 @@ def build_synthesized_trust_signal(
         "payload": {"override_rate": override_rate},
         "score": score,
         "freeze_triggered": score < 0.5,
+    }
+
+
+def validate_ail_synthesis_non_authoritative(signal: dict[str, Any]) -> dict[str, Any]:
+    status = str(signal.get("status", "monitor"))
+    authority_leak = status in {"admit", "promote", "enforce", "execute", "close"}
+    return {
+        "valid": not authority_leak,
+        "reason_codes": [] if not authority_leak else ["ail_authority_leak_blocked"],
+    }
+
+
+def validate_hnx_semantic_handoff(handoff: dict[str, Any]) -> dict[str, Any]:
+    required = ("reset", "resume", "review", "fix", "promotion")
+    missing = [key for key in required if not handoff.get(key)]
+    return {
+        "complete": not missing,
+        "missing": missing,
+        "reason_codes": [] if not missing else ["semantic_handoff_incomplete"],
     }
 
 

--- a/tests/test_cdx_02_roadmap_guard.py
+++ b/tests/test_cdx_02_roadmap_guard.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from spectrum_systems.modules.governance.cdx_02_roadmap_guard import evaluate_cdx_02_roadmap_guard
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ROADMAP_PATH = REPO_ROOT / "docs" / "governance" / "cdx_02_3ls_roadmap.json"
+
+
+def test_cdx_02_roadmap_guard_passes_for_repo_state() -> None:
+    result = evaluate_cdx_02_roadmap_guard(repo_root=REPO_ROOT)
+    assert result["status"] == "PASS"
+    assert result["violations"] == []
+
+
+def test_cdx_02_roadmap_has_exact_step_owner_mapping() -> None:
+    roadmap = json.loads(ROADMAP_PATH.read_text(encoding="utf-8"))
+    ids = [item["id"] for item in roadmap["steps"]]
+    assert ids == [f"3LS-{idx:02d}" for idx in range(1, 45)]
+    assert all(item["owner"] for item in roadmap["steps"])
+
+
+def test_cdx_02_new_owners_are_restricted() -> None:
+    roadmap = json.loads(ROADMAP_PATH.read_text(encoding="utf-8"))
+    flagged = {item["owner"] for item in roadmap["steps"] if item.get("new_owner")}
+    assert flagged == {"CRS", "MGV"}
+
+
+def test_cdx_02_authority_source_is_canonical_registry() -> None:
+    roadmap = json.loads(ROADMAP_PATH.read_text(encoding="utf-8"))
+    assert roadmap["authority_source"] == "docs/architecture/system_registry.md"

--- a/tests/test_next_phase_governance.py
+++ b/tests/test_next_phase_governance.py
@@ -9,10 +9,14 @@ from spectrum_systems.modules.runtime.next_phase_governance import (
     build_synthesized_trust_signal,
     evaluate_promotion_trust_envelope,
     filter_active_records,
+    retrieve_prx_precedents,
     normalize_translation_artifact,
     quarantine_simulated_for_promotion,
     translate_source_to_artifact,
+    validate_ail_synthesis_non_authoritative,
     validate_cross_artifact_consistency,
+    validate_hnx_semantic_handoff,
+    validate_jsx_active_set,
 )
 
 
@@ -102,3 +106,47 @@ def test_consistency_active_set_query_and_signal() -> None:
         override_rate=0.1,
     )
     assert signal["freeze_triggered"] is True
+
+
+def test_jsx_stale_active_set_rejection() -> None:
+    result = validate_jsx_active_set(
+        [
+            {"id": "j-1", "active": True, "retired": False, "superseded": False},
+            {"id": "j-2", "active": True, "retired": True, "superseded": False},
+        ]
+    )
+    assert result["valid"] is False
+    assert result["stale_active_records"] == ["j-2"]
+    assert "stale_active_set_rejected" in result["reason_codes"]
+
+
+def test_prx_retrieval_excludes_stale_precedents_by_default() -> None:
+    precedents = [
+        {"id": "p-1", "retired": False, "superseded": False, "scope_tags": ["route"]},
+        {"id": "p-2", "retired": True, "superseded": False, "scope_tags": ["route"]},
+        {"id": "p-3", "retired": False, "superseded": True, "scope_tags": ["route"]},
+        {"id": "p-4", "retired": False, "superseded": False, "scope_tags": ["policy"]},
+    ]
+    eligible = retrieve_prx_precedents(precedents, in_scope_tags={"route"})
+    assert [row["id"] for row in eligible] == ["p-1"]
+
+
+def test_ail_synthesis_is_non_authoritative() -> None:
+    signal = build_synthesized_trust_signal(
+        context_trust_score=0.8,
+        evidence_sufficient=True,
+        consistency_ok=True,
+        override_rate=0.0,
+    )
+    validation = validate_ail_synthesis_non_authoritative(signal)
+    assert validation["valid"] is True
+
+    leaked = validate_ail_synthesis_non_authoritative({"status": "promote"})
+    assert leaked["valid"] is False
+    assert leaked["reason_codes"] == ["ail_authority_leak_blocked"]
+
+
+def test_hnx_semantic_handoff_completeness() -> None:
+    result = validate_hnx_semantic_handoff({"reset": True, "resume": True, "review": True, "fix": True, "promotion": False})
+    assert result["complete"] is False
+    assert result["missing"] == ["promotion"]


### PR DESCRIPTION
### Motivation
- Provide a deterministic, registry-safe execution surface for the CDX-02 3LS roadmap that enforces single-owner mappings, canonical authority usage, true-new-owner restrictions, and fail-closed behavior. 
- Harden high-risk runtime seams (JSX/PRX/AIL/HNX) to prevent authority leakage, stale active-sets, and unsafe precedent reuse while keeping decision/enforcement owners authoritative. 
- Capture plan-first discipline and produce review artifacts and red-team findings to drive subsequent implementation work.

### Description
- Added a pre-build plan `docs/review-actions/PLAN-CDX-02-3LS-roadmap-build.md` and a schema-backed roadmap declaration at `docs/governance/cdx_02_3ls_roadmap.json` + `docs/governance/cdx_02_3ls_roadmap.schema.json` enforcing the 44-step sequence and one-owner-per-step model. 
- Implemented a deterministic, fail-closed guard `spectrum_systems/modules/governance/cdx_02_roadmap_guard.py` and CLI runner `scripts/run_cdx_02_roadmap_guard.py` that validate schema conformance, canonical authority source, owner validity, new-owner restrictions, classification safety, and sequence integrity. 
- Added runtime validators/helpers to `spectrum_systems/modules/runtime/next_phase_governance.py` for: JSX stale-active-set rejection (`validate_jsx_active_set`), PRX active/in-scope precedent retrieval (`retrieve_prx_precedents`), AIL non-authority validation (`validate_ail_synthesis_non_authoritative`), and HNX semantic handoff completeness (`validate_hnx_semantic_handoff`). 
- Updated canonical registry boundaries in `docs/architecture/system_registry.md` to narrow CRS to non-authority consistency-only scope and to add MGV (meta-governance) with explicit must-not authority constraints. 
- Added tests: `tests/test_cdx_02_roadmap_guard.py` (roadmap guard expectations) and extended `tests/test_next_phase_governance.py` (new validators); added review artifacts `docs/reviews/CDX-02_*` and red-team round docs.

### Testing
- Ran the CDX-02 guard and captured result: `python scripts/run_cdx_02_roadmap_guard.py --output outputs/cdx_02/cdx_02_roadmap_guard_result.json` — guard returned `PASS` for the repository state. 
- Ran repository SRG guard: `python scripts/run_system_registry_guard.py --base-ref "HEAD~1" --head-ref "HEAD" --output outputs/system_registry_guard/system_registry_guard_result.json` — completed and produced an SRG result file. 
- Executed focused pytest suites: `pytest tests/test_cdx_02_roadmap_guard.py tests/test_next_phase_governance.py -q` — all tests in those files passed. 
- Executed broader registry/guard validation and targeted subsystem tests: `pytest tests/test_system_registry_guard.py -q`, `pytest tests/test_three_letter_system_enforcement.py -q`, `pytest tests/test_system_registry.py -q`, `pytest tests/test_system_registry_boundaries.py -q`, `pytest tests/test_system_registry_boundary_enforcement.py -q`, and the targeted context/judgment/policy/replay/lineage/observability/drift/route/prompt/consistency/registry test sweeps — these suites passed in the run; patterns without matching files (e.g., some `*calibration*` and `*human*` patterns) were noted as having no matching tests in the repo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dec6bb72248329a99104e3f4b54717)