### PR TITLE
ALD-01: close P1 owner-path and preparatory allowlist bypasses

### DIFF
--- a/docs/architecture/authority_leak_detection.md
+++ b/docs/architecture/authority_leak_detection.md
@@ -16,6 +16,7 @@ Categories covered:
 - `promotion`
 
 Only declared canonical owners for each category may emit authority artifacts or authority vocabulary.
+Owner matching is boundary-safe: canonical-owner status applies only to the exact registered file path, or to an explicitly declared directory boundary path ending with `/`.
 
 ## Forbidden vocabulary boundary
 Guard rules are defined in:
@@ -45,7 +46,8 @@ The detector blocks non-owner artifacts that:
 - combine outcome + action semantics in one object,
 - resemble certification/promotion verdict artifacts,
 - advertise authority-shaped `artifact_type` or `schema_ref`,
-- declare preparatory assertions but still carry authority semantics.
+- declare preparatory assertions but still carry authority semantics,
+- declare preparatory assertions while containing undeclared fields outside `preparatory_only.allowed_fields`.
 
 ## Preparatory-only convention
 Preparatory artifacts are observational only.
@@ -68,6 +70,7 @@ Allowed preparatory fields:
 - `non_authority_assertions`
 
 Preparatory artifacts must not include final-state authority fields or authority verdict values.
+Preparatory artifacts are allowlist-enforced: when `non_authority_assertions` is declared, every field in the artifact must be present in `preparatory_only.allowed_fields` unless explicitly allowlisted by policy.
 
 ## CI/guard enforcement
 Runner:

--- a/docs/review-actions/PLAN-ALD-01-FIX-P1-2026-04-18.md
+++ b/docs/review-actions/PLAN-ALD-01-FIX-P1-2026-04-18.md
@@ -1,0 +1,26 @@
+# PLAN-ALD-01-FIX-P1-2026-04-18
+
+## Prompt Type
+`BUILD`
+
+## Intent
+Close two residual bypasses in ALD-01 by hardening canonical owner-path matching and enforcing preparatory artifact allowlists while preserving fail-closed, deterministic execution.
+
+## Scope
+1. Tighten owner detection in `scripts/authority_leak_rules.py` to boundary-safe matching.
+2. Enforce `preparatory_only.allowed_fields` in `scripts/authority_shape_detector.py` when `non_authority_assertions` is present.
+3. Add deterministic regression coverage in `tests/test_authority_leak_detection.py`.
+4. Update ALD-01 docs and delivery report language to reflect allowlist enforcement.
+5. Add fix report documenting root cause, remediation, and validation outcomes.
+
+## Constraints honored
+- Artifact-first, fail-closed behavior preserved.
+- No broadening of owner authority beyond explicit registry declarations.
+- Repo-native deterministic implementation (stdlib-first, no network dependencies).
+- No unrelated refactors.
+
+## Validation plan
+- `pytest -q tests/test_authority_leak_detection.py`
+- `python scripts/run_authority_leak_guard.py --changed-files ...`
+- `pytest -q tests/test_authority_leak_detection.py tests/test_system_registry_guard.py`
+- `python scripts/run_system_registry_guard.py --changed-files ...`

--- a/docs/reviews/ALD-01_delivery_report.md
+++ b/docs/reviews/ALD-01_delivery_report.md
@@ -23,8 +23,10 @@ Shadow authority paths were possible when non-owner files emitted authority voca
 
 ## 4) Examples caught
 - Non-owner file emitting `decision: allow` is blocked.
+- Filename-prefix shadow files (for example `control_executor.py_shadow.py`) do not inherit canonical-owner status.
 - Non-owner object combining `decision` + `enforcement_action` is blocked.
 - Preparatory artifact with required non-authority assertions but hidden authority field is blocked (FXA-1100 style regression shape).
+- Preparatory artifact fields are allowlist-enforced: undeclared fields (for example `closure_decision`) fail unless explicitly allowlisted by policy/registry.
 
 ## 5) Tests added
 - `tests/test_authority_leak_detection.py`
@@ -42,5 +44,4 @@ Shadow authority paths were possible when non-owner files emitted authority voca
 
 ## 7) Future extensions
 - Add optional AST flow analysis to detect computed authority fields before serialization.
-- Add policy-tunable strict mode to fail on preparatory artifacts that include non-whitelisted fields.
 - Integrate authority leak guard invocation into preflight orchestration runner once adoption matures.

--- a/docs/reviews/ALD-01_fix_p1_report.md
+++ b/docs/reviews/ALD-01_fix_p1_report.md
@@ -1,0 +1,52 @@
+# ALD-01 Fix P1 Report
+
+## Prompt Type
+`BUILD`
+
+## Scope
+Close two P1 bypasses in the ALD-01 authority leak detection layer:
+1. boundary-unsafe canonical owner matching,
+2. missing preparatory allowlist enforcement.
+
+## Root cause
+
+### 1) Owner-path boundary bypass
+- `scripts/authority_leak_rules.py` treated canonical owners as loose prefixes and substring matches.
+- `forbidden_contexts.excluded_path_prefixes` used the same loose prefix semantics.
+- A non-owner file such as `spectrum_systems/modules/runtime/control_executor.py_shadow.py` could be treated as owner/excluded and bypass vocabulary checks.
+
+### 2) Preparatory allowlist bypass
+- `scripts/authority_shape_detector.py` enforced required `non_authority_assertions` and authority-token checks, but did not enforce `preparatory_only.allowed_fields`.
+- A preparatory artifact could include undeclared authority-like fields (for example `closure_decision`) and pass when forbidden-token heuristics did not catch it.
+
+## Exact fixes
+
+### A) Boundary-safe owner and scope matching
+- Added normalized boundary-safe path matching in `scripts/authority_leak_rules.py`:
+  - exact file match by default,
+  - directory match only when registry entry explicitly ends with `/`.
+- Replaced loose `startswith`/substring behavior in:
+  - canonical owner detection,
+  - forbidden context include/exclude matching.
+- Reused the same boundary-safe matching for shape detector context scoping via `scripts/authority_shape_detector.py`.
+
+### B) Preparatory allowlist enforcement
+- Updated `scripts/authority_shape_detector.py` so any artifact declaring `non_authority_assertions` is treated as preparatory and must satisfy:
+  1. required assertions present,
+  2. all object fields are declared in `preparatory_only.allowed_fields`.
+- Added new fail-closed violation rule:
+  - `preparatory_fields_not_allowlisted`.
+
+## Regression tests added
+- `tests/test_authority_leak_detection.py`
+  - `test_filename_prefix_shadow_does_not_inherit_owner_status`
+  - `test_preparatory_artifact_undeclared_field_fails_allowlist`
+
+## Validation results
+- Targeted authority leak tests: pass.
+- Full authority leak guard tests: pass.
+- System Registry Guard tests: pass.
+- System Registry Guard runner check against changed files: pass.
+
+## Final status
+Both P1 bypasses are closed with deterministic, repo-native, fail-closed enforcement.

--- a/scripts/authority_leak_rules.py
+++ b/scripts/authority_leak_rules.py
@@ -55,26 +55,43 @@ def _owner_prefixes(registry: dict[str, Any]) -> tuple[str, ...]:
     return tuple(sorted(set(prefixes)))
 
 
+def _matches_declared_owner_path(normalized_path: str, declared_path: str) -> bool:
+    normalized_declared = _normalize(str(declared_path)).strip()
+    if not normalized_declared:
+        return False
+    if normalized_declared.endswith("/"):
+        boundary = normalized_declared.strip("/") + "/"
+        return normalized_path.startswith(boundary)
+    return normalized_path == normalized_declared.strip("/")
+
+
+def _matches_scope_entry(normalized_path: str, entry: str) -> bool:
+    normalized_entry = _normalize(entry).strip()
+    if not normalized_entry:
+        return False
+    if normalized_entry.endswith("/"):
+        return normalized_path.startswith(normalized_entry.strip("/") + "/")
+    return normalized_path == normalized_entry.strip("/")
+
+
 def is_owner_path(path: str, registry: dict[str, Any]) -> bool:
-    normalized = _normalize(path)
+    normalized = _normalize(path).strip("/")
     for prefix in _owner_prefixes(registry):
-        if normalized.startswith(prefix):
-            return True
-        if f"/{prefix}" in normalized:
+        if _matches_declared_owner_path(normalized, prefix):
             return True
     return False
 
 
 def _in_forbidden_context_scope(path: str, registry: dict[str, Any]) -> bool:
-    normalized = _normalize(path)
+    normalized = _normalize(path).strip("/")
     contexts = registry.get("forbidden_contexts", {})
     if not isinstance(contexts, dict):
         return True
     scope_prefixes = tuple(str(item) for item in contexts.get("default_scope_prefixes", []) if str(item).strip())
     excluded_prefixes = tuple(str(item) for item in contexts.get("excluded_path_prefixes", []) if str(item).strip())
-    if scope_prefixes and not normalized.startswith(scope_prefixes):
+    if scope_prefixes and not any(_matches_scope_entry(normalized, item) for item in scope_prefixes):
         return False
-    if excluded_prefixes and normalized.startswith(excluded_prefixes):
+    if excluded_prefixes and any(_matches_scope_entry(normalized, item) for item in excluded_prefixes):
         return False
     return True
 

--- a/scripts/authority_shape_detector.py
+++ b/scripts/authority_shape_detector.py
@@ -8,7 +8,7 @@ import re
 from pathlib import Path
 from typing import Any
 
-from scripts.authority_leak_rules import FORBIDDEN_FIELDS, FORBIDDEN_VALUES, is_owner_path
+from scripts.authority_leak_rules import FORBIDDEN_FIELDS, FORBIDDEN_VALUES, _matches_scope_entry, is_owner_path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -18,15 +18,15 @@ _ARTIFACT_AUTHORITY_PATTERN = re.compile(r"(decision|certification|promotion|enf
 
 
 def _in_forbidden_context_scope(path: str, registry: dict[str, Any]) -> bool:
-    normalized = path.replace("\\", "/")
+    normalized = path.replace("\\", "/").strip("/")
     contexts = registry.get("forbidden_contexts", {})
     if not isinstance(contexts, dict):
         return True
     scope_prefixes = tuple(str(item) for item in contexts.get("default_scope_prefixes", []) if str(item).strip())
     excluded_prefixes = tuple(str(item) for item in contexts.get("excluded_path_prefixes", []) if str(item).strip())
-    if scope_prefixes and not normalized.startswith(scope_prefixes):
+    if scope_prefixes and not any(_matches_scope_entry(normalized, item) for item in scope_prefixes):
         return False
-    if excluded_prefixes and normalized.startswith(excluded_prefixes):
+    if excluded_prefixes and any(_matches_scope_entry(normalized, item) for item in excluded_prefixes):
         return False
     return True
 
@@ -97,6 +97,10 @@ def detect_authority_shapes(path: Path, registry: dict[str, Any]) -> list[dict[s
         str(item).strip().lower()
         for item in registry.get("preparatory_only", {}).get("required_non_authority_assertions", [])
     )
+    allowed_preparatory_fields = set(
+        str(item).strip().lower()
+        for item in registry.get("preparatory_only", {}).get("allowed_fields", [])
+    )
 
     violations: list[dict[str, Any]] = []
     for index, obj in enumerate(objects, start=1):
@@ -159,6 +163,18 @@ def detect_authority_shapes(path: Path, registry: dict[str, Any]) -> list[dict[s
                         "expected": sorted(required_assertions),
                         "actual": sorted(assertion_set),
                         "message": "preparatory artifact missing required non_authority_assertions",
+                    }
+                )
+            undeclared_fields = sorted(key for key in keys if key not in allowed_preparatory_fields)
+            if undeclared_fields:
+                violations.append(
+                    {
+                        "rule": "preparatory_fields_not_allowlisted",
+                        "path": rel_path,
+                        "object_index": index,
+                        "allowed_fields": sorted(allowed_preparatory_fields),
+                        "undeclared_fields": undeclared_fields,
+                        "message": "preparatory-only artifact contains fields outside preparatory_only.allowed_fields",
                     }
                 )
 

--- a/tests/test_authority_leak_detection.py
+++ b/tests/test_authority_leak_detection.py
@@ -41,6 +41,17 @@ def test_non_owner_emits_authority_field_fails() -> None:
         test_file.unlink(missing_ok=True)
 
 
+def test_filename_prefix_shadow_does_not_inherit_owner_status() -> None:
+    registry = load_authority_registry(REGISTRY_PATH)
+    test_file = REPO_ROOT / "spectrum_systems" / "modules" / "runtime" / "control_executor.py_shadow.py"
+    test_file.write_text("payload = {'decision': 'allow'}\n", encoding="utf-8")
+    try:
+        violations = find_forbidden_vocabulary(test_file, registry)
+        assert any(v["rule"] == "forbidden_field" and v["token"] == "decision" for v in violations)
+    finally:
+        test_file.unlink(missing_ok=True)
+
+
 def test_disguised_authority_shape_fails() -> None:
     registry = load_authority_registry(REGISTRY_PATH)
     payload = {
@@ -54,6 +65,28 @@ def test_disguised_authority_shape_fails() -> None:
     try:
         violations = detect_authority_shapes(path, registry)
         assert any(v["rule"] == "authority_shape_outcome_action" for v in violations)
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def test_preparatory_artifact_undeclared_field_fails_allowlist() -> None:
+    registry = load_authority_registry(REGISTRY_PATH)
+    payload = {
+        "artifact_type": "transcript_control_input_signal",
+        "non_authority_assertions": [
+            "preparatory_only",
+            "not_control_authority",
+            "not_certification_authority",
+        ],
+        "observations": ["candidate signal"],
+        "replay_hash": "abc123",
+        "closure_decision": "pending",
+    }
+    path = REPO_ROOT / "contracts" / "examples" / "tmp_preparatory_allowlist_violation.json"
+    _write_json(path, payload)
+    try:
+        violations = detect_authority_shapes(path, registry)
+        assert any(v["rule"] == "preparatory_fields_not_allowlisted" for v in violations)
     finally:
         path.unlink(missing_ok=True)
 


### PR DESCRIPTION
### Motivation
- Close two P1 bypasses in the ALD-01 authority leak detection layer by removing loose owner-path substring matching and enforcing preparatory-allowlist semantics so the guard remains fail-closed and deterministic.

### Description
- Hardened owner/scope matching in `scripts/authority_leak_rules.py` to boundary-safe semantics so canonical-owner status requires an exact path match or an explicitly-declared directory boundary (trailing `/`), eliminating filename-prefix inheritance like `control_executor.py_shadow.py`.
- Enforced preparatory allowlist in `scripts/authority_shape_detector.py` so any artifact that declares `non_authority_assertions` must include required assertions and may only contain fields present in `preparatory_only.allowed_fields`, adding the `preparatory_fields_not_allowlisted` violation rule.
- Added deterministic regression tests in `tests/test_authority_leak_detection.py` for the filename-prefix shadow case and the preparatory allowlist violation, and updated ALD docs and delivery report to document boundary-safe owner matching and allowlist enforcement; also added the plan and fix report artifacts.

### Testing
- Ran `pytest -q tests/test_authority_leak_detection.py` and it passed (`8 passed`).
- Ran `pytest -q tests/test_authority_leak_detection.py tests/test_forbidden_authority_vocabulary_guard.py` and it passed (`12 passed`).
- Ran `pytest -q tests/test_system_registry_guard.py` and it passed (`10 passed`).
- Ran the guard runners `python scripts/run_authority_leak_guard.py --changed-files ...` and `python scripts/run_system_registry_guard.py --changed-files ...` and both returned pass with JSON result artifacts generated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3941e271c83298e005e1539530692)