### PR TITLE
MNT Phase‑0: Promotion enforcement, coverage audit, and red‑team conversion artifacts

### DIFF
--- a/contracts/examples/mnt_advancement_coverage_audit.json
+++ b/contracts/examples/mnt_advancement_coverage_audit.json
@@ -1,0 +1,20 @@
+{
+  "artifact_type": "mnt_advancement_coverage_audit",
+  "artifact_id": "mnt-advancement-audit-001",
+  "artifact_version": "1.0.0",
+  "schema_version": "1.0.0",
+  "standards_version": "1.3.131",
+  "created_at": "2026-04-15T00:00:00Z",
+  "required_paths": [
+    "promotion_gate",
+    "release_gate",
+    "control_loop_certification"
+  ],
+  "audited_paths": [
+    "promotion_gate",
+    "release_gate",
+    "control_loop_certification"
+  ],
+  "uncovered_paths": [],
+  "complete": true
+}

--- a/contracts/examples/mnt_promotion_enforcement_result.json
+++ b/contracts/examples/mnt_promotion_enforcement_result.json
@@ -1,0 +1,13 @@
+{
+  "artifact_type": "mnt_promotion_enforcement_result",
+  "artifact_id": "mnt-promotion-guard-001",
+  "artifact_version": "1.0.0",
+  "schema_version": "1.0.0",
+  "standards_version": "1.3.131",
+  "created_at": "2026-04-15T00:00:00Z",
+  "entrypoint": "promotion_gate",
+  "mnt_002_executed": true,
+  "certification_bundle_ref": "cde_certification_bundle:bundle-001",
+  "status": "pass",
+  "blocked_reasons": []
+}

--- a/contracts/schemas/mnt_advancement_coverage_audit.schema.json
+++ b/contracts/schemas/mnt_advancement_coverage_audit.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/mnt_advancement_coverage_audit.schema.json",
+  "title": "mnt_advancement_coverage_audit",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "artifact_version",
+    "schema_version",
+    "standards_version",
+    "created_at",
+    "required_paths",
+    "audited_paths",
+    "uncovered_paths",
+    "complete"
+  ],
+  "properties": {
+    "artifact_type": {"const": "mnt_advancement_coverage_audit"},
+    "artifact_id": {"type": "string", "minLength": 1},
+    "artifact_version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"},
+    "schema_version": {"const": "1.0.0"},
+    "standards_version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"},
+    "created_at": {"type": "string", "format": "date-time"},
+    "required_paths": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+    "audited_paths": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+    "uncovered_paths": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+    "complete": {"type": "boolean"}
+  }
+}

--- a/contracts/schemas/mnt_promotion_enforcement_result.schema.json
+++ b/contracts/schemas/mnt_promotion_enforcement_result.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/mnt_promotion_enforcement_result.schema.json",
+  "title": "mnt_promotion_enforcement_result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "artifact_version",
+    "schema_version",
+    "standards_version",
+    "created_at",
+    "entrypoint",
+    "mnt_002_executed",
+    "certification_bundle_ref",
+    "status",
+    "blocked_reasons"
+  ],
+  "properties": {
+    "artifact_type": {"const": "mnt_promotion_enforcement_result"},
+    "artifact_id": {"type": "string", "minLength": 1},
+    "artifact_version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"},
+    "schema_version": {"const": "1.0.0"},
+    "standards_version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"},
+    "created_at": {"type": "string", "format": "date-time"},
+    "entrypoint": {"type": "string", "minLength": 1},
+    "mnt_002_executed": {"type": "boolean"},
+    "certification_bundle_ref": {"type": ["string", "null"]},
+    "status": {"type": "string", "enum": ["pass", "block"]},
+    "blocked_reasons": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "unknown_promotion_entrypoint",
+          "mnt_002_required_before_advancement",
+          "missing_certification_bundle"
+        ]
+      },
+      "uniqueItems": true
+    }
+  }
+}

--- a/contracts/standards-manifest.json
+++ b/contracts/standards-manifest.json
@@ -4070,6 +4070,19 @@
       "notes": "Fail-closed enforcement output for missing or indeterminate required eval coverage."
     },
     {
+      "artifact_type": "mnt_advancement_coverage_audit",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.131",
+      "last_updated_in": "1.3.131",
+      "example_path": "contracts/examples/mnt_advancement_coverage_audit.json",
+      "notes": "FSG-RA-001 PRG non-authoritative advancement-path coverage completeness artifact."
+    },
+    {
       "artifact_type": "mnt_enforcement_consistency_result",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -4107,6 +4120,19 @@
       "last_updated_in": "1.3.126",
       "example_path": "contracts/examples/mnt_platform_reliability_bundle.json",
       "notes": "MNT-002 serial reliability operations bundle covering SLO/error budget/burn-rate/certification/active-set/maintain/review and freeze gating."
+    },
+    {
+      "artifact_type": "mnt_promotion_enforcement_result",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.131",
+      "last_updated_in": "1.3.131",
+      "example_path": "contracts/examples/mnt_promotion_enforcement_result.json",
+      "notes": "FSG-RA-001 TLC/SEL/CDE enforcement artifact proving MNT-002 and certification bundle presence before advancement."
     },
     {
       "artifact_type": "mnt_promotion_entrypoint_coverage_report",

--- a/docs/architecture/system_registry.md
+++ b/docs/architecture/system_registry.md
@@ -2039,3 +2039,13 @@ flowchart LR
   - become_sel
   - become_pqx
   - become_prg
+
+## FSG-RA-001 Phase-0 Implementation Note (2026-04-15)
+
+This note records concrete artifact mappings for MNT enforcement hardening without changing canonical ownership.
+
+- **TLC + SEL**: `mnt_promotion_enforcement_result` captures promotion-entrypoint execution checks and fail-closed block decisions when MNT-002 has not executed.
+- **CDE authority seam**: `mnt_promotion_enforcement_result.certification_bundle_ref` is required for advancement, preventing promotion without certification bundle injection.
+- **PRG (non-authoritative)**: `mnt_advancement_coverage_audit` reports required vs audited advancement paths and uncovered paths only; it does not enforce.
+- **SEL semantics**: pass/block/freeze normalization remains enforced through `mnt_enforcement_consistency_result` and real-flow checks.
+- **RIL red-team loop**: `mnt_red_team_round_report` remains the exploit conversion evidence artifact, with explicit test/eval/guard conversion flags.

--- a/docs/review-actions/PLAN-FSG-RA-001-2026-04-15.md
+++ b/docs/review-actions/PLAN-FSG-RA-001-2026-04-15.md
@@ -1,0 +1,43 @@
+# Plan — FULL-STACK-GOVERNANCE-REGISTRY-ALIGNED-001 — 2026-04-15
+
+## Prompt type
+BUILD
+
+## Roadmap item
+FSG-RA-001 (Phase 0 scope): MNT-25, MNT-26, MNT-27, MNT-28, MNT-29, RT-A1/FX-A1
+
+## Objective
+Implement deterministic MNT promotion enforcement and adversarial guard conversion with contract-backed artifacts, tests, and registry-aligned documentation.
+
+## Declared files
+
+| File | Change type | Reason |
+| --- | --- | --- |
+| docs/architecture/system_registry.md | MODIFY | Add implementation note mapping new MNT phase-0 artifacts to canonical owners without changing ownership boundaries. |
+| contracts/schemas/mnt_promotion_enforcement_result.schema.json | CREATE | Contract for promotion entrypoint/bundle enforcement decisions. |
+| contracts/examples/mnt_promotion_enforcement_result.json | CREATE | Golden example for MNT promotion enforcement result. |
+| contracts/schemas/mnt_advancement_coverage_audit.schema.json | CREATE | Contract for PRG non-authoritative coverage audit over advancement paths. |
+| contracts/examples/mnt_advancement_coverage_audit.json | CREATE | Golden example for advancement path coverage artifact. |
+| contracts/standards-manifest.json | MODIFY | Register new contract versions and examples. |
+| spectrum_systems/modules/runtime/mnt_enforcement_runtime.py | MODIFY | Implement promotion guard, certification bundle injection check, coverage audit, real-flow validation, and RT->FX guard conversion helpers. |
+| tests/test_next_wave_contracts.py | MODIFY | Validate new MNT phase-0 examples. |
+| tests/test_next_wave_runtime.py | MODIFY | Add fail-closed tests for bypass prevention, bundle enforcement, coverage completeness, flow enforcement, and red-team conversion rules. |
+
+## Contracts touched
+- mnt_promotion_enforcement_result (new)
+- mnt_advancement_coverage_audit (new)
+- standards-manifest version registry entries for both contracts
+
+## Tests that must pass after execution
+1. `pytest tests/test_next_wave_contracts.py -q`
+2. `pytest tests/test_next_wave_runtime.py -q`
+3. `pytest tests/test_contracts.py tests/test_contract_enforcement.py -q`
+4. `python scripts/run_contract_enforcement.py`
+
+## Scope exclusions
+- No ownership changes in canonical registry role definitions.
+- No authority reassignment between TLC/SEL/CDE/PRG/RIL.
+- No unrelated module refactors outside MNT phase-0 scope.
+
+## Dependencies
+- Existing MNT contracts and runtime baseline in repository.

--- a/spectrum_systems/modules/runtime/mnt_enforcement_runtime.py
+++ b/spectrum_systems/modules/runtime/mnt_enforcement_runtime.py
@@ -1,7 +1,7 @@
-"""MNT-25..MNT-29 enforcement coverage/runtime checks."""
+"""MNT-25..MNT-29 deterministic enforcement coverage/runtime checks."""
 from __future__ import annotations
 
-from typing import Any, Mapping
+from typing import Any, Iterable, Mapping
 
 from spectrum_systems.contracts import validate_artifact
 
@@ -12,6 +12,8 @@ REQUIRED_PROMOTION_ENTRYPOINTS = {
     "control_loop_certification",
 }
 
+_ALLOWED_ENFORCEMENT_STATES = {"pass", "freeze", "block"}
+
 
 def audit_promotion_entrypoints(*, observed_entrypoints: set[str], created_at: str) -> dict[str, Any]:
     uncovered = sorted(REQUIRED_PROMOTION_ENTRYPOINTS - observed_entrypoints)
@@ -20,7 +22,7 @@ def audit_promotion_entrypoints(*, observed_entrypoints: set[str], created_at: s
         "artifact_id": "mnt-entrypoint-audit-001",
         "artifact_version": "1.0.0",
         "schema_version": "1.0.0",
-        "standards_version": "1.3.130",
+        "standards_version": "1.3.131",
         "created_at": created_at,
         "entrypoints": sorted(observed_entrypoints),
         "uncovered_entrypoints": uncovered,
@@ -30,18 +32,116 @@ def audit_promotion_entrypoints(*, observed_entrypoints: set[str], created_at: s
     return rec
 
 
+def enforce_promotion_entrypoint(
+    *,
+    entrypoint: str,
+    mnt_002_executed: bool,
+    certification_bundle_ref: str | None,
+    created_at: str,
+    artifact_id: str = "mnt-promotion-guard-001",
+) -> dict[str, Any]:
+    blocked_reasons: list[str] = []
+    if entrypoint not in REQUIRED_PROMOTION_ENTRYPOINTS:
+        blocked_reasons.append("unknown_promotion_entrypoint")
+    if not mnt_002_executed:
+        blocked_reasons.append("mnt_002_required_before_advancement")
+    if not certification_bundle_ref:
+        blocked_reasons.append("missing_certification_bundle")
+
+    status = "pass" if not blocked_reasons else "block"
+    rec = {
+        "artifact_type": "mnt_promotion_enforcement_result",
+        "artifact_id": artifact_id,
+        "artifact_version": "1.0.0",
+        "schema_version": "1.0.0",
+        "standards_version": "1.3.131",
+        "created_at": created_at,
+        "entrypoint": entrypoint,
+        "mnt_002_executed": mnt_002_executed,
+        "certification_bundle_ref": certification_bundle_ref,
+        "status": status,
+        "blocked_reasons": blocked_reasons,
+    }
+    validate_artifact(rec, "mnt_promotion_enforcement_result")
+    return rec
+
+
+def audit_advancement_path_coverage(
+    *, required_paths: Iterable[str], audited_paths: Iterable[str], created_at: str, artifact_id: str = "mnt-advancement-audit-001"
+) -> dict[str, Any]:
+    required = sorted({str(v) for v in required_paths if str(v).strip()})
+    audited = sorted({str(v) for v in audited_paths if str(v).strip()})
+    uncovered = sorted(set(required) - set(audited))
+    rec = {
+        "artifact_type": "mnt_advancement_coverage_audit",
+        "artifact_id": artifact_id,
+        "artifact_version": "1.0.0",
+        "schema_version": "1.0.0",
+        "standards_version": "1.3.131",
+        "created_at": created_at,
+        "required_paths": required,
+        "audited_paths": audited,
+        "uncovered_paths": uncovered,
+        "complete": not uncovered,
+    }
+    validate_artifact(rec, "mnt_advancement_coverage_audit")
+    return rec
+
+
 def consistency_check(*, gate_results: Mapping[str, str], created_at: str) -> dict[str, Any]:
-    inconsistent = sorted([gate for gate, state in gate_results.items() if state not in {"pass", "freeze", "block"}])
+    inconsistent = sorted([gate for gate, state in gate_results.items() if state not in _ALLOWED_ENFORCEMENT_STATES])
     rec = {
         "artifact_type": "mnt_enforcement_consistency_result",
         "artifact_id": "mnt-consistency-001",
         "artifact_version": "1.0.0",
         "schema_version": "1.0.0",
-        "standards_version": "1.3.130",
+        "standards_version": "1.3.131",
         "created_at": created_at,
         "checked_gates": sorted(gate_results.keys()),
         "inconsistent_gates": inconsistent,
         "status": "pass" if not inconsistent else "fail",
     }
     validate_artifact(rec, "mnt_enforcement_consistency_result")
+    return rec
+
+
+def validate_real_flow(*, flow_id: str, step_results: Mapping[str, str], created_at: str, artifact_id: str = "mnt-flow-001") -> dict[str, Any]:
+    reason_codes = sorted([f"{step}:invalid_state" for step, value in step_results.items() if value not in _ALLOWED_ENFORCEMENT_STATES])
+    status = "pass" if not reason_codes else "fail"
+    rec = {
+        "artifact_type": "mnt_real_flow_reliability_result",
+        "artifact_id": artifact_id,
+        "artifact_version": "1.0.0",
+        "schema_version": "1.0.0",
+        "standards_version": "1.3.131",
+        "created_at": created_at,
+        "flow_id": flow_id,
+        "steps_checked": sorted(step_results.keys()),
+        "status": status,
+        "reason_codes": reason_codes or ["all_steps_enforced"],
+    }
+    validate_artifact(rec, "mnt_real_flow_reliability_result")
+    return rec
+
+
+def run_mnt_red_team_round(*, round_id: str, exploits: list[dict[str, Any]], generated_at: str, artifact_id: str = "mnt-rt-round-001") -> dict[str, Any]:
+    exploit_ids = sorted(str(item.get("exploit_id") or "unknown") for item in exploits)
+    tests_converted = all(bool(item.get("guard_test_id")) for item in exploits)
+    evals_converted = all(bool(item.get("eval_case_id")) for item in exploits)
+    guards_converted = all(bool(item.get("guard_rule_id")) for item in exploits)
+    rec = {
+        "artifact_type": "mnt_red_team_round_report",
+        "artifact_id": artifact_id,
+        "artifact_version": "1.0.0",
+        "schema_version": "1.0.0",
+        "standards_version": "1.3.131",
+        "round_id": round_id,
+        "generated_at": generated_at,
+        "exploit_count": len(exploits),
+        "exploits": exploit_ids,
+        "all_exploits_converted_to_tests": tests_converted,
+        "all_exploits_converted_to_evals": evals_converted,
+        "all_exploits_converted_to_guards": guards_converted,
+    }
+    validate_artifact(rec, "mnt_red_team_round_report")
     return rec

--- a/tests/test_next_wave_contracts.py
+++ b/tests/test_next_wave_contracts.py
@@ -27,6 +27,8 @@ CONTRACTS = [
     "ext_constraint_enforcement_record",
     "ext_runtime_governance_bundle",
     "mnt_promotion_entrypoint_coverage_report",
+    "mnt_promotion_enforcement_result",
+    "mnt_advancement_coverage_audit",
     "mnt_enforcement_consistency_result",
     "mnt_real_flow_reliability_result",
 ]

--- a/tests/test_next_wave_runtime.py
+++ b/tests/test_next_wave_runtime.py
@@ -3,7 +3,14 @@ import pytest
 from spectrum_systems.modules.runtime.dag_runtime import build_dependency_graph, detect_cycles, DAGRuntimeError
 from spectrum_systems.modules.runtime.ext_runtime import build_runtime_provenance, enforce_constraints, EXTRuntimeError
 from spectrum_systems.modules.runtime.jdx_runtime import create_judgment_record, evaluate_judgment, run_jdx_redteam, JDXRuntimeError
-from spectrum_systems.modules.runtime.mnt_enforcement_runtime import audit_promotion_entrypoints, consistency_check
+from spectrum_systems.modules.runtime.mnt_enforcement_runtime import (
+    audit_advancement_path_coverage,
+    audit_promotion_entrypoints,
+    consistency_check,
+    enforce_promotion_entrypoint,
+    run_mnt_red_team_round,
+    validate_real_flow,
+)
 from spectrum_systems.modules.runtime.rel_runtime import build_canary_metrics, build_release_record, freeze_on_budget
 from spectrum_systems.modules.runtime.rux_runtime import create_reuse_record, enforce_reuse_boundary, RUXRuntimeError
 from spectrum_systems.modules.runtime.xpl_runtime import create_artifact_card, XPLRuntimeError
@@ -84,3 +91,47 @@ def test_mnt_coverage_and_consistency() -> None:
     assert coverage["status"] == "fail"
     consistency = consistency_check(gate_results={"g1": "pass", "g2": "weird"}, created_at=CREATED)
     assert consistency["status"] == "fail"
+
+
+def test_mnt_promotion_guard_blocks_bypass_and_missing_bundle() -> None:
+    blocked = enforce_promotion_entrypoint(
+        entrypoint="promotion_gate",
+        mnt_002_executed=False,
+        certification_bundle_ref=None,
+        created_at=CREATED,
+    )
+    assert blocked["status"] == "block"
+    assert "mnt_002_required_before_advancement" in blocked["blocked_reasons"]
+    assert "missing_certification_bundle" in blocked["blocked_reasons"]
+
+
+def test_mnt_coverage_audit_completeness_and_real_flow_validation() -> None:
+    audit = audit_advancement_path_coverage(
+        required_paths={"promotion_gate", "release_gate", "control_loop_certification"},
+        audited_paths={"promotion_gate", "release_gate"},
+        created_at=CREATED,
+    )
+    assert audit["complete"] is False
+    assert "control_loop_certification" in audit["uncovered_paths"]
+
+    flow = validate_real_flow(
+        flow_id="flow-001",
+        step_results={"s1": "pass", "s2": "freeze", "s3": "bad"},
+        created_at=CREATED,
+    )
+    assert flow["status"] == "fail"
+    assert "s3:invalid_state" in flow["reason_codes"]
+
+
+def test_mnt_red_team_requires_guard_eval_test_conversion() -> None:
+    report = run_mnt_red_team_round(
+        round_id="RT3",
+        generated_at=CREATED,
+        exploits=[
+            {"exploit_id": "exp-1", "guard_test_id": "t-1", "eval_case_id": "e-1", "guard_rule_id": "g-1"},
+            {"exploit_id": "exp-2", "guard_test_id": "t-2", "eval_case_id": "e-2", "guard_rule_id": ""},
+        ],
+    )
+    assert report["all_exploits_converted_to_tests"] is True
+    assert report["all_exploits_converted_to_evals"] is True
+    assert report["all_exploits_converted_to_guards"] is False


### PR DESCRIPTION
### Motivation
- Close the MNT-25..MNT-29 enforcement gap by providing deterministic, fail-closed promotion guards that prevent bypass of required certification and execution steps. 
- Produce a non-authoritative coverage audit so PRG can report uncovered advancement paths without expanding authority. 
- Ensure adversarial findings are converted into guard/eval/test artifacts and visible via an auditable red-team report. 
- Preserve canonical system ownership and registry alignment while adding concrete contracts, runtime checks, and tests. 

### Description
- Added two new contracts and golden examples: `mnt_promotion_enforcement_result` and `mnt_advancement_coverage_audit` under `contracts/schemas/` and `contracts/examples/`. 
- Implemented deterministic runtime functions in `spectrum_systems/modules/runtime/mnt_enforcement_runtime.py`: `enforce_promotion_entrypoint`, `audit_advancement_path_coverage`, `validate_real_flow`, and `run_mnt_red_team_round`, and tightened consistency checks. 
- Registered the new artifacts in `contracts/standards-manifest.json` and appended an implementation note to `docs/architecture/system_registry.md` that maps artifacts to owners without changing ownership. 
- Added a scoped BUILD plan `docs/review-actions/PLAN-FSG-RA-001-2026-04-15.md` and extended `tests/test_next_wave_contracts.py` and `tests/test_next_wave_runtime.py` to validate new contracts and guard behavior. 

### Testing
- Ran `pytest tests/test_next_wave_contracts.py -q` and it passed. 
- Ran `pytest tests/test_next_wave_runtime.py -q` and all new and existing runtime tests passed. 
- Ran `pytest tests/test_contracts.py tests/test_contract_enforcement.py -q` and the full contract suite passed (`132 passed`). 
- Ran `python scripts/run_contract_enforcement.py` and the contract enforcement run produced no failures (`failures=0 warnings=0`), and `.codex/skills/contract-boundary-audit/run.sh` reported `PASS-WARN` with no blocking violations. 
- Ran `pytest tests/test_system_registry_boundaries.py -q` (12 passed) and `pytest tests/test_system_integration_validator.py -q` (7 passed); all validations succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ded6dbb89c8329961775b04bc92a5d)