### PR TITLE
MAL-001: Add prompt minimalism + automatic review/fix contract layer

### DIFF
--- a/contracts/examples/cde_fix_completion_decision.json
+++ b/contracts/examples/cde_fix_completion_decision.json
@@ -1,0 +1,13 @@
+{
+  "artifact_type": "cde_fix_completion_decision",
+  "artifact_id": "cde_fix_completion_decision-001",
+  "artifact_version": "1.0.0",
+  "schema_version": "1.0.0",
+  "standards_version": "1.9.2",
+  "created_at": "2026-04-16T00:00:00Z",
+  "owner": "CDE",
+  "status": "allow",
+  "fre_fix_pack_ref": "fre_fix_pack_record:001",
+  "unresolved_fix_count": 0,
+  "decision": "allow"
+}

--- a/contracts/examples/cde_review_completion_decision.json
+++ b/contracts/examples/cde_review_completion_decision.json
@@ -1,0 +1,13 @@
+{
+  "artifact_type": "cde_review_completion_decision",
+  "artifact_id": "cde_review_completion_decision-001",
+  "artifact_version": "1.0.0",
+  "schema_version": "1.0.0",
+  "standards_version": "1.9.2",
+  "created_at": "2026-04-16T00:00:00Z",
+  "owner": "CDE",
+  "status": "allow",
+  "tlc_cycle_ref": "tlc_review_fix_cycle_record:001",
+  "required_reviews_complete": true,
+  "decision": "allow"
+}

--- a/contracts/examples/con_composition_only_result.json
+++ b/contracts/examples/con_composition_only_result.json
@@ -1,0 +1,14 @@
+{
+  "artifact_type": "con_composition_only_result",
+  "artifact_id": "con_composition_only_result-001",
+  "artifact_version": "1.0.0",
+  "schema_version": "1.0.0",
+  "standards_version": "1.9.2",
+  "created_at": "2026-04-16T00:00:00Z",
+  "owner": "CON",
+  "status": "pass",
+  "checked_artifact_refs": [
+    "contracts/schemas/prm_prompt_minimalism_profile.schema.json"
+  ],
+  "overlap_found": false
+}

--- a/contracts/examples/final_auto_review_fix_scenario.json
+++ b/contracts/examples/final_auto_review_fix_scenario.json
@@ -1,0 +1,13 @@
+{
+  "artifact_type": "final_auto_review_fix_scenario",
+  "artifact_id": "final_auto_review_fix_scenario-001",
+  "artifact_version": "1.0.0",
+  "schema_version": "1.0.0",
+  "standards_version": "1.9.2",
+  "created_at": "2026-04-16T00:00:00Z",
+  "owner": "TLC",
+  "status": "pass",
+  "cycle_ref": "tlc_review_fix_cycle_record:001",
+  "auto_review_triggered": true,
+  "auto_fix_triggered": true
+}

--- a/contracts/examples/final_minimal_prompt_scenario.json
+++ b/contracts/examples/final_minimal_prompt_scenario.json
@@ -1,0 +1,12 @@
+{
+  "artifact_type": "final_minimal_prompt_scenario",
+  "artifact_id": "final_minimal_prompt_scenario-001",
+  "artifact_version": "1.0.0",
+  "schema_version": "1.0.0",
+  "standards_version": "1.9.2",
+  "created_at": "2026-04-16T00:00:00Z",
+  "owner": "TLC",
+  "status": "pass",
+  "minimal_prompt_ref": "prm_prompt_minimalism_profile:001",
+  "execution_plan_ref": "rdx_prompt_to_plan_record:001"
+}

--- a/contracts/examples/final_rerun_report.json
+++ b/contracts/examples/final_rerun_report.json
@@ -1,0 +1,12 @@
+{
+  "artifact_type": "final_rerun_report",
+  "artifact_id": "final_rerun_report-001",
+  "artifact_version": "1.0.0",
+  "schema_version": "1.0.0",
+  "standards_version": "1.9.2",
+  "created_at": "2026-04-16T00:00:00Z",
+  "owner": "TLC",
+  "status": "pass",
+  "impacted_suite_count": 4,
+  "failed_suites": 0
+}

--- a/contracts/examples/fre_fix_compilation_record.json
+++ b/contracts/examples/fre_fix_compilation_record.json
@@ -1,0 +1,13 @@
+{
+  "artifact_type": "fre_fix_compilation_record",
+  "artifact_id": "fre_fix_compilation_record-001",
+  "artifact_version": "1.0.0",
+  "schema_version": "1.0.0",
+  "standards_version": "1.9.2",
+  "created_at": "2026-04-16T00:00:00Z",
+  "owner": "FRE",
+  "status": "pass",
+  "findings_ref": "ril_prompt_minimalism_red_team_report:001",
+  "fix_count": 2,
+  "all_findings_mapped": true
+}

--- a/contracts/examples/fre_fix_pack_m1.json
+++ b/contracts/examples/fre_fix_pack_m1.json
@@ -1,0 +1,14 @@
+{
+  "artifact_type": "fre_fix_pack_m1",
+  "artifact_id": "fre_fix_pack_m1-001",
+  "artifact_version": "1.0.0",
+  "schema_version": "1.0.0",
+  "standards_version": "1.9.2",
+  "created_at": "2026-04-16T00:00:00Z",
+  "owner": "FRE",
+  "status": "pass",
+  "red_team_report_ref": "ril_prompt_minimalism_red_team_report:001",
+  "fix_pack_ref": "fre_fix_pack_record:001",
+  "rerun_ladder_ref": "tlc_validation_ladder_result:001",
+  "regressions_added": 2
+}

--- a/contracts/examples/fre_fix_pack_record.json
+++ b/contracts/examples/fre_fix_pack_record.json
@@ -1,0 +1,17 @@
+{
+  "artifact_type": "fre_fix_pack_record",
+  "artifact_id": "fre_fix_pack_record-001",
+  "artifact_version": "1.0.0",
+  "schema_version": "1.0.0",
+  "standards_version": "1.9.2",
+  "created_at": "2026-04-16T00:00:00Z",
+  "owner": "FRE",
+  "status": "pass",
+  "compilation_ref": "fre_fix_compilation_record:001",
+  "fix_artifact_refs": [
+    "fix:001"
+  ],
+  "regression_tests": [
+    "tests/test_minimalism_automation_contracts.py::test_examples_validate"
+  ]
+}

--- a/contracts/examples/prm_authority_language_scrubber_result.json
+++ b/contracts/examples/prm_authority_language_scrubber_result.json
@@ -1,0 +1,16 @@
+{
+  "artifact_type": "prm_authority_language_scrubber_result",
+  "artifact_id": "prm_authority_language_scrubber_result-001",
+  "artifact_version": "1.0.0",
+  "schema_version": "1.0.0",
+  "standards_version": "1.9.2",
+  "created_at": "2026-04-16T00:00:00Z",
+  "owner": "PRM",
+  "status": "fail_closed",
+  "prompt_ref": "prm_prompt_minimalism_profile:001",
+  "forbidden_terms": [
+    "unauthorized gate",
+    "external decision"
+  ],
+  "violations_detected": 1
+}

--- a/contracts/examples/prm_owner_scope_expansion_record.json
+++ b/contracts/examples/prm_owner_scope_expansion_record.json
@@ -1,0 +1,15 @@
+{
+  "artifact_type": "prm_owner_scope_expansion_record",
+  "artifact_id": "prm_owner_scope_expansion_record-001",
+  "artifact_version": "1.0.0",
+  "schema_version": "1.0.0",
+  "standards_version": "1.9.2",
+  "created_at": "2026-04-16T00:00:00Z",
+  "owner": "PRM",
+  "status": "pass",
+  "prompt_ref": "prm_prompt_minimalism_profile:001",
+  "owner_constraints": [
+    "no_shadow_ownership"
+  ],
+  "drift_prevented": true
+}

--- a/contracts/examples/prm_prompt_minimalism_profile.json
+++ b/contracts/examples/prm_prompt_minimalism_profile.json
@@ -1,0 +1,20 @@
+{
+  "artifact_type": "prm_prompt_minimalism_profile",
+  "artifact_id": "prm_prompt_minimalism_profile-001",
+  "artifact_version": "1.0.0",
+  "schema_version": "1.0.0",
+  "standards_version": "1.9.2",
+  "created_at": "2026-04-16T00:00:00Z",
+  "owner": "PRM",
+  "status": "pass",
+  "intent": "Build minimalism automation layer",
+  "scope": [
+    "contracts",
+    "tests"
+  ],
+  "output": [
+    "schemas",
+    "examples",
+    "tests"
+  ]
+}

--- a/contracts/examples/prm_step_template_registry_record.json
+++ b/contracts/examples/prm_step_template_registry_record.json
@@ -1,0 +1,17 @@
+{
+  "artifact_type": "prm_step_template_registry_record",
+  "artifact_id": "prm_step_template_registry_record-001",
+  "artifact_version": "1.0.0",
+  "schema_version": "1.0.0",
+  "standards_version": "1.9.2",
+  "created_at": "2026-04-16T00:00:00Z",
+  "owner": "PRM",
+  "status": "pass",
+  "template_id": "step-template-default",
+  "step_template": {
+    "step_key": "S1",
+    "step_label": "Compile Plan",
+    "step_instructions": "Render canonical execution step."
+  },
+  "authority_terms_present": false
+}

--- a/contracts/examples/rdx_change_budget_record.json
+++ b/contracts/examples/rdx_change_budget_record.json
@@ -1,0 +1,13 @@
+{
+  "artifact_type": "rdx_change_budget_record",
+  "artifact_id": "rdx_change_budget_record-001",
+  "artifact_version": "1.0.0",
+  "schema_version": "1.0.0",
+  "standards_version": "1.9.2",
+  "created_at": "2026-04-16T00:00:00Z",
+  "owner": "RDX",
+  "status": "pass",
+  "change_scope": "harden",
+  "classification_basis": "artifact delta + owner boundary policy",
+  "deterministic": true
+}

--- a/contracts/examples/rdx_narrowest_owner_resolution_record.json
+++ b/contracts/examples/rdx_narrowest_owner_resolution_record.json
@@ -1,0 +1,16 @@
+{
+  "artifact_type": "rdx_narrowest_owner_resolution_record",
+  "artifact_id": "rdx_narrowest_owner_resolution_record-001",
+  "artifact_version": "1.0.0",
+  "schema_version": "1.0.0",
+  "standards_version": "1.9.2",
+  "created_at": "2026-04-16T00:00:00Z",
+  "owner": "RDX",
+  "status": "pass",
+  "candidate_owners": [
+    "RDX",
+    "TLC"
+  ],
+  "resolved_owner": "PRM",
+  "overlap_detected": false
+}

--- a/contracts/examples/rdx_prompt_to_plan_record.json
+++ b/contracts/examples/rdx_prompt_to_plan_record.json
@@ -1,0 +1,14 @@
+{
+  "artifact_type": "rdx_prompt_to_plan_record",
+  "artifact_id": "rdx_prompt_to_plan_record-001",
+  "artifact_version": "1.0.0",
+  "schema_version": "1.0.0",
+  "standards_version": "1.9.2",
+  "created_at": "2026-04-16T00:00:00Z",
+  "owner": "RDX",
+  "status": "pass",
+  "prompt_ref": "prm_prompt_minimalism_profile:001",
+  "compiled_plan_ref": "rdx_compiled_plan:001",
+  "injected_owner_scope_ref": "prm_owner_scope_expansion_record:001",
+  "authority_added": false
+}

--- a/contracts/examples/rdx_step_render_record.json
+++ b/contracts/examples/rdx_step_render_record.json
@@ -1,0 +1,18 @@
+{
+  "artifact_type": "rdx_step_render_record",
+  "artifact_id": "rdx_step_render_record-001",
+  "artifact_version": "1.0.0",
+  "schema_version": "1.0.0",
+  "standards_version": "1.9.2",
+  "created_at": "2026-04-16T00:00:00Z",
+  "owner": "RDX",
+  "status": "pass",
+  "plan_ref": "rdx_prompt_to_plan_record:001",
+  "template_ref": "prm_step_template_registry_record:001",
+  "rendered_steps": [
+    {
+      "step_id": "S1",
+      "description": "Render step"
+    }
+  ]
+}

--- a/contracts/examples/ril_prompt_minimalism_red_team_report.json
+++ b/contracts/examples/ril_prompt_minimalism_red_team_report.json
@@ -1,0 +1,14 @@
+{
+  "artifact_type": "ril_prompt_minimalism_red_team_report",
+  "artifact_id": "ril_prompt_minimalism_red_team_report-001",
+  "artifact_version": "1.0.0",
+  "schema_version": "1.0.0",
+  "standards_version": "1.9.2",
+  "created_at": "2026-04-16T00:00:00Z",
+  "owner": "RIL",
+  "status": "pass",
+  "prompt_ref": "prm_prompt_minimalism_profile:001",
+  "exploit_count": 2,
+  "findings_ref": "ril_prompt_minimalism_red_team_report:001",
+  "all_exploits_converted": true
+}

--- a/contracts/examples/ril_red_team_package_record.json
+++ b/contracts/examples/ril_red_team_package_record.json
@@ -1,0 +1,16 @@
+{
+  "artifact_type": "ril_red_team_package_record",
+  "artifact_id": "ril_red_team_package_record-001",
+  "artifact_version": "1.0.0",
+  "schema_version": "1.0.0",
+  "standards_version": "1.9.2",
+  "created_at": "2026-04-16T00:00:00Z",
+  "owner": "RIL",
+  "status": "pass",
+  "selection_ref": "ril_review_type_selection_record:001",
+  "attack_surfaces": [
+    "underspecified-intent",
+    "owner-drift"
+  ],
+  "fixtures_ref": "tst_fixture_pack:prompt-minimalism"
+}

--- a/contracts/examples/ril_review_type_selection_record.json
+++ b/contracts/examples/ril_review_type_selection_record.json
@@ -1,0 +1,17 @@
+{
+  "artifact_type": "ril_review_type_selection_record",
+  "artifact_id": "ril_review_type_selection_record-001",
+  "artifact_version": "1.0.0",
+  "schema_version": "1.0.0",
+  "standards_version": "1.9.2",
+  "created_at": "2026-04-16T00:00:00Z",
+  "owner": "RIL",
+  "status": "pass",
+  "change_budget_ref": "rdx_change_budget_record:001",
+  "review_types": [
+    "architecture",
+    "contract",
+    "adversarial"
+  ],
+  "deterministic": true
+}

--- a/contracts/examples/tlc_rerun_cycle_record.json
+++ b/contracts/examples/tlc_rerun_cycle_record.json
@@ -1,0 +1,15 @@
+{
+  "artifact_type": "tlc_rerun_cycle_record",
+  "artifact_id": "tlc_rerun_cycle_record-001",
+  "artifact_version": "1.0.0",
+  "schema_version": "1.0.0",
+  "standards_version": "1.9.2",
+  "created_at": "2026-04-16T00:00:00Z",
+  "owner": "TLC",
+  "status": "pass",
+  "fix_pack_ref": "fre_fix_pack_record:001",
+  "impacted_tests": [
+    "tests/test_minimalism_automation_contracts.py"
+  ],
+  "rerun_status": "completed"
+}

--- a/contracts/examples/tlc_review_fix_cycle_record.json
+++ b/contracts/examples/tlc_review_fix_cycle_record.json
@@ -1,0 +1,14 @@
+{
+  "artifact_type": "tlc_review_fix_cycle_record",
+  "artifact_id": "tlc_review_fix_cycle_record-001",
+  "artifact_version": "1.0.0",
+  "schema_version": "1.0.0",
+  "standards_version": "1.9.2",
+  "created_at": "2026-04-16T00:00:00Z",
+  "owner": "TLC",
+  "status": "pass",
+  "review_ref": "review:001",
+  "fix_pack_ref": "fre_fix_pack_record:001",
+  "rerun_ref": "tlc_rerun_cycle_record:001",
+  "cycle_status": "completed"
+}

--- a/contracts/examples/tlc_validation_ladder_result.json
+++ b/contracts/examples/tlc_validation_ladder_result.json
@@ -1,0 +1,22 @@
+{
+  "artifact_type": "tlc_validation_ladder_result",
+  "artifact_id": "tlc_validation_ladder_result-001",
+  "artifact_version": "1.0.0",
+  "schema_version": "1.0.0",
+  "standards_version": "1.9.2",
+  "created_at": "2026-04-16T00:00:00Z",
+  "owner": "TLC",
+  "status": "pass",
+  "ladder_order": [
+    "registry",
+    "contracts",
+    "owner_tests",
+    "integration"
+  ],
+  "executed_order": [
+    "registry",
+    "contracts",
+    "owner_tests",
+    "integration"
+  ]
+}

--- a/contracts/schemas/cde_fix_completion_decision.schema.json
+++ b/contracts/schemas/cde_fix_completion_decision.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/cde_fix_completion_decision.schema.json",
+  "title": "cde_fix_completion_decision",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "artifact_version",
+    "schema_version",
+    "standards_version",
+    "created_at",
+    "owner",
+    "status",
+    "fre_fix_pack_ref",
+    "unresolved_fix_count",
+    "decision"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "cde_fix_completion_decision"
+    },
+    "artifact_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifact_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "standards_version": {
+      "type": "string",
+      "pattern": "^1\\.[0-9]+\\.[0-9]+$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "owner": {
+      "type": "string",
+      "const": "CDE"
+    },
+    "status": {
+      "type": "string",
+      "minLength": 1
+    },
+    "fre_fix_pack_ref": {
+      "type": "string"
+    },
+    "unresolved_fix_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "decision": {
+      "enum": [
+        "allow",
+        "block"
+      ]
+    }
+  }
+}

--- a/contracts/schemas/cde_review_completion_decision.schema.json
+++ b/contracts/schemas/cde_review_completion_decision.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/cde_review_completion_decision.schema.json",
+  "title": "cde_review_completion_decision",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "artifact_version",
+    "schema_version",
+    "standards_version",
+    "created_at",
+    "owner",
+    "status",
+    "tlc_cycle_ref",
+    "required_reviews_complete",
+    "decision"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "cde_review_completion_decision"
+    },
+    "artifact_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifact_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "standards_version": {
+      "type": "string",
+      "pattern": "^1\\.[0-9]+\\.[0-9]+$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "owner": {
+      "type": "string",
+      "const": "CDE"
+    },
+    "status": {
+      "type": "string",
+      "minLength": 1
+    },
+    "tlc_cycle_ref": {
+      "type": "string"
+    },
+    "required_reviews_complete": {
+      "type": "boolean"
+    },
+    "decision": {
+      "enum": [
+        "allow",
+        "block"
+      ]
+    }
+  }
+}

--- a/contracts/schemas/con_composition_only_result.schema.json
+++ b/contracts/schemas/con_composition_only_result.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/con_composition_only_result.schema.json",
+  "title": "con_composition_only_result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "artifact_version",
+    "schema_version",
+    "standards_version",
+    "created_at",
+    "owner",
+    "status",
+    "checked_artifact_refs",
+    "overlap_found",
+    "status"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "con_composition_only_result"
+    },
+    "artifact_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifact_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "standards_version": {
+      "type": "string",
+      "pattern": "^1\\.[0-9]+\\.[0-9]+$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "owner": {
+      "type": "string",
+      "const": "CON"
+    },
+    "status": {
+      "enum": [
+        "pass",
+        "fail_closed"
+      ]
+    },
+    "checked_artifact_refs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "overlap_found": {
+      "type": "boolean"
+    }
+  }
+}

--- a/contracts/schemas/final_auto_review_fix_scenario.schema.json
+++ b/contracts/schemas/final_auto_review_fix_scenario.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/final_auto_review_fix_scenario.schema.json",
+  "title": "final_auto_review_fix_scenario",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "artifact_version",
+    "schema_version",
+    "standards_version",
+    "created_at",
+    "owner",
+    "status",
+    "cycle_ref",
+    "auto_review_triggered",
+    "auto_fix_triggered",
+    "status"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "final_auto_review_fix_scenario"
+    },
+    "artifact_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifact_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "standards_version": {
+      "type": "string",
+      "pattern": "^1\\.[0-9]+\\.[0-9]+$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "owner": {
+      "type": "string",
+      "const": "TLC"
+    },
+    "status": {
+      "enum": [
+        "pass",
+        "fail"
+      ]
+    },
+    "cycle_ref": {
+      "type": "string"
+    },
+    "auto_review_triggered": {
+      "type": "boolean",
+      "const": true
+    },
+    "auto_fix_triggered": {
+      "type": "boolean",
+      "const": true
+    }
+  }
+}

--- a/contracts/schemas/final_minimal_prompt_scenario.schema.json
+++ b/contracts/schemas/final_minimal_prompt_scenario.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/final_minimal_prompt_scenario.schema.json",
+  "title": "final_minimal_prompt_scenario",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "artifact_version",
+    "schema_version",
+    "standards_version",
+    "created_at",
+    "owner",
+    "status",
+    "minimal_prompt_ref",
+    "execution_plan_ref",
+    "status"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "final_minimal_prompt_scenario"
+    },
+    "artifact_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifact_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "standards_version": {
+      "type": "string",
+      "pattern": "^1\\.[0-9]+\\.[0-9]+$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "owner": {
+      "type": "string",
+      "const": "TLC"
+    },
+    "status": {
+      "enum": [
+        "pass",
+        "fail"
+      ]
+    },
+    "minimal_prompt_ref": {
+      "type": "string"
+    },
+    "execution_plan_ref": {
+      "type": "string"
+    }
+  }
+}

--- a/contracts/schemas/final_rerun_report.schema.json
+++ b/contracts/schemas/final_rerun_report.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/final_rerun_report.schema.json",
+  "title": "final_rerun_report",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "artifact_version",
+    "schema_version",
+    "standards_version",
+    "created_at",
+    "owner",
+    "status",
+    "impacted_suite_count",
+    "failed_suites",
+    "status"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "final_rerun_report"
+    },
+    "artifact_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifact_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "standards_version": {
+      "type": "string",
+      "pattern": "^1\\.[0-9]+\\.[0-9]+$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "owner": {
+      "type": "string",
+      "const": "TLC"
+    },
+    "status": {
+      "enum": [
+        "pass",
+        "fail"
+      ]
+    },
+    "impacted_suite_count": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "failed_suites": {
+      "type": "integer",
+      "minimum": 0
+    }
+  }
+}

--- a/contracts/schemas/fre_fix_compilation_record.schema.json
+++ b/contracts/schemas/fre_fix_compilation_record.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/fre_fix_compilation_record.schema.json",
+  "title": "fre_fix_compilation_record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "artifact_version",
+    "schema_version",
+    "standards_version",
+    "created_at",
+    "owner",
+    "status",
+    "findings_ref",
+    "fix_count",
+    "all_findings_mapped"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "fre_fix_compilation_record"
+    },
+    "artifact_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifact_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "standards_version": {
+      "type": "string",
+      "pattern": "^1\\.[0-9]+\\.[0-9]+$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "owner": {
+      "type": "string",
+      "const": "FRE"
+    },
+    "status": {
+      "type": "string",
+      "minLength": 1
+    },
+    "findings_ref": {
+      "type": "string"
+    },
+    "fix_count": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "all_findings_mapped": {
+      "type": "boolean",
+      "const": true
+    }
+  }
+}

--- a/contracts/schemas/fre_fix_pack_m1.schema.json
+++ b/contracts/schemas/fre_fix_pack_m1.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/fre_fix_pack_m1.schema.json",
+  "title": "fre_fix_pack_m1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "artifact_version",
+    "schema_version",
+    "standards_version",
+    "created_at",
+    "owner",
+    "status",
+    "red_team_report_ref",
+    "fix_pack_ref",
+    "rerun_ladder_ref",
+    "regressions_added"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "fre_fix_pack_m1"
+    },
+    "artifact_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifact_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "standards_version": {
+      "type": "string",
+      "pattern": "^1\\.[0-9]+\\.[0-9]+$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "owner": {
+      "type": "string",
+      "const": "FRE"
+    },
+    "status": {
+      "type": "string",
+      "minLength": 1
+    },
+    "red_team_report_ref": {
+      "type": "string"
+    },
+    "fix_pack_ref": {
+      "type": "string"
+    },
+    "rerun_ladder_ref": {
+      "type": "string"
+    },
+    "regressions_added": {
+      "type": "integer",
+      "minimum": 1
+    }
+  }
+}

--- a/contracts/schemas/fre_fix_pack_record.schema.json
+++ b/contracts/schemas/fre_fix_pack_record.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/fre_fix_pack_record.schema.json",
+  "title": "fre_fix_pack_record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "artifact_version",
+    "schema_version",
+    "standards_version",
+    "created_at",
+    "owner",
+    "status",
+    "compilation_ref",
+    "fix_artifact_refs",
+    "regression_tests"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "fre_fix_pack_record"
+    },
+    "artifact_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifact_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "standards_version": {
+      "type": "string",
+      "pattern": "^1\\.[0-9]+\\.[0-9]+$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "owner": {
+      "type": "string",
+      "const": "FRE"
+    },
+    "status": {
+      "type": "string",
+      "minLength": 1
+    },
+    "compilation_ref": {
+      "type": "string"
+    },
+    "fix_artifact_refs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "regression_tests": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    }
+  }
+}

--- a/contracts/schemas/prm_authority_language_scrubber_result.schema.json
+++ b/contracts/schemas/prm_authority_language_scrubber_result.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/prm_authority_language_scrubber_result.schema.json",
+  "title": "prm_authority_language_scrubber_result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "artifact_version",
+    "schema_version",
+    "standards_version",
+    "created_at",
+    "owner",
+    "status",
+    "prompt_ref",
+    "forbidden_terms",
+    "violations_detected",
+    "status"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "prm_authority_language_scrubber_result"
+    },
+    "artifact_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifact_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "standards_version": {
+      "type": "string",
+      "pattern": "^1\\.[0-9]+\\.[0-9]+$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "owner": {
+      "type": "string",
+      "const": "PRM"
+    },
+    "status": {
+      "enum": [
+        "pass",
+        "fail_closed"
+      ]
+    },
+    "prompt_ref": {
+      "type": "string"
+    },
+    "forbidden_terms": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "violations_detected": {
+      "type": "integer",
+      "minimum": 0
+    }
+  }
+}

--- a/contracts/schemas/prm_owner_scope_expansion_record.schema.json
+++ b/contracts/schemas/prm_owner_scope_expansion_record.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/prm_owner_scope_expansion_record.schema.json",
+  "title": "prm_owner_scope_expansion_record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "artifact_version",
+    "schema_version",
+    "standards_version",
+    "created_at",
+    "owner",
+    "status",
+    "prompt_ref",
+    "owner_constraints",
+    "drift_prevented"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "prm_owner_scope_expansion_record"
+    },
+    "artifact_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifact_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "standards_version": {
+      "type": "string",
+      "pattern": "^1\\.[0-9]+\\.[0-9]+$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "owner": {
+      "type": "string",
+      "const": "PRM"
+    },
+    "status": {
+      "type": "string",
+      "minLength": 1
+    },
+    "prompt_ref": {
+      "type": "string"
+    },
+    "resolved_owner": {
+      "type": "string"
+    },
+    "owner_constraints": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "drift_prevented": {
+      "type": "boolean"
+    }
+  }
+}

--- a/contracts/schemas/prm_prompt_minimalism_profile.schema.json
+++ b/contracts/schemas/prm_prompt_minimalism_profile.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/prm_prompt_minimalism_profile.schema.json",
+  "title": "prm_prompt_minimalism_profile",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "artifact_version",
+    "schema_version",
+    "standards_version",
+    "created_at",
+    "owner",
+    "status",
+    "intent",
+    "scope",
+    "output"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "prm_prompt_minimalism_profile"
+    },
+    "artifact_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifact_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "standards_version": {
+      "type": "string",
+      "pattern": "^1\\.[0-9]+\\.[0-9]+$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "owner": {
+      "type": "string",
+      "const": "PRM"
+    },
+    "status": {
+      "type": "string",
+      "minLength": 1
+    },
+    "intent": {
+      "type": "string",
+      "minLength": 1
+    },
+    "scope": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
+    },
+    "output": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
+    }
+  }
+}

--- a/contracts/schemas/prm_step_template_registry_record.schema.json
+++ b/contracts/schemas/prm_step_template_registry_record.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/prm_step_template_registry_record.schema.json",
+  "title": "prm_step_template_registry_record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "artifact_version",
+    "schema_version",
+    "standards_version",
+    "created_at",
+    "owner",
+    "status",
+    "template_id",
+    "step_template",
+    "authority_terms_present"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "prm_step_template_registry_record"
+    },
+    "artifact_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifact_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "standards_version": {
+      "type": "string",
+      "pattern": "^1\\.[0-9]+\\.[0-9]+$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "owner": {
+      "type": "string",
+      "const": "PRM"
+    },
+    "status": {
+      "type": "string",
+      "minLength": 1
+    },
+    "template_id": {
+      "type": "string"
+    },
+    "step_template": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "step_key",
+        "step_label",
+        "step_instructions"
+      ],
+      "properties": {
+        "step_key": {
+          "type": "string"
+        },
+        "step_label": {
+          "type": "string"
+        },
+        "step_instructions": {
+          "type": "string"
+        }
+      }
+    },
+    "authority_terms_present": {
+      "type": "boolean",
+      "const": false
+    }
+  }
+}

--- a/contracts/schemas/rdx_change_budget_record.schema.json
+++ b/contracts/schemas/rdx_change_budget_record.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/rdx_change_budget_record.schema.json",
+  "title": "rdx_change_budget_record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "artifact_version",
+    "schema_version",
+    "standards_version",
+    "created_at",
+    "owner",
+    "status",
+    "change_scope",
+    "classification_basis",
+    "deterministic"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "rdx_change_budget_record"
+    },
+    "artifact_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifact_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "standards_version": {
+      "type": "string",
+      "pattern": "^1\\.[0-9]+\\.[0-9]+$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "owner": {
+      "type": "string",
+      "const": "RDX"
+    },
+    "status": {
+      "type": "string",
+      "minLength": 1
+    },
+    "change_scope": {
+      "enum": [
+        "repair",
+        "extend",
+        "harden",
+        "stabilize"
+      ]
+    },
+    "classification_basis": {
+      "type": "string"
+    },
+    "deterministic": {
+      "type": "boolean",
+      "const": true
+    }
+  }
+}

--- a/contracts/schemas/rdx_narrowest_owner_resolution_record.schema.json
+++ b/contracts/schemas/rdx_narrowest_owner_resolution_record.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/rdx_narrowest_owner_resolution_record.schema.json",
+  "title": "rdx_narrowest_owner_resolution_record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "artifact_version",
+    "schema_version",
+    "standards_version",
+    "created_at",
+    "owner",
+    "status",
+    "candidate_owners",
+    "resolved_owner",
+    "overlap_detected"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "rdx_narrowest_owner_resolution_record"
+    },
+    "artifact_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifact_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "standards_version": {
+      "type": "string",
+      "pattern": "^1\\.[0-9]+\\.[0-9]+$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "owner": {
+      "type": "string",
+      "const": "RDX"
+    },
+    "status": {
+      "type": "string",
+      "minLength": 1
+    },
+    "candidate_owners": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "resolved_owner": {
+      "type": "string"
+    },
+    "overlap_detected": {
+      "type": "boolean"
+    }
+  }
+}

--- a/contracts/schemas/rdx_prompt_to_plan_record.schema.json
+++ b/contracts/schemas/rdx_prompt_to_plan_record.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/rdx_prompt_to_plan_record.schema.json",
+  "title": "rdx_prompt_to_plan_record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "artifact_version",
+    "schema_version",
+    "standards_version",
+    "created_at",
+    "owner",
+    "status",
+    "prompt_ref",
+    "compiled_plan_ref",
+    "injected_owner_scope_ref",
+    "authority_added"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "rdx_prompt_to_plan_record"
+    },
+    "artifact_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifact_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "standards_version": {
+      "type": "string",
+      "pattern": "^1\\.[0-9]+\\.[0-9]+$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "owner": {
+      "type": "string",
+      "const": "RDX"
+    },
+    "status": {
+      "type": "string",
+      "minLength": 1
+    },
+    "prompt_ref": {
+      "type": "string"
+    },
+    "compiled_plan_ref": {
+      "type": "string"
+    },
+    "injected_owner_scope_ref": {
+      "type": "string"
+    },
+    "authority_added": {
+      "type": "boolean",
+      "const": false
+    }
+  }
+}

--- a/contracts/schemas/rdx_step_render_record.schema.json
+++ b/contracts/schemas/rdx_step_render_record.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/rdx_step_render_record.schema.json",
+  "title": "rdx_step_render_record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "artifact_version",
+    "schema_version",
+    "standards_version",
+    "created_at",
+    "owner",
+    "status",
+    "plan_ref",
+    "template_ref",
+    "rendered_steps"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "rdx_step_render_record"
+    },
+    "artifact_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifact_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "standards_version": {
+      "type": "string",
+      "pattern": "^1\\.[0-9]+\\.[0-9]+$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "owner": {
+      "type": "string",
+      "const": "RDX"
+    },
+    "status": {
+      "type": "string",
+      "minLength": 1
+    },
+    "plan_ref": {
+      "type": "string"
+    },
+    "template_ref": {
+      "type": "string"
+    },
+    "rendered_steps": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "minItems": 1
+    }
+  }
+}

--- a/contracts/schemas/ril_prompt_minimalism_red_team_report.schema.json
+++ b/contracts/schemas/ril_prompt_minimalism_red_team_report.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/ril_prompt_minimalism_red_team_report.schema.json",
+  "title": "ril_prompt_minimalism_red_team_report",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "artifact_version",
+    "schema_version",
+    "standards_version",
+    "created_at",
+    "owner",
+    "status",
+    "prompt_ref",
+    "exploit_count",
+    "findings_ref",
+    "all_exploits_converted"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "ril_prompt_minimalism_red_team_report"
+    },
+    "artifact_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifact_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "standards_version": {
+      "type": "string",
+      "pattern": "^1\\.[0-9]+\\.[0-9]+$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "owner": {
+      "type": "string",
+      "const": "RIL"
+    },
+    "status": {
+      "type": "string",
+      "minLength": 1
+    },
+    "prompt_ref": {
+      "type": "string"
+    },
+    "exploit_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "findings_ref": {
+      "type": "string"
+    },
+    "all_exploits_converted": {
+      "type": "boolean"
+    }
+  }
+}

--- a/contracts/schemas/ril_red_team_package_record.schema.json
+++ b/contracts/schemas/ril_red_team_package_record.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/ril_red_team_package_record.schema.json",
+  "title": "ril_red_team_package_record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "artifact_version",
+    "schema_version",
+    "standards_version",
+    "created_at",
+    "owner",
+    "status",
+    "selection_ref",
+    "attack_surfaces",
+    "fixtures_ref"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "ril_red_team_package_record"
+    },
+    "artifact_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifact_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "standards_version": {
+      "type": "string",
+      "pattern": "^1\\.[0-9]+\\.[0-9]+$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "owner": {
+      "type": "string",
+      "const": "RIL"
+    },
+    "status": {
+      "type": "string",
+      "minLength": 1
+    },
+    "selection_ref": {
+      "type": "string"
+    },
+    "attack_surfaces": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "fixtures_ref": {
+      "type": "string"
+    }
+  }
+}

--- a/contracts/schemas/ril_review_type_selection_record.schema.json
+++ b/contracts/schemas/ril_review_type_selection_record.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/ril_review_type_selection_record.schema.json",
+  "title": "ril_review_type_selection_record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "artifact_version",
+    "schema_version",
+    "standards_version",
+    "created_at",
+    "owner",
+    "status",
+    "change_budget_ref",
+    "review_types",
+    "deterministic"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "ril_review_type_selection_record"
+    },
+    "artifact_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifact_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "standards_version": {
+      "type": "string",
+      "pattern": "^1\\.[0-9]+\\.[0-9]+$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "owner": {
+      "type": "string",
+      "const": "RIL"
+    },
+    "status": {
+      "type": "string",
+      "minLength": 1
+    },
+    "change_budget_ref": {
+      "type": "string"
+    },
+    "review_types": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "deterministic": {
+      "type": "boolean",
+      "const": true
+    }
+  }
+}

--- a/contracts/schemas/tlc_rerun_cycle_record.schema.json
+++ b/contracts/schemas/tlc_rerun_cycle_record.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/tlc_rerun_cycle_record.schema.json",
+  "title": "tlc_rerun_cycle_record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "artifact_version",
+    "schema_version",
+    "standards_version",
+    "created_at",
+    "owner",
+    "status",
+    "fix_pack_ref",
+    "impacted_tests",
+    "rerun_status"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "tlc_rerun_cycle_record"
+    },
+    "artifact_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifact_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "standards_version": {
+      "type": "string",
+      "pattern": "^1\\.[0-9]+\\.[0-9]+$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "owner": {
+      "type": "string",
+      "const": "TLC"
+    },
+    "status": {
+      "type": "string",
+      "minLength": 1
+    },
+    "fix_pack_ref": {
+      "type": "string"
+    },
+    "impacted_tests": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "rerun_status": {
+      "enum": [
+        "completed",
+        "blocked"
+      ]
+    }
+  }
+}

--- a/contracts/schemas/tlc_review_fix_cycle_record.schema.json
+++ b/contracts/schemas/tlc_review_fix_cycle_record.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/tlc_review_fix_cycle_record.schema.json",
+  "title": "tlc_review_fix_cycle_record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "artifact_version",
+    "schema_version",
+    "standards_version",
+    "created_at",
+    "owner",
+    "status",
+    "review_ref",
+    "fix_pack_ref",
+    "rerun_ref",
+    "cycle_status"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "tlc_review_fix_cycle_record"
+    },
+    "artifact_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifact_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "standards_version": {
+      "type": "string",
+      "pattern": "^1\\.[0-9]+\\.[0-9]+$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "owner": {
+      "type": "string",
+      "const": "TLC"
+    },
+    "status": {
+      "type": "string",
+      "minLength": 1
+    },
+    "review_ref": {
+      "type": "string"
+    },
+    "fix_pack_ref": {
+      "type": "string"
+    },
+    "rerun_ref": {
+      "type": "string"
+    },
+    "cycle_status": {
+      "enum": [
+        "completed",
+        "blocked"
+      ]
+    }
+  }
+}

--- a/contracts/schemas/tlc_validation_ladder_result.schema.json
+++ b/contracts/schemas/tlc_validation_ladder_result.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/tlc_validation_ladder_result.schema.json",
+  "title": "tlc_validation_ladder_result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "artifact_version",
+    "schema_version",
+    "standards_version",
+    "created_at",
+    "owner",
+    "status",
+    "ladder_order",
+    "executed_order",
+    "status"
+  ],
+  "properties": {
+    "artifact_type": {
+      "const": "tlc_validation_ladder_result"
+    },
+    "artifact_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifact_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "standards_version": {
+      "type": "string",
+      "pattern": "^1\\.[0-9]+\\.[0-9]+$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "owner": {
+      "type": "string",
+      "const": "TLC"
+    },
+    "status": {
+      "enum": [
+        "pass",
+        "fail_closed"
+      ]
+    },
+    "ladder_order": {
+      "type": "array",
+      "const": [
+        "registry",
+        "contracts",
+        "owner_tests",
+        "integration"
+      ]
+    },
+    "executed_order": {
+      "type": "array",
+      "const": [
+        "registry",
+        "contracts",
+        "owner_tests",
+        "integration"
+      ]
+    }
+  }
+}

--- a/contracts/standards-manifest.json
+++ b/contracts/standards-manifest.json
@@ -1,12 +1,12 @@
 {
   "artifact_type": "standards_manifest",
   "artifact_id": "STD-CONTRACTS",
-  "artifact_version": "1.3.130",
+  "artifact_version": "1.3.131",
   "schema_version": "1.3.99",
-  "standards_version": "1.9.1",
-  "record_id": "REC-STD-2026-04-15-RGP-02",
-  "run_id": "run-20260415T210000Z-rgp-02",
-  "created_at": "2026-04-15T00:00:00Z",
+  "standards_version": "1.9.2",
+  "record_id": "REC-STD-2026-04-16-MAL-001",
+  "run_id": "run-20260416T000000Z-mal-001",
+  "created_at": "2026-04-16T00:00:00Z",
   "created_by": {
     "name": "Spectrum Systems Architecture Team",
     "role": "standards-publication",
@@ -15,7 +15,7 @@
     "contact": "architecture@spectrum-systems.test"
   },
   "source_repo": "nicklasorte/spectrum-systems",
-  "source_repo_version": "1.3.143",
+  "source_repo_version": "1.3.144",
   "input_artifacts": [
     {
       "artifact_id": "STD-CONTRACTS",
@@ -550,6 +550,19 @@
       "notes": "Canonical governed artifact envelope for deterministic identity, timestamp, schema version, and trace reference normalization."
     },
     {
+      "artifact_type": "artifact_eval_requirement_profile",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/artifact_eval_requirement_profile.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
+    },
+    {
       "artifact_type": "artifact_family_health_report",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -587,6 +600,32 @@
       "last_updated_in": "1.3.113",
       "example_path": "contracts/examples/artifact_intelligence_index.json",
       "notes": "RIL-owned deterministic index over governed artifact telemetry for non-authoritative retrieval and analysis."
+    },
+    {
+      "artifact_type": "artifact_intelligence_index_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/artifact_intelligence_index_record.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
+    },
+    {
+      "artifact_type": "artifact_intelligence_redteam_findings",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/artifact_intelligence_redteam_findings.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
     },
     {
       "artifact_type": "artifact_intelligence_report",
@@ -807,6 +846,32 @@
       "last_updated_in": "1.0.0",
       "example_path": "contracts/examples/book_intelligence_pack.json",
       "notes": "Extracted strategic intelligence pack from book sources with evidence anchors."
+    },
+    {
+      "artifact_type": "bottleneck_alert_trigger_result",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/bottleneck_alert_trigger_result.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
+    },
+    {
+      "artifact_type": "bottleneck_wave_certification_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/bottleneck_wave_certification_record.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
     },
     {
       "artifact_type": "bounded_repair_candidate_artifact",
@@ -1228,6 +1293,19 @@
       "notes": "R100-001 integration fabric extension artifact."
     },
     {
+      "artifact_type": "cde_fix_completion_decision",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.144",
+      "last_updated_in": "1.3.144",
+      "example_path": "contracts/examples/cde_fix_completion_decision.json",
+      "notes": "MAL-001 prompt minimalism + automatic review/fix enforcement surface."
+    },
+    {
       "artifact_type": "cde_global_execution_readiness_decision",
       "artifact_class": "governance",
       "schema_version": "1.0.0",
@@ -1308,6 +1386,19 @@
       "notes": "CDE decision input derived from failure packet + bounded repair candidate."
     },
     {
+      "artifact_type": "cde_review_completion_decision",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.144",
+      "last_updated_in": "1.3.144",
+      "example_path": "contracts/examples/cde_review_completion_decision.json",
+      "notes": "MAL-001 prompt minimalism + automatic review/fix enforcement surface."
+    },
+    {
       "artifact_type": "cde_roadmap_continuation_readiness_bundle_contract",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -1334,6 +1425,45 @@
       "notes": "VAL-11 governed DONE-01 integrity validation artifact proving fail-closed certification behavior under inconsistent, partial, and conflicting signal combinations."
     },
     {
+      "artifact_type": "certification_remediation_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/certification_remediation_record.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
+    },
+    {
+      "artifact_type": "checkpoint_hibernate_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/checkpoint_hibernate_record.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
+    },
+    {
+      "artifact_type": "checkpoint_policy_maintain_redteam_findings",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/checkpoint_policy_maintain_redteam_findings.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
+    },
+    {
       "artifact_type": "checkpoint_record",
       "artifact_class": "governance",
       "schema_version": "1.0.0",
@@ -1345,6 +1475,32 @@
       "last_updated_in": "1.3.92",
       "example_path": "contracts/examples/checkpoint_record.json",
       "notes": "HR-B canonical checkpoint continuity artifact for long-running governed execution."
+    },
+    {
+      "artifact_type": "checkpoint_stage_contract_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/checkpoint_stage_contract_record.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
+    },
+    {
+      "artifact_type": "checkpoint_wake_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/checkpoint_wake_record.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
     },
     {
       "artifact_type": "chx_campaign_result",
@@ -1573,6 +1729,19 @@
       "notes": "TPA complexity governance artifact for deterministic budget/trend/campaign enforcement and PQX cleanup scheduling."
     },
     {
+      "artifact_type": "con_composition_only_result",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.144",
+      "last_updated_in": "1.3.144",
+      "example_path": "contracts/examples/con_composition_only_result.json",
+      "notes": "MAL-001 prompt minimalism + automatic review/fix enforcement surface."
+    },
+    {
       "artifact_type": "con_contract_evolution_pressure_map",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -1636,6 +1805,32 @@
       "last_updated_in": "1.9.1",
       "example_path": "contracts/examples/confidence_drift_record.json",
       "notes": "OSX-03 serial substrate contracts for prompt_task_bundle bounded rollout."
+    },
+    {
+      "artifact_type": "confidence_usage_policy",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/confidence_usage_policy.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
+    },
+    {
+      "artifact_type": "confidence_violation_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/confidence_violation_record.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
     },
     {
       "artifact_type": "context_admission_decision",
@@ -1818,6 +2013,19 @@
       "last_updated_in": "1.3.61",
       "example_path": "contracts/examples/continuous_eval_run_record.json",
       "notes": "BATCH-12 ST-10 governed stage-explicit deterministic continuous evaluation record."
+    },
+    {
+      "artifact_type": "contract_compatibility_evaluation_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/contract_compatibility_evaluation_record.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
     },
     {
       "artifact_type": "contract_impact_artifact",
@@ -2078,6 +2286,19 @@
       "notes": "CDX-01 next-phase governed contract surface."
     },
     {
+      "artifact_type": "cross_run_bottleneck_report",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/cross_run_bottleneck_report.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
+    },
+    {
       "artifact_type": "cross_run_intelligence_decision",
       "artifact_class": "coordination",
       "schema_version": "2.0.0",
@@ -2089,6 +2310,19 @@
       "last_updated_in": "1.0.67",
       "example_path": null,
       "notes": "XRUN-01 deterministic decision-driving cross-run artifact with trend metrics, detected patterns, recommended actions, and stable|warning|unstable system signal."
+    },
+    {
+      "artifact_type": "cross_run_redteam_findings",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/cross_run_redteam_findings.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
     },
     {
       "artifact_type": "crs_active_rule_ambiguity_report",
@@ -3343,6 +3577,19 @@
       "notes": "Legacy executable eval-case specification consumed by eval_engine with trace-linked inputs, expected outputs, scoring rubric, and optional slice/risk metadata for SF-07 coverage reporting."
     },
     {
+      "artifact_type": "eval_coverage_redteam_findings",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/eval_coverage_redteam_findings.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
+    },
+    {
       "artifact_type": "eval_coverage_registry",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -4221,6 +4468,19 @@
       "notes": "BATCH-11 deterministic normalized failure taxonomy artifact turning governed failures into recurring structured inputs."
     },
     {
+      "artifact_type": "failure_to_eval_conversion_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/failure_to_eval_conversion_record.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
+    },
+    {
       "artifact_type": "faq_artifact",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -4338,6 +4598,32 @@
       "notes": "AIG-001 governed AI integration artifact"
     },
     {
+      "artifact_type": "final_auto_review_fix_scenario",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.144",
+      "last_updated_in": "1.3.144",
+      "example_path": "contracts/examples/final_auto_review_fix_scenario.json",
+      "notes": "MAL-001 prompt minimalism + automatic review/fix enforcement surface."
+    },
+    {
+      "artifact_type": "final_bottleneck_wave_redteam_findings",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/final_bottleneck_wave_redteam_findings.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
+    },
+    {
       "artifact_type": "final_impacted_suite_rerun_report",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -4349,6 +4635,32 @@
       "last_updated_in": "1.3.138",
       "example_path": "contracts/examples/final_impacted_suite_rerun_report.json",
       "notes": "R100-NP-001 final integration and rerun evidence."
+    },
+    {
+      "artifact_type": "final_minimal_prompt_scenario",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.144",
+      "last_updated_in": "1.3.144",
+      "example_path": "contracts/examples/final_minimal_prompt_scenario.json",
+      "notes": "MAL-001 prompt minimalism + automatic review/fix enforcement surface."
+    },
+    {
+      "artifact_type": "final_rerun_report",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.144",
+      "last_updated_in": "1.3.144",
+      "example_path": "contracts/examples/final_rerun_report.json",
+      "notes": "MAL-001 prompt minimalism + automatic review/fix enforcement surface."
     },
     {
       "artifact_type": "final_umbrella_boundary_continue_halt_test_matrix",
@@ -4401,6 +4713,45 @@
       "last_updated_in": "1.3.38",
       "example_path": "contracts/examples/fre_closeout_gate_record.json",
       "notes": "RIL-001 batch deterministic fail-closed bounded interpretation/FRE closeout artifact contract."
+    },
+    {
+      "artifact_type": "fre_fix_compilation_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.144",
+      "last_updated_in": "1.3.144",
+      "example_path": "contracts/examples/fre_fix_compilation_record.json",
+      "notes": "MAL-001 prompt minimalism + automatic review/fix enforcement surface."
+    },
+    {
+      "artifact_type": "fre_fix_pack_m1",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.144",
+      "last_updated_in": "1.3.144",
+      "example_path": "contracts/examples/fre_fix_pack_m1.json",
+      "notes": "MAL-001 prompt minimalism + automatic review/fix enforcement surface."
+    },
+    {
+      "artifact_type": "fre_fix_pack_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.144",
+      "last_updated_in": "1.3.144",
+      "example_path": "contracts/examples/fre_fix_pack_record.json",
+      "notes": "MAL-001 prompt minimalism + automatic review/fix enforcement surface."
     },
     {
       "artifact_class": "coordination",
@@ -5251,6 +5602,19 @@
       "notes": "AUTONOMOUS-LOOP-01 dual implementation review artifact for Claude/Codex findings ingestion."
     },
     {
+      "artifact_type": "improvement_recommendation_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/improvement_recommendation_record.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
+    },
+    {
       "artifact_type": "industry_critique_profile",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -5551,6 +5915,19 @@
       "notes": "R100-NP-001 learning and pressure posture."
     },
     {
+      "artifact_type": "judge_disagreement_report",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/judge_disagreement_report.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
+    },
+    {
       "artifact_type": "judgment_active_set_record",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -5733,6 +6110,19 @@
       "notes": "CL-05 longitudinal calibration outcome linkage contract with required judgment/decision/policy/trace binding and observation timestamp."
     },
     {
+      "artifact_type": "judgment_override_redteam_findings",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/judgment_override_redteam_findings.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
+    },
+    {
       "artifact_type": "judgment_policy",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -5744,6 +6134,19 @@
       "last_updated_in": "1.0.99",
       "example_path": "contracts/examples/judgment_policy.json",
       "notes": "Versioned deterministic judgment policy now includes learning_control_policy thresholds for drift, calibration, and error-budget enforcement seams. Extended status enum with revoked for explicit lifecycle revocation governance."
+    },
+    {
+      "artifact_type": "judgment_policy_candidate_artifact",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/judgment_policy_candidate_artifact.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
     },
     {
       "artifact_type": "judgment_policy_extraction_record",
@@ -6006,6 +6409,19 @@
       "last_updated_in": "1.3.131",
       "example_path": "contracts/examples/maintain_cycle_record.json",
       "notes": "RAX serial operating substrate governance contract."
+    },
+    {
+      "artifact_type": "maintain_drift_report",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/maintain_drift_report.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
     },
     {
       "artifact_type": "map_projection_bundle",
@@ -6695,6 +7111,19 @@
       "notes": "SRE-10 deterministic metrics aggregation artifact for replay/runtime control outputs with strict bounded metric vocabulary and optional SLO breach summary."
     },
     {
+      "artifact_type": "observability_redteam_findings",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/observability_redteam_findings.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
+    },
+    {
       "artifact_type": "operations_execution_schedule",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -6787,6 +7216,19 @@
       "last_updated_in": "1.3.36",
       "example_path": "contracts/examples/operator_friction_report.json",
       "notes": "BATCH-Y deterministic operator-friction harvest report emitted from realistic governed system-cycle scenarios."
+    },
+    {
+      "artifact_type": "operator_trust_bottleneck_view",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/operator_trust_bottleneck_view.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
     },
     {
       "artifact_type": "opx_005_integration_artifact",
@@ -6920,6 +7362,19 @@
       "last_updated_in": "BATCH-HR-C",
       "example_path": "contracts/examples/permission_request_record.json",
       "notes": "HR-C canonical control-surface artifact family"
+    },
+    {
+      "artifact_type": "phase_certified_expansion_gate_result",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/phase_certified_expansion_gate_result.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
     },
     {
       "artifact_type": "phase_checkpoint_record",
@@ -7157,6 +7612,19 @@
       "notes": "WPG EXEC C-H governed execution artifact."
     },
     {
+      "artifact_type": "policy_canary_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/policy_canary_record.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
+    },
+    {
       "artifact_type": "policy_candidate_record",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -7233,6 +7701,32 @@
       "last_updated_in": "1.9.1",
       "example_path": "contracts/examples/policy_lifecycle_record.json",
       "notes": "OSX-03 serial substrate contracts for prompt_task_bundle bounded rollout."
+    },
+    {
+      "artifact_type": "policy_regression_report",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/policy_regression_report.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
+    },
+    {
+      "artifact_type": "policy_rollback_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/policy_rollback_record.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
     },
     {
       "artifact_type": "pqx_block_record",
@@ -7690,6 +8184,19 @@
       "notes": "LT-02 explicit precedent conflict classification, severity, blocking state, and required follow-up governance."
     },
     {
+      "artifact_type": "precedent_ranking_evaluation_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/precedent_ranking_evaluation_record.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
+    },
+    {
       "artifact_type": "precedent_retrieval",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -8084,6 +8591,58 @@
       "notes": "AIG-001 governed AI integration artifact"
     },
     {
+      "artifact_type": "prm_authority_language_scrubber_result",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.144",
+      "last_updated_in": "1.3.144",
+      "example_path": "contracts/examples/prm_authority_language_scrubber_result.json",
+      "notes": "MAL-001 prompt minimalism + automatic review/fix enforcement surface."
+    },
+    {
+      "artifact_type": "prm_owner_scope_expansion_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.144",
+      "last_updated_in": "1.3.144",
+      "example_path": "contracts/examples/prm_owner_scope_expansion_record.json",
+      "notes": "MAL-001 prompt minimalism + automatic review/fix enforcement surface."
+    },
+    {
+      "artifact_type": "prm_prompt_minimalism_profile",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.144",
+      "last_updated_in": "1.3.144",
+      "example_path": "contracts/examples/prm_prompt_minimalism_profile.json",
+      "notes": "MAL-001 prompt minimalism + automatic review/fix enforcement surface."
+    },
+    {
+      "artifact_type": "prm_step_template_registry_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.144",
+      "last_updated_in": "1.3.144",
+      "example_path": "contracts/examples/prm_step_template_registry_record.json",
+      "notes": "MAL-001 prompt minimalism + automatic review/fix enforcement surface."
+    },
+    {
       "artifact_type": "program_alignment_assessment",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -8226,6 +8785,32 @@
       "last_updated_in": "1.3.90",
       "example_path": "contracts/examples/promotion_gate_decision_artifact.json",
       "notes": "BATCH-MB-02 deterministic fail-closed promotion gate decision artifact requiring ready_for_merge plus certified governed evidence before merge-ready visibility."
+    },
+    {
+      "artifact_type": "promotion_requirement_evaluation_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/promotion_requirement_evaluation_record.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
+    },
+    {
+      "artifact_type": "promotion_requirement_profile",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/promotion_requirement_profile.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
     },
     {
       "artifact_type": "promotion_requirements",
@@ -9353,6 +9938,19 @@
       "notes": "RDX bounded roadmap-governance hardening contract for deterministic selection, eval, replay, readiness, and fail-closed integrity checks."
     },
     {
+      "artifact_type": "rdx_change_budget_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.144",
+      "last_updated_in": "1.3.144",
+      "example_path": "contracts/examples/rdx_change_budget_record.json",
+      "notes": "MAL-001 prompt minimalism + automatic review/fix enforcement surface."
+    },
+    {
       "artifact_type": "rdx_execution_loop_readiness_handoff_record",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -9391,6 +9989,32 @@
       "last_updated_in": "1.0.83",
       "example_path": "contracts/examples/rdx_must_revalidate_set.json",
       "notes": "R100-001 integration fabric extension artifact."
+    },
+    {
+      "artifact_type": "rdx_narrowest_owner_resolution_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.144",
+      "last_updated_in": "1.3.144",
+      "example_path": "contracts/examples/rdx_narrowest_owner_resolution_record.json",
+      "notes": "MAL-001 prompt minimalism + automatic review/fix enforcement surface."
+    },
+    {
+      "artifact_type": "rdx_prompt_to_plan_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.144",
+      "last_updated_in": "1.3.144",
+      "example_path": "contracts/examples/rdx_prompt_to_plan_record.json",
+      "notes": "MAL-001 prompt minimalism + automatic review/fix enforcement surface."
     },
     {
       "artifact_type": "rdx_rework_debt_record",
@@ -9564,6 +10188,19 @@
       "notes": "RDX bounded roadmap-governance hardening contract for deterministic selection, eval, replay, readiness, and fail-closed integrity checks."
     },
     {
+      "artifact_type": "rdx_step_render_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.144",
+      "last_updated_in": "1.3.144",
+      "example_path": "contracts/examples/rdx_step_render_record.json",
+      "notes": "MAL-001 prompt minimalism + automatic review/fix enforcement surface."
+    },
+    {
       "artifact_type": "rdx_umbrella_dependency_seal",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -9601,6 +10238,19 @@
       "last_updated_in": "1.3.138",
       "example_path": "contracts/examples/rdx_unsafe_breadth_report.json",
       "notes": "R100-NP-001 long-roadmap fabric."
+    },
+    {
+      "artifact_type": "readiness_promotion_redteam_findings",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/readiness_promotion_redteam_findings.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
     },
     {
       "artifact_type": "readiness_review_dashboard_artifact",
@@ -9682,6 +10332,19 @@
       "notes": "WPG EXEC C-H governed execution artifact."
     },
     {
+      "artifact_type": "registry_divergence_report",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/registry_divergence_report.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
+    },
+    {
       "artifact_type": "rel_canary_metrics_breakdown",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -9732,6 +10395,19 @@
       "last_updated_in": "1.3.130",
       "example_path": "contracts/examples/rel_release_record.json",
       "notes": "NEXT-WAVE-001 governed runtime artifact."
+    },
+    {
+      "artifact_type": "release_readiness_policy_result",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/release_readiness_policy_result.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
     },
     {
       "artifact_type": "release_record",
@@ -10730,6 +11406,45 @@
       "notes": "IFB-001 roadmap integration fabric contract surface."
     },
     {
+      "artifact_type": "ril_prompt_minimalism_red_team_report",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.144",
+      "last_updated_in": "1.3.144",
+      "example_path": "contracts/examples/ril_prompt_minimalism_red_team_report.json",
+      "notes": "MAL-001 prompt minimalism + automatic review/fix enforcement surface."
+    },
+    {
+      "artifact_type": "ril_red_team_package_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.144",
+      "last_updated_in": "1.3.144",
+      "example_path": "contracts/examples/ril_red_team_package_record.json",
+      "notes": "MAL-001 prompt minimalism + automatic review/fix enforcement surface."
+    },
+    {
+      "artifact_type": "ril_review_type_selection_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.144",
+      "last_updated_in": "1.3.144",
+      "example_path": "contracts/examples/ril_review_type_selection_record.json",
+      "notes": "MAL-001 prompt minimalism + automatic review/fix enforcement surface."
+    },
+    {
       "artifact_type": "ril_roadmap_contract_structure_red_team_report",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -11095,6 +11810,19 @@
       "last_updated_in": "1.0.83",
       "example_path": "contracts/examples/route_candidate_set.json",
       "notes": "CDX-01 next-phase governed contract surface."
+    },
+    {
+      "artifact_type": "route_efficiency_report",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/route_efficiency_report.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
     },
     {
       "artifact_type": "routing_decision",
@@ -11653,6 +12381,19 @@
       "notes": "WPG EXEC C-H governed execution artifact."
     },
     {
+      "artifact_type": "stale_assumption_report",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/stale_assumption_report.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
+    },
+    {
       "artifact_type": "standards_manifest",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -12070,6 +12811,32 @@
       "notes": "Candidate-only TLC orchestration readiness artifact with non-authority assertions."
     },
     {
+      "artifact_type": "tlc_rerun_cycle_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.144",
+      "last_updated_in": "1.3.144",
+      "example_path": "contracts/examples/tlc_rerun_cycle_record.json",
+      "notes": "MAL-001 prompt minimalism + automatic review/fix enforcement surface."
+    },
+    {
+      "artifact_type": "tlc_review_fix_cycle_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.144",
+      "last_updated_in": "1.3.144",
+      "example_path": "contracts/examples/tlc_review_fix_cycle_record.json",
+      "notes": "MAL-001 prompt minimalism + automatic review/fix enforcement surface."
+    },
+    {
       "artifact_type": "tlc_routing_bundle",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -12107,6 +12874,19 @@
       "last_updated_in": "1.3.119",
       "example_path": "contracts/examples/tlc_routing_eval_result.json",
       "notes": "TLC routing evaluation result with fail-closed checks and explicit fail reasons."
+    },
+    {
+      "artifact_type": "tlc_validation_ladder_result",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.144",
+      "last_updated_in": "1.3.144",
+      "example_path": "contracts/examples/tlc_validation_ladder_result.json",
+      "notes": "MAL-001 prompt minimalism + automatic review/fix enforcement surface."
     },
     {
       "artifact_type": "tlx_ai_adapter_dispatch_record",
@@ -12499,6 +13279,19 @@
       "notes": "RGP-02 bounded governed_prompt_queue contract expansion."
     },
     {
+      "artifact_type": "trend_report_artifact",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/trend_report_artifact.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
+    },
+    {
       "artifact_type": "trust_posture_snapshot",
       "artifact_class": "coordination",
       "schema_version": "1.1.0",
@@ -12616,6 +13409,32 @@
       "notes": "Strategic viewpoint package with supporting and counter evidence."
     },
     {
+      "artifact_type": "workflow_semantic_audit_result",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/workflow_semantic_audit_result.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
+    },
+    {
+      "artifact_type": "workflow_trust_redteam_findings",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/workflow_trust_redteam_findings.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
+    },
+    {
       "artifact_type": "working_paper_artifact",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -12695,6 +13514,19 @@
       "notes": "WPG-00 governed working paper generator artifact chain."
     },
     {
+      "artifact_type": "wpg_eval_coverage_artifact",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/wpg_eval_coverage_artifact.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
+    },
+    {
       "artifact_type": "wpg_grounding_eval_case",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -12758,6 +13590,19 @@
       "last_updated_in": "1.3.140",
       "example_path": "contracts/examples/wpg_redteam_findings_phase_b.json",
       "notes": "WPG Phase B governed workflow loop contract."
+    },
+    {
+      "artifact_type": "wpg_release_readiness_artifact",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.143",
+      "last_updated_in": "1.3.143",
+      "example_path": "contracts/examples/wpg_release_readiness_artifact.json",
+      "notes": "BNE-00 bottleneck attack wave governed artifact."
     },
     {
       "artifact_type": "wpg_reusable_template",
@@ -12875,552 +13720,6 @@
       "last_updated_in": "1.0.82",
       "example_path": "contracts/examples/xrun_signal_quality_result.json",
       "notes": "VAL-06 governed validation artifact proving deterministic XRUN-01 pattern/action/signal quality and fail-closed handling under insufficient/malformed inputs."
-    },
-    {
-      "artifact_type": "artifact_eval_requirement_profile",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/artifact_eval_requirement_profile.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "wpg_eval_coverage_artifact",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/wpg_eval_coverage_artifact.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "failure_to_eval_conversion_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/failure_to_eval_conversion_record.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "eval_coverage_redteam_findings",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/eval_coverage_redteam_findings.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "wpg_release_readiness_artifact",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/wpg_release_readiness_artifact.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "release_readiness_policy_result",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/release_readiness_policy_result.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "promotion_requirement_profile",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/promotion_requirement_profile.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "promotion_requirement_evaluation_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/promotion_requirement_evaluation_record.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "readiness_promotion_redteam_findings",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/readiness_promotion_redteam_findings.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "contract_compatibility_evaluation_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/contract_compatibility_evaluation_record.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "workflow_semantic_audit_result",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/workflow_semantic_audit_result.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "workflow_trust_redteam_findings",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/workflow_trust_redteam_findings.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "artifact_intelligence_index_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/artifact_intelligence_index_record.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "trend_report_artifact",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/trend_report_artifact.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "improvement_recommendation_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/improvement_recommendation_record.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "artifact_intelligence_redteam_findings",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/artifact_intelligence_redteam_findings.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "judgment_policy_candidate_artifact",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/judgment_policy_candidate_artifact.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "precedent_ranking_evaluation_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/precedent_ranking_evaluation_record.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "judge_disagreement_report",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/judge_disagreement_report.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "judgment_override_redteam_findings",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/judgment_override_redteam_findings.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "cross_run_bottleneck_report",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/cross_run_bottleneck_report.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "route_efficiency_report",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/route_efficiency_report.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "cross_run_redteam_findings",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/cross_run_redteam_findings.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "policy_regression_report",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/policy_regression_report.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "policy_canary_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/policy_canary_record.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "policy_rollback_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/policy_rollback_record.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "confidence_usage_policy",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/confidence_usage_policy.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "confidence_violation_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/confidence_violation_record.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "checkpoint_stage_contract_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/checkpoint_stage_contract_record.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "checkpoint_hibernate_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/checkpoint_hibernate_record.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "checkpoint_wake_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/checkpoint_wake_record.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "maintain_drift_report",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/maintain_drift_report.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "stale_assumption_report",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/stale_assumption_report.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "registry_divergence_report",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/registry_divergence_report.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "checkpoint_policy_maintain_redteam_findings",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/checkpoint_policy_maintain_redteam_findings.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "operator_trust_bottleneck_view",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/operator_trust_bottleneck_view.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "bottleneck_alert_trigger_result",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/bottleneck_alert_trigger_result.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "observability_redteam_findings",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/observability_redteam_findings.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "phase_certified_expansion_gate_result",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/phase_certified_expansion_gate_result.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "final_bottleneck_wave_redteam_findings",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/final_bottleneck_wave_redteam_findings.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "bottleneck_wave_certification_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/bottleneck_wave_certification_record.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
-    },
-    {
-      "artifact_type": "certification_remediation_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "proposed",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.143",
-      "last_updated_in": "1.3.143",
-      "example_path": "contracts/examples/certification_remediation_record.json",
-      "notes": "BNE-00 bottleneck attack wave governed artifact."
     }
   ]
 }

--- a/docs/governance-reports/contract-enforcement-report.md
+++ b/docs/governance-reports/contract-enforcement-report.md
@@ -1,6 +1,6 @@
 # Cross-Repo Contract Enforcement Report
 
-Generated: 2026-04-15T20:54:01Z
+Generated: 2026-04-16T10:38:03Z
 Source: `contracts/standards-manifest.json`
 
 ## Summary

--- a/docs/review-actions/PLAN-MAL-001-2026-04-16.md
+++ b/docs/review-actions/PLAN-MAL-001-2026-04-16.md
@@ -1,0 +1,12 @@
+# PLAN-MAL-001-2026-04-16
+
+- **Primary prompt type:** BUILD
+- **Batch:** MAL-001
+- **Scope:** Build Prompt Minimalism Layer + Automatic Review/Fix System contract surface and validation coverage in `spectrum-systems`.
+
+## Execution plan
+1. Add new canonical contract schemas for MAL-001 deliverables (PRM/RDX/TLC/RIL/FRE/CON/CDE/final scenarios), aligned to existing owners in `docs/architecture/system_registry.md`.
+2. Add deterministic example artifacts for each new schema in `contracts/examples/`.
+3. Register all new artifact types in `contracts/standards-manifest.json` with version and example linkage.
+4. Add focused tests validating MAL-001 examples and minimal-prompt enforcement behavior.
+5. Run contract/test enforcement commands required by repository policy.

--- a/governance/reports/contract-dependency-graph.json
+++ b/governance/reports/contract-dependency-graph.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0.0",
-  "generated_at": "2026-04-15T20:54:01Z",
+  "generated_at": "2026-04-16T10:38:03Z",
   "source_manifest": "contracts/standards-manifest.json",
   "repos": [
     {

--- a/tests/test_minimalism_automation_contracts.py
+++ b/tests/test_minimalism_automation_contracts.py
@@ -1,0 +1,51 @@
+import copy
+
+import pytest
+
+from spectrum_systems.contracts import load_example, validate_artifact
+
+
+MAL_CONTRACTS = (
+    "prm_step_template_registry_record",
+    "prm_prompt_minimalism_profile",
+    "prm_owner_scope_expansion_record",
+    "prm_authority_language_scrubber_result",
+    "rdx_prompt_to_plan_record",
+    "rdx_step_render_record",
+    "rdx_change_budget_record",
+    "rdx_narrowest_owner_resolution_record",
+    "tlc_review_fix_cycle_record",
+    "tlc_validation_ladder_result",
+    "tlc_rerun_cycle_record",
+    "ril_review_type_selection_record",
+    "ril_red_team_package_record",
+    "fre_fix_compilation_record",
+    "fre_fix_pack_record",
+    "con_composition_only_result",
+    "cde_review_completion_decision",
+    "cde_fix_completion_decision",
+    "ril_prompt_minimalism_red_team_report",
+    "fre_fix_pack_m1",
+    "final_minimal_prompt_scenario",
+    "final_auto_review_fix_scenario",
+    "final_rerun_report",
+)
+
+
+def test_mal_001_contract_examples_validate() -> None:
+    for contract in MAL_CONTRACTS:
+        validate_artifact(load_example(contract), contract)
+
+
+def test_prm_prompt_minimalism_profile_rejects_verbose_prompt_fields() -> None:
+    profile = copy.deepcopy(load_example("prm_prompt_minimalism_profile"))
+    profile["sequencing"] = ["manual"]
+    with pytest.raises(Exception):
+        validate_artifact(profile, "prm_prompt_minimalism_profile")
+
+
+def test_tlc_validation_ladder_enforces_required_order() -> None:
+    record = copy.deepcopy(load_example("tlc_validation_ladder_result"))
+    record["executed_order"] = ["contracts", "registry", "owner_tests", "integration"]
+    with pytest.raises(Exception):
+        validate_artifact(record, "tlc_validation_ladder_result")


### PR DESCRIPTION
### Motivation
- Implement the Prompt Minimalism Layer and Automatic Review/Fix System as a contract-level extraction so prompts carry only intent/scope/output and system behavior (review/fix/rerun) is enforced via governed artifacts. 
- Preserve existing owner boundaries (PRM, RDX, TLC, RIL, FRE, CON, CDE) and route orchestration through TLC while keeping CDE as closure authority. 
- Provide a plan-first, contract-first delivery that can be validated deterministically by existing tooling and CI checks.

### Description
- Added a set of new JSON Schema contracts (23 new schema files) under `contracts/schemas/` covering PRM, RDX, TLC, RIL, FRE, CON, CDE and final validation scenario artifacts. 
- Added deterministic example artifacts for every new schema under `contracts/examples/` and registered each new artifact in `contracts/standards-manifest.json` while bumping manifest metadata (`artifact_version`, `standards_version`, `source_repo_version`, `record_id`, `run_id`, `created_at`).
- Introduced a plan artifact `docs/review-actions/PLAN-MAL-001-2026-04-16.md` to satisfy the repo "plan first" rule and comply with multi-file BUILD governance. 
- Added focused tests `tests/test_minimalism_automation_contracts.py` that validate all new examples and check key fail-closed behaviors (reject verbose prompt fields and enforce validation-ladder order).

### Testing
- Ran `pytest tests/test_minimalism_automation_contracts.py tests/test_contracts.py tests/test_contract_enforcement.py` which completed successfully with all tests passing (test session: 135 passed). 
- Ran `python scripts/run_contract_enforcement.py` and verified it produced the enforcement report and contract dependency graph with `failures=0 warnings=0`. 
- Ran the contract boundary audit `.codex/skills/contract-boundary-audit/run.sh` which completed and reported non-blocking warnings but no blocking errors. 
- Regenerated governance outputs `docs/governance-reports/contract-enforcement-report.md` and `governance/reports/contract-dependency-graph.json` as part of the validation run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0bb532be88329b88d83b9f566a8bd)