### PR TITLE
PYX-04: restore push governed preflight and harden required-check alignment audit

### DIFF
--- a/.github/workflows/artifact-boundary.yml
+++ b/.github/workflows/artifact-boundary.yml
@@ -105,6 +105,79 @@ jobs:
           if-no-files-found: warn
           path: outputs/system_registry_guard/system_registry_guard_result.json
 
+  governed-contract-preflight:
+    if: github.event_name == 'push'
+    needs:
+      - enforce-artifact-boundary
+      - validate-module-architecture
+      - validate-orchestration-boundaries
+      - system-registry-guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install test dependencies
+        run: python -m pip install -r requirements-dev.txt
+
+      - name: Resolve preflight refs
+        id: preflight-refs
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            echo "base_ref=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT"
+            echo "head_ref=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          elif [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            echo "base_ref=${{ github.event.before }}" >> "$GITHUB_OUTPUT"
+            echo "head_ref=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "base_ref=origin/main" >> "$GITHUB_OUTPUT"
+            echo "head_ref=HEAD" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run authoritative governed preflight gate (push)
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
+          GITHUB_BEFORE_SHA: ${{ github.event.before || '' }}
+          GITHUB_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          python scripts/build_preflight_pqx_wrapper.py \
+            --base-ref "${{ steps.preflight-refs.outputs.base_ref }}" \
+            --head-ref "${{ steps.preflight-refs.outputs.head_ref }}" \
+            --output outputs/contract_preflight/preflight_pqx_task_wrapper.json
+
+          python scripts/run_contract_preflight.py \
+            --base-ref "${{ steps.preflight-refs.outputs.base_ref }}" \
+            --head-ref "${{ steps.preflight-refs.outputs.head_ref }}" \
+            --output-dir outputs/contract_preflight \
+            --execution-context pqx_governed \
+            --pqx-wrapper-path outputs/contract_preflight/preflight_pqx_task_wrapper.json \
+            --authority-evidence-ref artifacts/pqx_runs/preflight.pqx_slice_execution_record.json
+
+      - name: Upload contract preflight outputs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: contract-preflight-outputs-push
+          if-no-files-found: warn
+          path: |
+            outputs/contract_preflight/contract_preflight_report.md
+            outputs/contract_preflight/contract_preflight_report.json
+            outputs/contract_preflight/contract_preflight_result_artifact.json
+            outputs/contract_preflight/system_registry_guard_result.json
+            outputs/contract_preflight/contract_preflight_diagnosis_bundle.md
+
   run-pytest:
     needs:
       - enforce-artifact-boundary

--- a/contracts/examples/required_check_alignment_audit_result.json
+++ b/contracts/examples/required_check_alignment_audit_result.json
@@ -9,6 +9,7 @@
   "live_github_alignment_status": "unknown",
   "final_decision": "WARN",
   "blocking_reasons": [],
+  "mismatch_details": [],
   "operator_actions_required": [
     "Verify GitHub branch protection required status checks include exactly 'PR / pytest' and remove obsolete checks."
   ],

--- a/contracts/schemas/required_check_alignment_audit_result.schema.json
+++ b/contracts/schemas/required_check_alignment_audit_result.schema.json
@@ -15,6 +15,7 @@
     "live_github_alignment_status",
     "final_decision",
     "blocking_reasons",
+    "mismatch_details",
     "operator_actions_required",
     "generated_at"
   ],
@@ -41,6 +42,27 @@
       "type": "array",
       "items": {"type": "string", "minLength": 1},
       "uniqueItems": true
+    },
+    "mismatch_details": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "mismatch_class",
+          "expected_policy_value",
+          "discovered_workflow_value",
+          "blocking",
+          "recommended_remediation"
+        ],
+        "properties": {
+          "mismatch_class": {"type": "string", "minLength": 1},
+          "expected_policy_value": {"type": "string"},
+          "discovered_workflow_value": {"type": "string"},
+          "blocking": {"type": "boolean"},
+          "recommended_remediation": {"type": "string", "minLength": 1}
+        }
+      }
     },
     "operator_actions_required": {
       "type": "array",

--- a/docs/review-actions/PLAN-PYX-04-2026-04-15.md
+++ b/docs/review-actions/PLAN-PYX-04-2026-04-15.md
@@ -1,0 +1,114 @@
+# PLAN-PYX-04-2026-04-15
+
+Prompt type: BUILD
+
+PYX-04-01 — restore push-path authoritative governed preflight  
+Owner: PYX / GOV
+
+Build:
+- files:
+  - update `.github/workflows/artifact-boundary.yml`
+  - update `.github/workflows/pr-pytest.yml` only if needed for consistency
+- functionality:
+  - restore an authoritative governed preflight execution path on push
+  - ensure push-triggered CI runs the governed preflight path, not just lightweight pytest
+  - preserve the explicit PR-visible workflow/job that surfaces as `PR / pytest`
+  - do NOT make push rely on PR-only workflow
+- integration:
+  - keep `artifact-boundary.yml` as the authoritative push surface and invoke `python scripts/run_contract_preflight.py` on push
+  - keep required artifact generation / enforcement semantics for preflight outputs
+  - avoid duplicate authorities; keep one authoritative push preflight surface and one explicit PR-visible surface
+- tests:
+  - update/add tests proving push workflow runs governed preflight
+  - update/add tests proving PR workflow surfaces explicit `PR / pytest`
+  - update/add tests proving push path is not downgraded to lightweight pytest-only execution
+
+Definition of done:
+- push-triggered CI has authoritative governed preflight coverage
+- PR-visible `PR / pytest` surface remains intact
+
+PYX-04-02 — make required-check alignment audit fail closed with structured mismatch, not exception  
+Owner: AUD / GOV
+
+Build:
+- files:
+  - update required-check alignment audit runtime module and contract schema/example
+  - update callers/tests that previously assumed brittle drift handling
+- functionality:
+  - convert ordinary policy/workflow drift into structured mismatch entries
+  - keep fail-closed behavior so mismatch still blocks
+  - remove raw exception dependence for ordinary drift conditions
+- integration:
+  - compute discovered workflow/job/check surfaces from workflow payload
+  - emit mismatch details including expected policy value, discovered value, mismatch class, blocking boolean, and remediation
+- tests:
+  - add/update tests for structured mismatch on drift
+  - add/update tests for fail-closed blocking on mismatch
+  - add/update tests proving ordinary drift does not throw unstructured exceptions
+  - keep clean pass behavior when aligned
+
+Definition of done:
+- required-check drift is diagnosable via structured mismatch artifacts and remains fail-closed
+
+PYX-04-03 — preserve explicit PR-visible pytest check naming and required-check alignment  
+Owner: PYX / GOV
+
+Build:
+- files:
+  - update `docs/governance/required_pr_checks.json` only if needed
+  - keep workflow naming stable unless correction is required
+- functionality:
+  - preserve explicit PR-visible check as `PR / pytest`
+  - keep policy/workflow naming aligned and stable
+- integration:
+  - verify workflow name + job name surface the intended check name
+  - verify required-check policy points at the surfaced check
+- tests:
+  - add/update tests proving surfaced PR check remains `PR / pytest`
+  - add/update tests proving policy points at surfaced check
+  - add/update tests proving naming stability
+
+Definition of done:
+- PR UI remains operator-clear and policy-aligned
+
+PYX-04-04 — strengthen explicit push-context and PR-context regression coverage  
+Owner: PYX / GOV / TEST
+
+Build:
+- files:
+  - update `tests/test_artifact_boundary_workflow_pytest_enforcement.py`
+  - update `tests/test_required_check_alignment_audit.py`
+  - update `tests/test_contract_preflight.py`
+  - add `tests/test_pyx_push_and_pr_context_enforcement.py` if needed
+- functionality:
+  - ensure explicit coverage for push-context governed preflight behavior
+  - ensure explicit coverage for PR-context governed preflight behavior
+  - ensure strict PR-visible check semantics stay enforced
+  - ensure deterministic non-PR environment handling remains explicit
+  - ensure audit mismatch structure is covered
+- integration:
+  - keep tests deterministic with fixture/text inspection patterns
+  - avoid ambient GitHub Actions dependencies
+- tests:
+  - use clear push and PR context fixtures/inputs
+  - explicitly exercise both contexts
+
+Definition of done:
+- test surface explicitly covers push and PR trust paths
+
+PYX-04-05 — write review and delivery artifacts for this corrective slice  
+Owner: GOV
+
+Build:
+- files:
+  - `docs/review-actions/PLAN-PYX-04-2026-04-15.md`
+  - `docs/reviews/PYX-04_push_preflight_and_required_check_alignment_review.md`
+- functionality:
+  - record root cause, workflow/job/check names before/after, push-path restoration details, structured mismatch behavior, and residual risk
+- integration:
+  - keep review artifact concise and technical
+- tests:
+  - no additional tests beyond repo validation norms
+
+Definition of done:
+- corrective slice is documented and reviewable

--- a/docs/reviews/PYX-04_push_preflight_and_required_check_alignment_review.md
+++ b/docs/reviews/PYX-04_push_preflight_and_required_check_alignment_review.md
@@ -1,0 +1,52 @@
+# PYX-04 Push Preflight and Required-Check Alignment Review
+
+## Root cause
+
+Prior hardening introduced an explicit PR-visible pytest check (`PR / pytest`) but left trust seams:
+- push-path authoritative governed preflight was not explicitly executed from the push authority workflow;
+- required-check drift handling relied on brittle extraction/exception behavior rather than structured mismatch diagnostics.
+
+## Workflow / job / check surface before vs after
+
+### Before
+- Push authority workflow: `.github/workflows/artifact-boundary.yml`
+  - had no explicit governed contract preflight job on push.
+  - had non-authoritative redundancy `run-pytest` (`pytest` command).
+- PR-visible workflow: `.github/workflows/pr-pytest.yml`
+  - workflow name: `PR`
+  - authoritative job id: `pytest`
+  - job display name: `pytest`
+  - surfaced check: `PR / pytest`
+
+### After
+- Push authority workflow: `.github/workflows/artifact-boundary.yml`
+  - adds `governed-contract-preflight` job gated to push (`if: github.event_name == 'push'`).
+  - job executes governed preflight entrypoint `python scripts/run_contract_preflight.py` with `pqx_governed` context and canonical authority evidence ref.
+  - existing `run-pytest` remains explicit non-authoritative redundancy.
+- PR-visible workflow: `.github/workflows/pr-pytest.yml`
+  - unchanged explicit surface:
+    - workflow `PR`
+    - job `pytest` / display name `pytest`
+    - surfaced required check `PR / pytest`
+
+## Push-path authority restoration
+
+- Restored push-authoritative preflight by adding a dedicated governed preflight job inside `artifact-boundary.yml`.
+- Job resolves refs, builds PQX wrapper, runs contract preflight, and uploads preflight artifacts.
+- This keeps one push authority surface (`artifact-boundary`) while preserving explicit PR UI surface (`PR / pytest`).
+
+## Required-check drift handling correction
+
+- `required_check_alignment_audit` now emits structured mismatch entries for ordinary drift instead of relying on unstructured exceptions.
+- Mismatch entry fields:
+  - `mismatch_class`
+  - `expected_policy_value`
+  - `discovered_workflow_value`
+  - `blocking`
+  - `recommended_remediation`
+- Drift remains fail-closed: any blocking mismatch yields `final_decision: BLOCK`.
+
+## Remaining risks
+
+- Live GitHub required-check evidence can still be unavailable in local/offline runs; this remains explicitly surfaced as readable mismatch/action guidance.
+- Workflow-text based regression tests are intentionally strict string guards; future intentional workflow renames must update tests and policy in the same change.

--- a/spectrum_systems/modules/runtime/required_check_alignment_audit.py
+++ b/spectrum_systems/modules/runtime/required_check_alignment_audit.py
@@ -35,6 +35,23 @@ def _extract_authoritative_job(workflow_payload: dict[str, Any], *, authoritativ
     return workflow_name, authoritative_job_id, display_name
 
 
+def _mismatch(
+    *,
+    mismatch_class: str,
+    expected_policy_value: str,
+    discovered_workflow_value: str,
+    recommended_remediation: str,
+    blocking: bool = True,
+) -> dict[str, Any]:
+    return {
+        "mismatch_class": mismatch_class,
+        "expected_policy_value": expected_policy_value,
+        "discovered_workflow_value": discovered_workflow_value,
+        "blocking": bool(blocking),
+        "recommended_remediation": recommended_remediation,
+    }
+
+
 def run_required_check_alignment_audit(
     *,
     workflow_payload: dict[str, Any],
@@ -44,36 +61,102 @@ def run_required_check_alignment_audit(
     generated_at: str | None = None,
 ) -> dict[str, Any]:
     policy_job_id = str(required_policy_payload.get("authoritative_job_id") or "").strip()
-    if not policy_job_id:
-        raise ValueError("policy_missing_authoritative_job_id")
+    policy_workflow = str(required_policy_payload.get("workflow") or "").strip()
+    policy_display_name = str(required_policy_payload.get("authoritative_display_name") or "").strip()
+    required_status_check_name = str(required_policy_payload.get("required_status_check_name") or "").strip()
 
-    workflow_name, authoritative_job_id, authoritative_display_name = _extract_authoritative_job(
-        workflow_payload,
-        authoritative_job_id=policy_job_id,
-    )
-    expected_required_check = f"{workflow_name} / {authoritative_display_name}"
+    discovered_workflow_name = str(workflow_payload.get("name") or "").strip() or "artifact-boundary"
+    discovered_job_id = policy_job_id or "pytest"
+    discovered_display_name = ""
+    expected_required_check = required_status_check_name or f"{policy_workflow or discovered_workflow_name} / {policy_display_name or 'pytest'}"
+    mismatch_details: list[dict[str, Any]] = []
+
+    jobs = workflow_payload.get("jobs")
+    if not isinstance(jobs, dict):
+        mismatch_details.append(
+            _mismatch(
+                mismatch_class="WORKFLOW_MISSING_JOBS",
+                expected_policy_value="workflow.jobs object with authoritative job",
+                discovered_workflow_value="missing_or_invalid_workflow.jobs",
+                recommended_remediation="Define workflow jobs map and include policy authoritative_job_id.",
+            )
+        )
+    elif policy_job_id and isinstance(jobs.get(policy_job_id), dict):
+        discovered_job = jobs.get(policy_job_id) or {}
+        discovered_display_name = str(discovered_job.get("name") or "").strip()
+        discovered_job_id = policy_job_id
+        expected_required_check = f"{discovered_workflow_name} / {discovered_display_name or policy_display_name or 'pytest'}"
+    else:
+        mismatch_details.append(
+            _mismatch(
+                mismatch_class="WORKFLOW_MISSING_AUTHORITATIVE_JOB",
+                expected_policy_value=policy_job_id or "authoritative_job_id",
+                discovered_workflow_value="missing",
+                recommended_remediation="Align policy authoritative_job_id to a real workflow job id and set a job name.",
+            )
+        )
+
+    if policy_job_id and not discovered_display_name and isinstance(jobs, dict) and isinstance(jobs.get(policy_job_id), dict):
+        mismatch_details.append(
+            _mismatch(
+                mismatch_class="WORKFLOW_MISSING_AUTHORITATIVE_JOB_NAME",
+                expected_policy_value="non-empty workflow job display name",
+                discovered_workflow_value="empty",
+                recommended_remediation="Set jobs.<authoritative_job_id>.name so required check surface is explicit.",
+            )
+        )
 
     local_required_checks_payloads = local_required_checks_payloads or []
 
     blocking_reasons: list[str] = []
     operator_actions_required: list[str] = []
-
-    required_status_check_name = str(required_policy_payload.get("required_status_check_name") or "").strip()
-    policy_workflow = str(required_policy_payload.get("workflow") or "").strip()
-    policy_job_id = str(required_policy_payload.get("authoritative_job_id") or "").strip()
-    policy_display_name = str(required_policy_payload.get("authoritative_display_name") or "").strip()
+    authoritative_job_id = discovered_job_id
+    authoritative_display_name = discovered_display_name or policy_display_name or "pytest"
+    workflow_name = discovered_workflow_name
 
     if required_status_check_name != expected_required_check:
         blocking_reasons.append("POLICY_REQUIRED_CHECK_NAME_MISMATCH")
+        mismatch_details.append(
+            _mismatch(
+                mismatch_class="POLICY_REQUIRED_CHECK_NAME_MISMATCH",
+                expected_policy_value=required_status_check_name or "<missing>",
+                discovered_workflow_value=expected_required_check,
+                recommended_remediation="Set policy required_status_check_name to match workflow/check surface.",
+            )
+        )
     if policy_workflow != workflow_name:
         blocking_reasons.append("POLICY_WORKFLOW_MISMATCH")
+        mismatch_details.append(
+            _mismatch(
+                mismatch_class="POLICY_WORKFLOW_MISMATCH",
+                expected_policy_value=policy_workflow or "<missing>",
+                discovered_workflow_value=workflow_name,
+                recommended_remediation="Set policy workflow to the authoritative workflow name.",
+            )
+        )
     if policy_job_id != authoritative_job_id:
         blocking_reasons.append("POLICY_JOB_ID_MISMATCH")
+        mismatch_details.append(
+            _mismatch(
+                mismatch_class="POLICY_JOB_ID_MISMATCH",
+                expected_policy_value=policy_job_id or "<missing>",
+                discovered_workflow_value=authoritative_job_id,
+                recommended_remediation="Set policy authoritative_job_id to the authoritative workflow job id.",
+            )
+        )
     if policy_display_name != authoritative_display_name:
         blocking_reasons.append("POLICY_DISPLAY_NAME_MISMATCH")
+        mismatch_details.append(
+            _mismatch(
+                mismatch_class="POLICY_DISPLAY_NAME_MISMATCH",
+                expected_policy_value=policy_display_name or "<missing>",
+                discovered_workflow_value=authoritative_display_name,
+                recommended_remediation="Set policy authoritative_display_name to the workflow job display name.",
+            )
+        )
 
     local_policy_alignment_status = "aligned"
-    if blocking_reasons:
+    if blocking_reasons or mismatch_details:
         local_policy_alignment_status = "contradiction"
 
     local_config_reasons: list[str] = []
@@ -86,9 +169,25 @@ def run_required_check_alignment_audit(
             continue
         if expected_required_check not in normalized:
             local_config_reasons.append("LOCAL_REQUIRED_CHECKS_MISSING_EXPECTED")
+            mismatch_details.append(
+                _mismatch(
+                    mismatch_class="LOCAL_REQUIRED_CHECKS_MISSING_EXPECTED",
+                    expected_policy_value=expected_required_check,
+                    discovered_workflow_value=", ".join(sorted(normalized)) or "<empty>",
+                    recommended_remediation="Update local required status checks evidence to include authoritative check.",
+                )
+            )
         obsolete = {"contract-preflight"}
         if obsolete & normalized:
             local_config_reasons.append("LOCAL_REQUIRED_CHECKS_REFERENCE_OBSOLETE")
+            mismatch_details.append(
+                _mismatch(
+                    mismatch_class="LOCAL_REQUIRED_CHECKS_REFERENCE_OBSOLETE",
+                    expected_policy_value="no obsolete required checks",
+                    discovered_workflow_value=", ".join(sorted(obsolete & normalized)),
+                    recommended_remediation="Remove obsolete required checks from local branch-protection snapshots.",
+                )
+            )
 
     if local_config_reasons:
         local_policy_alignment_status = "contradiction"
@@ -104,12 +203,36 @@ def run_required_check_alignment_audit(
             else:
                 live_github_alignment_status = "misaligned"
                 blocking_reasons.append("LIVE_GITHUB_REQUIRED_CHECK_MISSING_EXPECTED")
+                mismatch_details.append(
+                    _mismatch(
+                        mismatch_class="LIVE_GITHUB_REQUIRED_CHECK_MISSING_EXPECTED",
+                        expected_policy_value=expected_required_check,
+                        discovered_workflow_value=", ".join(sorted(normalized)) or "<empty>",
+                        recommended_remediation="Update GitHub branch protection to require the authoritative check.",
+                    )
+                )
             if "contract-preflight" in normalized:
                 live_github_alignment_status = "misaligned"
                 blocking_reasons.append("LIVE_GITHUB_REQUIRED_CHECK_REFERENCES_OBSOLETE")
+                mismatch_details.append(
+                    _mismatch(
+                        mismatch_class="LIVE_GITHUB_REQUIRED_CHECK_REFERENCES_OBSOLETE",
+                        expected_policy_value="no obsolete checks",
+                        discovered_workflow_value="contract-preflight",
+                        recommended_remediation="Remove obsolete contract-preflight from GitHub required checks.",
+                    )
+                )
         else:
             blocking_reasons.append("LIVE_GITHUB_REQUIRED_CHECKS_UNREADABLE")
             live_github_alignment_status = "unknown"
+            mismatch_details.append(
+                _mismatch(
+                    mismatch_class="LIVE_GITHUB_REQUIRED_CHECKS_UNREADABLE",
+                    expected_policy_value="readable required_status_checks array",
+                    discovered_workflow_value="missing_or_invalid_required_status_checks",
+                    recommended_remediation="Collect readable live required checks evidence payload and rerun audit.",
+                )
+            )
 
     if live_github_alignment_status == "unknown":
         operator_actions_required.append(
@@ -118,8 +241,16 @@ def run_required_check_alignment_audit(
 
     blocking_reasons = sorted(set(blocking_reasons))
     operator_actions_required = sorted(set(operator_actions_required))
+    mismatch_details = sorted(
+        mismatch_details,
+        key=lambda item: (
+            str(item.get("mismatch_class") or ""),
+            str(item.get("expected_policy_value") or ""),
+            str(item.get("discovered_workflow_value") or ""),
+        ),
+    )
 
-    if blocking_reasons:
+    if any(bool(item.get("blocking")) for item in mismatch_details) or blocking_reasons:
         final_decision = "BLOCK"
     elif live_github_alignment_status == "aligned":
         final_decision = "PASS"
@@ -137,6 +268,7 @@ def run_required_check_alignment_audit(
         "live_github_alignment_status": live_github_alignment_status,
         "final_decision": final_decision,
         "blocking_reasons": blocking_reasons,
+        "mismatch_details": mismatch_details,
         "operator_actions_required": operator_actions_required,
         "generated_at": generated_at or _utc_now(),
     }

--- a/tests/test_artifact_boundary_workflow_pytest_enforcement.py
+++ b/tests/test_artifact_boundary_workflow_pytest_enforcement.py
@@ -24,6 +24,24 @@ def test_artifact_boundary_redundant_pytest_job_no_longer_depends_on_preflight_j
     text = ARTIFACT_BOUNDARY_WORKFLOW.read_text(encoding='utf-8')
     assert '- pytest-pr' not in text
     assert '- contract-preflight' not in text
+    assert '- governed-contract-preflight' not in text
+
+
+def test_artifact_boundary_restores_push_authoritative_governed_preflight() -> None:
+    text = ARTIFACT_BOUNDARY_WORKFLOW.read_text(encoding='utf-8')
+    assert 'governed-contract-preflight:' in text
+    assert "if: github.event_name == 'push'" in text
+    assert 'Run authoritative governed preflight gate (push)' in text
+    assert 'python scripts/run_contract_preflight.py' in text
+    assert '--execution-context pqx_governed' in text
+    assert '--authority-evidence-ref artifacts/pqx_runs/preflight.pqx_slice_execution_record.json' in text
+
+
+def test_artifact_boundary_push_preflight_is_not_replaced_by_lightweight_pytest_only() -> None:
+    text = ARTIFACT_BOUNDARY_WORKFLOW.read_text(encoding='utf-8')
+    assert 'governed-contract-preflight:' in text
+    assert 'run: pytest' in text
+    assert text.index('governed-contract-preflight:') < text.index('run-pytest:')
 
 
 def test_pr_pytest_workflow_does_not_bypass_artifact_validation_on_preflight_exit_zero() -> None:

--- a/tests/test_contract_preflight.py
+++ b/tests/test_contract_preflight.py
@@ -2173,6 +2173,14 @@ def test_push_warn_control_signal_remains_explicit() -> None:
     assert result["strategy_gate_decision"] == "ALLOW"
 
 
+def test_push_and_pull_request_control_signal_decisions_remain_context_specific() -> None:
+    report = {"status": "passed", "changed_path_detection": {}, "pqx_execution_policy": {"status": "warn"}}
+    pr = preflight.map_preflight_control_signal(report=report, hardening_flow=False, event_name="pull_request")
+    push = preflight.map_preflight_control_signal(report=report, hardening_flow=False, event_name="push")
+    assert pr["strategy_gate_decision"] == "BLOCK"
+    assert push["strategy_gate_decision"] == "ALLOW"
+
+
 def test_pr_degraded_ref_resolution_blocks_with_invariants(tmp_path: Path, monkeypatch) -> None:
     output_dir = tmp_path / "out"
     monkeypatch.setattr(

--- a/tests/test_pyx_push_and_pr_context_enforcement.py
+++ b/tests/test_pyx_push_and_pr_context_enforcement.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ARTIFACT_BOUNDARY_WORKFLOW = Path(".github/workflows/artifact-boundary.yml")
+PR_PYTEST_WORKFLOW = Path(".github/workflows/pr-pytest.yml")
+REQUIRED_CHECK_POLICY = Path("docs/governance/required_pr_checks.json")
+
+
+def test_push_and_pull_request_triggers_are_explicit_and_separated() -> None:
+    artifact_text = ARTIFACT_BOUNDARY_WORKFLOW.read_text(encoding="utf-8")
+    pr_text = PR_PYTEST_WORKFLOW.read_text(encoding="utf-8")
+    assert "on:" in artifact_text
+    assert "push:" in artifact_text
+    assert "pull_request:" in artifact_text
+    assert "on:" in pr_text
+    assert "pull_request:" in pr_text
+    assert "push:" not in pr_text
+
+
+def test_pr_visible_check_surface_remains_pr_slash_pytest() -> None:
+    policy = json.loads(REQUIRED_CHECK_POLICY.read_text(encoding="utf-8"))
+    pr_text = PR_PYTEST_WORKFLOW.read_text(encoding="utf-8")
+    assert policy["workflow"] == "PR"
+    assert policy["authoritative_job_id"] == "pytest"
+    assert policy["authoritative_display_name"] == "pytest"
+    assert policy["required_status_check_name"] == "PR / pytest"
+    assert "name: PR" in pr_text
+    assert "pytest:" in pr_text
+    assert "name: pytest" in pr_text
+
+
+def test_push_preflight_and_pr_preflight_use_governed_contract_entrypoint() -> None:
+    artifact_text = ARTIFACT_BOUNDARY_WORKFLOW.read_text(encoding="utf-8")
+    pr_text = PR_PYTEST_WORKFLOW.read_text(encoding="utf-8")
+    assert "Run authoritative governed preflight gate (push)" in artifact_text
+    assert "python scripts/run_contract_preflight.py" in artifact_text
+    assert "--execution-context pqx_governed" in artifact_text
+    assert "Run governed pytest preflight gate" in pr_text
+    assert "python scripts/run_contract_preflight.py" in pr_text

--- a/tests/test_required_check_alignment_audit.py
+++ b/tests/test_required_check_alignment_audit.py
@@ -28,6 +28,7 @@ def test_required_check_alignment_passes_when_live_evidence_matches() -> None:
     )
     assert result["final_decision"] == "PASS"
     assert result["live_github_alignment_status"] == "aligned"
+    assert result["mismatch_details"] == []
     validate_artifact(result, "required_check_alignment_audit_result")
 
 
@@ -76,3 +77,22 @@ def test_required_check_alignment_detects_policy_workflow_drift() -> None:
     )
     assert result["final_decision"] == "BLOCK"
     assert "POLICY_WORKFLOW_MISMATCH" in result["blocking_reasons"]
+    mismatch_classes = {entry["mismatch_class"] for entry in result["mismatch_details"]}
+    assert "POLICY_WORKFLOW_MISMATCH" in mismatch_classes
+
+
+def test_required_check_alignment_drift_is_structured_when_workflow_job_missing() -> None:
+    result = run_required_check_alignment_audit(
+        workflow_payload={"name": "PR", "jobs": {}},
+        required_policy_payload={
+            "workflow": "PR",
+            "authoritative_job_id": "pytest",
+            "authoritative_display_name": "pytest",
+            "required_status_check_name": "PR / pytest",
+        },
+        generated_at="2026-04-14T00:00:00Z",
+    )
+    assert result["final_decision"] == "BLOCK"
+    mismatch_classes = {entry["mismatch_class"] for entry in result["mismatch_details"]}
+    assert "WORKFLOW_MISSING_AUTHORITATIVE_JOB" in mismatch_classes
+    assert "POLICY_JOB_ID_MISMATCH" not in result["blocking_reasons"]


### PR DESCRIPTION
### Motivation
- Restore authoritative governed preflight on the push path that had been weakened while keeping the explicit PR-visible `PR / pytest` surface intact.
- Prevent brittle crashes when policy drifts from workflow reality by emitting structured mismatch diagnostics instead of raw exceptions while preserving fail-closed semantics.
- Keep the change narrowly scoped to the PR/push governance seam and add deterministic regression coverage for both push and PR contexts.

### Description
- Added a push-gated governed preflight job `governed-contract-preflight` to `.github/workflows/artifact-boundary.yml` that resolves refs, builds PQX wrapper, runs `python scripts/run_contract_preflight.py --execution-context pqx_governed`, and uploads preflight artifacts to restore push-path authority.
- Reworked `spectrum_systems/modules/runtime/required_check_alignment_audit.py` to emit a `mismatch_details` array of structured entries (`mismatch_class`, `expected_policy_value`, `discovered_workflow_value`, `blocking`, `recommended_remediation`) for ordinary drift, and to derive discovered workflow/job/display values instead of raising on common drift cases.
- Updated the audit contract and example: `contracts/schemas/required_check_alignment_audit_result.schema.json` and `contracts/examples/required_check_alignment_audit_result.json` now include `mismatch_details` and validate the structured output.
- Added and updated deterministic tests and documentation: modified `tests/test_artifact_boundary_workflow_pytest_enforcement.py`, `tests/test_required_check_alignment_audit.py`, `tests/test_contract_preflight.py`, added `tests/test_pyx_push_and_pr_context_enforcement.py`, and added plan/review artifacts in `docs/review-actions/` and `docs/reviews/` to document scope and rationale.

### Testing
- Ran `python -m pytest -q tests/test_artifact_boundary_workflow_pytest_enforcement.py` which passed (`11 passed`).
- Ran `python -m pytest -q tests/test_required_check_alignment_audit.py` which passed (`5 passed`).
- Ran `python -m pytest -q tests/test_contract_preflight.py` which passed (`76 passed`).
- Ran `python -m pytest -q tests/test_pytest_trust_gap_audit.py` and `python -m pytest -q tests/test_retroactive_pytest_integrity_audit.py` which passed (`4 passed` and `7 passed`, respectively).
- Ran `python scripts/run_contract_enforcement.py` which completed with no failures (`failures=0 warnings=0 not_yet_enforceable=0`).
- Ran broader contract tests `python -m pytest -q tests/test_contracts.py tests/test_contract_enforcement.py tests/test_three_letter_system_enforcement.py` which passed (`137 passed`).
- Ran the new targeted file `python -m pytest -q tests/test_pyx_push_and_pr_context_enforcement.py` which passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfffe8c09c8329a03590976ab1dae5)