### PR TITLE
Add governed context bundle and fail-closed context admission to WPG pipeline

### DIFF
--- a/contracts/examples/context_admission_result.json
+++ b/contracts/examples/context_admission_result.json
@@ -1,0 +1,22 @@
+{
+  "artifact_type": "context_admission_result",
+  "schema_version": "1.0.0",
+  "admission_id": "ctxa-example-001",
+  "context_bundle_id": "ctxb-example-001",
+  "trace": {
+    "trace_id": "trace-ctx-001",
+    "run_id": "run-ctx-001"
+  },
+  "admission_status": "pass",
+  "enforcement_action": "ALLOW",
+  "blocking_reasons": [],
+  "stale_sources": [],
+  "contradictions": [],
+  "created_at": "2026-04-18T00:00:00Z",
+  "checks": {
+    "completeness": true,
+    "freshness": true,
+    "contradiction": true,
+    "provenance": true
+  }
+}

--- a/contracts/examples/context_bundle_artifact.json
+++ b/contracts/examples/context_bundle_artifact.json
@@ -1,0 +1,34 @@
+{
+  "artifact_type": "context_bundle_artifact",
+  "schema_version": "1.0.0",
+  "context_bundle_id": "ctxb-example-001",
+  "trace": {
+    "trace_id": "trace-ctx-001",
+    "run_id": "run-ctx-001"
+  },
+  "created_at": "2026-04-18T00:00:00Z",
+  "components": [
+    {
+      "component_type": "transcript",
+      "required": true,
+      "source_type": "transcript",
+      "source_ref": "transcript_artifact",
+      "captured_at": "2026-04-18T00:00:00Z",
+      "content_hash": "sha256:aaa",
+      "statements": [
+        {
+          "topic": "deployment_readiness",
+          "polarity": "affirm",
+          "text": "Deployment can start after control review."
+        }
+      ],
+      "provenance": {
+        "source_uri": "artifact://transcript_artifact",
+        "source_system": "wpg_pipeline",
+        "collected_by": "wpg_context_governance",
+        "collected_at": "2026-04-18T00:00:00Z",
+        "attribution": "transcript_artifact"
+      }
+    }
+  ]
+}

--- a/contracts/schemas/context_admission_result.schema.json
+++ b/contracts/schemas/context_admission_result.schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/context_admission_result.schema.json",
+  "title": "context_admission_result",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "artifact_type": { "type": "string", "const": "context_admission_result" },
+    "schema_version": { "type": "string", "const": "1.0.0" },
+    "admission_id": { "type": "string", "minLength": 1 },
+    "context_bundle_id": { "type": "string", "minLength": 1 },
+    "trace": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "trace_id": { "type": "string", "minLength": 1 },
+        "run_id": { "type": "string", "minLength": 1 }
+      },
+      "required": ["trace_id", "run_id"]
+    },
+    "admission_status": { "type": "string", "enum": ["pass", "fail"] },
+    "enforcement_action": { "type": "string", "enum": ["ALLOW", "BLOCK", "FREEZE"] },
+    "blocking_reasons": { "type": "array", "items": { "type": "string" } },
+    "stale_sources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "source_ref": { "type": "string" },
+          "source_type": { "type": "string" },
+          "classification": { "type": "string" },
+          "reason": { "type": "string" },
+          "critical": { "type": "boolean" }
+        },
+        "required": ["source_ref", "source_type", "classification", "reason", "critical"]
+      }
+    },
+    "contradictions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "topic": { "type": "string" },
+          "left_ref": { "type": "string" },
+          "right_ref": { "type": "string" },
+          "left_polarity": { "type": "string" },
+          "right_polarity": { "type": "string" },
+          "status": { "type": "string", "const": "unresolved" }
+        },
+        "required": ["topic", "left_ref", "right_ref", "left_polarity", "right_polarity", "status"]
+      }
+    },
+    "created_at": { "type": "string", "format": "date-time" },
+    "checks": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "completeness": { "type": "boolean" },
+        "freshness": { "type": "boolean" },
+        "contradiction": { "type": "boolean" },
+        "provenance": { "type": "boolean" }
+      },
+      "required": ["completeness", "freshness", "contradiction", "provenance"]
+    }
+  },
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "admission_id",
+    "context_bundle_id",
+    "trace",
+    "admission_status",
+    "enforcement_action",
+    "blocking_reasons",
+    "stale_sources",
+    "contradictions",
+    "created_at",
+    "checks"
+  ]
+}

--- a/contracts/schemas/context_bundle_artifact.schema.json
+++ b/contracts/schemas/context_bundle_artifact.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/context_bundle_artifact.schema.json",
+  "title": "context_bundle_artifact",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "artifact_type": { "type": "string", "const": "context_bundle_artifact" },
+    "schema_version": { "type": "string", "const": "1.0.0" },
+    "context_bundle_id": { "type": "string", "minLength": 1 },
+    "trace": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "trace_id": { "type": "string", "minLength": 1 },
+        "run_id": { "type": "string", "minLength": 1 }
+      },
+      "required": ["trace_id", "run_id"]
+    },
+    "created_at": { "type": "string", "format": "date-time" },
+    "components": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "component_type": {
+            "type": "string",
+            "enum": ["transcript", "meeting_minutes", "slides", "critique_artifacts", "prior_wpg_outputs", "eval_outputs"]
+          },
+          "required": { "type": "boolean" },
+          "source_type": { "type": "string", "minLength": 1 },
+          "source_ref": { "type": "string", "minLength": 1 },
+          "captured_at": { "type": "string", "format": "date-time" },
+          "content_hash": { "type": "string", "minLength": 1 },
+          "statements": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "topic": { "type": "string", "minLength": 1 },
+                "polarity": { "type": "string", "enum": ["affirm", "deny"] },
+                "text": { "type": "string", "minLength": 1 }
+              },
+              "required": ["topic", "polarity", "text"]
+            }
+          },
+          "provenance": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "source_uri": { "type": "string", "minLength": 1 },
+              "source_system": { "type": "string", "minLength": 1 },
+              "collected_by": { "type": "string", "minLength": 1 },
+              "collected_at": { "type": "string", "format": "date-time" },
+              "attribution": { "type": "string", "minLength": 1 }
+            },
+            "required": ["source_uri", "source_system", "collected_by", "collected_at", "attribution"]
+          }
+        },
+        "required": ["component_type", "required", "source_type", "source_ref", "captured_at", "content_hash", "provenance"]
+      }
+    }
+  },
+  "required": ["artifact_type", "schema_version", "context_bundle_id", "trace", "created_at", "components"]
+}

--- a/contracts/standards-manifest.json
+++ b/contracts/standards-manifest.json
@@ -1,12 +1,12 @@
 {
   "artifact_type": "standards_manifest",
   "artifact_id": "STD-CONTRACTS",
-  "artifact_version": "1.3.148",
+  "artifact_version": "1.3.149",
   "schema_version": "1.3.99",
   "standards_version": "1.9.8",
-  "record_id": "REC-STD-2026-04-17-SLH-001",
-  "run_id": "run-20260417T000000Z-slh-001",
-  "created_at": "2026-04-17T00:00:00Z",
+  "record_id": "REC-STD-2026-04-18-CTX-01-EXEC",
+  "run_id": "run-20260418T000000Z-ctx-01-exec",
+  "created_at": "2026-04-18T00:00:00Z",
   "created_by": {
     "name": "Spectrum Systems Architecture Team",
     "role": "standards-publication",
@@ -15,7 +15,7 @@
     "contact": "architecture@spectrum-systems.test"
   },
   "source_repo": "nicklasorte/spectrum-systems",
-  "source_repo_version": "1.3.148",
+  "source_repo_version": "1.3.149",
   "input_artifacts": [
     {
       "artifact_id": "STD-CONTRACTS",
@@ -2405,6 +2405,19 @@
       "notes": "WPG EXEC C-H governed execution artifact."
     },
     {
+      "artifact_type": "context_admission_result",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.149",
+      "last_updated_in": "1.3.149",
+      "example_path": "contracts/examples/context_admission_result.json",
+      "notes": "CTX-01-EXEC governed context admission evaluation result with fail-closed block/freeze semantics."
+    },
+    {
       "artifact_type": "context_bundle",
       "artifact_class": "coordination",
       "schema_version": "2.3.0",
@@ -2416,6 +2429,19 @@
       "last_updated_in": "1.0.61",
       "example_path": "contracts/examples/context_bundle.json",
       "notes": "AI-02 deterministic context bundle hardening: required per-item provenance_ref, deterministic item identity validation, and fail-closed trust-boundary enforcement."
+    },
+    {
+      "artifact_type": "context_bundle_artifact",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.149",
+      "last_updated_in": "1.3.149",
+      "example_path": "contracts/examples/context_bundle_artifact.json",
+      "notes": "CTX-01-EXEC governed context bundle artifact with required components, provenance, freshness, and contradiction-ready statements."
     },
     {
       "artifact_type": "context_bundle_record",

--- a/docs/review-actions/PLAN-CTX-01-EXEC-2026-04-18.md
+++ b/docs/review-actions/PLAN-CTX-01-EXEC-2026-04-18.md
@@ -1,0 +1,52 @@
+# Plan — CTX-01-EXEC — 2026-04-18
+
+## Prompt type
+BUILD
+
+## Roadmap item
+CTX-01-EXEC — Context Bundle + Admission Control (Governed Context Layer)
+
+## Objective
+Implement a governed, versioned context bundle and fail-closed context admission layer for WPG execution with contradiction/freshness/provenance enforcement, red-team coverage, and readiness integration.
+
+## Declared files
+| File | Change type | Reason |
+| --- | --- | --- |
+| contracts/schemas/context_bundle_artifact.schema.json | CREATE | Canonical schema for governed context bundle artifact. |
+| contracts/examples/context_bundle_artifact.json | CREATE | Golden example for context bundle artifact validation. |
+| contracts/schemas/context_admission_result.schema.json | CREATE | Canonical schema for admission outcome with blocking/freeze semantics. |
+| contracts/examples/context_admission_result.json | CREATE | Golden example for context admission result validation. |
+| contracts/standards-manifest.json | MODIFY | Register new governed contracts and bump manifest version metadata. |
+| spectrum_systems/modules/wpg/context_governance.py | CREATE | Implement context bundle composition, admission policy, contradiction/freshness/provenance checks, red-team generation, and readiness gate integration. |
+| spectrum_systems/orchestration/wpg_pipeline.py | MODIFY | Attach context bundle to pipeline input, enforce admission pre-execution, bind to readiness gate and artifact chain. |
+| tests/fixtures/wpg/sample_workflow_loop_input.json | MODIFY | Provide governed context input fixture for CLI/global validation path. |
+| tests/test_context_bundle_artifact.py | CREATE | Validate context bundle artifact schema and fail-closed required component behavior. |
+| tests/test_context_admission_policy.py | CREATE | Validate admission policy completeness/freshness/contradiction/provenance decisions. |
+| tests/test_context_contradiction_detection.py | CREATE | Validate cross-source contradiction detection and unresolved contradiction blocking. |
+| tests/test_context_freshness.py | CREATE | Validate source freshness classification and stale critical freeze behavior. |
+| tests/test_redteam_context_failures.py | CREATE | Validate adversarial context failure generation and detections. |
+| tests/test_context_regressions.py | CREATE | Bind fixes to regression tests for repeated failure class blocking behavior. |
+| tests/test_context_readiness_integration.py | CREATE | Validate readiness gate blocks promotion when context admission fails. |
+
+## Contracts touched
+- `context_bundle_artifact` (new)
+- `context_admission_result` (new)
+- `contracts/standards-manifest.json` version + contract registry entries
+
+## Tests that must pass after execution
+1. `python -m pytest -q tests/test_context_bundle_artifact.py`
+2. `python -m pytest -q tests/test_context_admission_policy.py`
+3. `python -m pytest -q tests/test_context_contradiction_detection.py`
+4. `python -m pytest -q tests/test_context_freshness.py`
+5. `python -m pytest -q tests/test_redteam_context_failures.py`
+6. `python -m pytest -q tests/test_context_regressions.py`
+7. `python scripts/run_contract_enforcement.py`
+8. `python scripts/run_wpg_pipeline.py --input tests/fixtures/wpg/sample_workflow_loop_input.json`
+
+## Scope exclusions
+- Do not redesign unrelated WPG stages.
+- Do not remove or weaken existing fail-closed controls.
+- Do not introduce network-dependent runtime behavior.
+
+## Dependencies
+- Existing WPG pipeline and contract loader infrastructure remain authoritative inputs.

--- a/docs/review-actions/PLAN-CTX-01-FIX-01-2026-04-18.md
+++ b/docs/review-actions/PLAN-CTX-01-FIX-01-2026-04-18.md
@@ -1,0 +1,46 @@
+# Plan — CTX-01-FIX-01 — 2026-04-18
+
+## Prompt type
+BUILD
+
+## Roadmap item
+CTX-01-FIX-01 — Fix zero-base system registry guard and close CTX P1 issues
+
+## Objective
+Repair zero-base SHA handling in system registry guard and restore strict fail-closed context admission and freshness behavior without placeholder masking.
+
+## Declared files
+| File | Change type | Reason |
+| --- | --- | --- |
+| scripts/run_system_registry_guard.py | MODIFY | Handle all-zero base SHA with valid changed-files fallback. |
+| tests/test_system_registry_guard.py | MODIFY | Add regressions for zero-base push and normal diff path. |
+| spectrum_systems/modules/wpg/context_governance.py | MODIFY | Remove timestamp freshness masking and reject placeholder required context. |
+| spectrum_systems/orchestration/wpg_pipeline.py | MODIFY | Stop synthesizing placeholder required context components. |
+| tests/test_context_bundle_artifact.py | MODIFY | Add strict completeness failure regression for placeholder components. |
+| tests/test_context_admission_policy.py | MODIFY | Add regressions for missing slides/critique and placeholder rejection. |
+| tests/test_context_freshness.py | MODIFY | Add regression for missing timestamp fail-closed stale/invalid handling. |
+| tests/test_context_regressions.py | MODIFY | Bind placeholder and missing required context regressions. |
+| tests/test_wpg_pipeline.py | MODIFY | Add fail-closed pipeline regressions for missing required context components. |
+
+## Contracts touched
+None.
+
+## Tests that must pass after execution
+1. `python -m pytest -q tests/test_system_registry_guard.py`
+2. `python -m pytest -q tests/test_context_bundle_artifact.py`
+3. `python -m pytest -q tests/test_context_admission_policy.py`
+4. `python -m pytest -q tests/test_context_contradiction_detection.py`
+5. `python -m pytest -q tests/test_context_freshness.py`
+6. `python -m pytest -q tests/test_context_regressions.py`
+7. `python -m pytest -q tests/test_context_readiness_integration.py`
+8. `python -m pytest -q tests/test_wpg_pipeline.py tests/test_wpg_phase_aware_execution.py`
+9. `python scripts/run_contract_enforcement.py`
+10. `python -m pytest -q`
+
+## Scope exclusions
+- Do not weaken system registry guard behavior.
+- Do not bypass or downgrade context admission outcomes.
+- Do not modify unrelated governance or contract surfaces.
+
+## Dependencies
+- Existing CTX-01 implementation and tests on branch head.

--- a/scripts/run_system_registry_guard.py
+++ b/scripts/run_system_registry_guard.py
@@ -29,6 +29,12 @@ def _run(command: list[str]) -> tuple[int, str]:
 def _resolve_changed_files(base_ref: str, head_ref: str, explicit: list[str]) -> list[str]:
     if explicit:
         return sorted(set(path.strip() for path in explicit if path.strip()))
+    zero_sha = "0" * 40
+    if base_ref == zero_sha:
+        code, output = _run(["git", "diff-tree", "--no-commit-id", "--name-only", "-r", head_ref])
+        if code != 0:
+            raise SystemRegistryGuardError(f"failed to resolve changed files from head commit {head_ref}: {output}")
+        return sorted(set(line.strip() for line in output.splitlines() if line.strip()))
     code, output = _run(["git", "diff", "--name-only", f"{base_ref}..{head_ref}"])
     if code != 0:
         raise SystemRegistryGuardError(f"failed to resolve changed files from {base_ref}..{head_ref}: {output}")

--- a/spectrum_systems/modules/wpg/context_governance.py
+++ b/spectrum_systems/modules/wpg/context_governance.py
@@ -71,6 +71,12 @@ def _extract_statements(component: Mapping[str, Any]) -> list[dict[str, str]]:
     return findings
 
 
+def _component_is_placeholder(component: Mapping[str, Any]) -> bool:
+    source_ref = str(component.get("source_ref") or "").strip().lower()
+    source_uri = str(((component.get("provenance") or {}) if isinstance(component.get("provenance"), Mapping) else {}).get("source_uri") or "").strip().lower()
+    return source_ref.endswith("_input") or source_ref.startswith("placeholder_") or source_uri.endswith("_input")
+
+
 
 def detect_context_contradictions(components: Sequence[Mapping[str, Any]]) -> list[dict[str, str]]:
     by_topic: dict[str, list[tuple[str, str]]] = {}
@@ -163,12 +169,18 @@ def build_context_bundle_artifact(
     created_at: str | None = None,
 ) -> dict[str, Any]:
     items: list[dict[str, Any]] = []
+    default_created_at = created_at or _utc_now_iso()
     for component_type in CRITICAL_COMPONENTS:
+        if component_type not in components:
+            continue
         payload = dict(components.get(component_type, {}))
         source_ref = str(payload.get("source_ref") or f"{component_type}_artifact")
-        captured_at = str(payload.get("captured_at") or created_at or _utc_now_iso())
+        source_metadata = payload.get("source_metadata") if isinstance(payload.get("source_metadata"), Mapping) else {}
+        captured_value = payload.get("captured_at") or payload.get("source_captured_at") or source_metadata.get("captured_at")
+        captured_at = str(captured_value) if captured_value is not None else ""
         statements = payload.get("statements") if isinstance(payload.get("statements"), list) else []
         content = payload.get("content", {})
+        collected_at = str(payload.get("collected_at") or default_created_at)
         items.append(
             {
                 "component_type": component_type,
@@ -182,7 +194,7 @@ def build_context_bundle_artifact(
                     "source_uri": str(payload.get("source_uri") or f"artifact://{source_ref}"),
                     "source_system": str(payload.get("source_system") or "wpg"),
                     "collected_by": str(payload.get("collected_by") or "wpg_context_governance"),
-                    "collected_at": captured_at,
+                    "collected_at": collected_at,
                     "attribution": str(payload.get("attribution") or source_ref),
                 },
             }
@@ -193,7 +205,7 @@ def build_context_bundle_artifact(
         "schema_version": "1.0.0",
         "context_bundle_id": f"ctxb-{stable_hash({'trace_id': trace_id, 'run_id': run_id, 'items': items})[:12]}",
         "trace": {"trace_id": trace_id, "run_id": run_id},
-        "created_at": created_at or _utc_now_iso(),
+        "created_at": default_created_at,
         "components": items,
     }
     return artifact
@@ -209,7 +221,11 @@ def evaluate_context_admission(
     if not isinstance(components, list):
         components = []
 
-    present_types = {str(item.get("component_type") or "") for item in components if isinstance(item, Mapping)}
+    present_types = {
+        str(item.get("component_type") or "")
+        for item in components
+        if isinstance(item, Mapping) and not _component_is_placeholder(item)
+    }
     missing = sorted([name for name in CRITICAL_COMPONENTS if name not in present_types])
 
     blocking_reasons: list[str] = []

--- a/spectrum_systems/modules/wpg/context_governance.py
+++ b/spectrum_systems/modules/wpg/context_governance.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Mapping, Sequence
+
+from spectrum_systems.modules.wpg.common import stable_hash
+
+
+CRITICAL_COMPONENTS: tuple[str, ...] = (
+    "transcript",
+    "meeting_minutes",
+    "slides",
+    "critique_artifacts",
+    "prior_wpg_outputs",
+    "eval_outputs",
+)
+
+SOURCE_CLASSIFICATION: dict[str, str] = {
+    "transcript": "real-time",
+    "meeting_minutes": "recent",
+    "slides": "recent",
+    "critique_artifacts": "recent",
+    "prior_wpg_outputs": "archival",
+    "eval_outputs": "recent",
+}
+
+FRESHNESS_MAX_AGE_DAYS: dict[str, int] = {
+    "real-time": 1,
+    "recent": 14,
+    "archival": 365,
+}
+
+
+class ContextGovernanceError(RuntimeError):
+    """Fail-closed context governance error."""
+
+
+@dataclass(frozen=True)
+class Contradiction:
+    topic: str
+    a_ref: str
+    b_ref: str
+    a_polarity: str
+    b_polarity: str
+
+
+
+def _utc_now_iso(now: datetime | None = None) -> str:
+    candidate = now or datetime.now(timezone.utc)
+    return candidate.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+
+def _parse_iso(ts: str) -> datetime:
+    cleaned = ts.replace("Z", "+00:00")
+    return datetime.fromisoformat(cleaned)
+
+
+
+def _extract_statements(component: Mapping[str, Any]) -> list[dict[str, str]]:
+    findings: list[dict[str, str]] = []
+    for row in component.get("statements", []) if isinstance(component.get("statements"), list) else []:
+        if not isinstance(row, dict):
+            continue
+        topic = str(row.get("topic") or "").strip().lower()
+        polarity = str(row.get("polarity") or "").strip().lower()
+        text = str(row.get("text") or "").strip()
+        if topic and polarity in {"affirm", "deny"} and text:
+            findings.append({"topic": topic, "polarity": polarity, "text": text})
+    return findings
+
+
+
+def detect_context_contradictions(components: Sequence[Mapping[str, Any]]) -> list[dict[str, str]]:
+    by_topic: dict[str, list[tuple[str, str]]] = {}
+    for component in components:
+        ref = str(component.get("source_ref") or component.get("component_type") or "unknown")
+        for st in _extract_statements(component):
+            by_topic.setdefault(st["topic"], []).append((ref, st["polarity"]))
+
+    contradictions: list[dict[str, str]] = []
+    for topic, rows in sorted(by_topic.items()):
+        affirm = [row for row in rows if row[1] == "affirm"]
+        deny = [row for row in rows if row[1] == "deny"]
+        if not affirm or not deny:
+            continue
+        a_ref = sorted(affirm, key=lambda r: r[0])[0][0]
+        b_ref = sorted(deny, key=lambda r: r[0])[0][0]
+        contradictions.append(
+            {
+                "topic": topic,
+                "left_ref": a_ref,
+                "right_ref": b_ref,
+                "left_polarity": "affirm",
+                "right_polarity": "deny",
+                "status": "unresolved",
+            }
+        )
+    return contradictions
+
+
+
+def enforce_context_freshness(
+    components: Sequence[Mapping[str, Any]],
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    now_dt = now or datetime.now(timezone.utc)
+    stale_sources: list[dict[str, Any]] = []
+
+    for component in components:
+        source_type = str(component.get("source_type") or "")
+        source_ref = str(component.get("source_ref") or source_type)
+        captured_at = str(component.get("captured_at") or "")
+        bucket = SOURCE_CLASSIFICATION.get(source_type, "recent")
+        max_age_days = FRESHNESS_MAX_AGE_DAYS[bucket]
+        try:
+            age_days = (now_dt - _parse_iso(captured_at)).total_seconds() / 86400.0
+        except Exception:
+            stale_sources.append(
+                {
+                    "source_ref": source_ref,
+                    "source_type": source_type,
+                    "classification": bucket,
+                    "age_days": None,
+                    "max_age_days": max_age_days,
+                    "reason": "invalid_or_missing_timestamp",
+                    "critical": source_type in CRITICAL_COMPONENTS,
+                }
+            )
+            continue
+
+        if age_days > max_age_days:
+            stale_sources.append(
+                {
+                    "source_ref": source_ref,
+                    "source_type": source_type,
+                    "classification": bucket,
+                    "age_days": round(age_days, 3),
+                    "max_age_days": max_age_days,
+                    "reason": "stale",
+                    "critical": source_type in CRITICAL_COMPONENTS,
+                }
+            )
+
+    critical_stale = [row for row in stale_sources if row.get("critical")]
+    action = "FREEZE" if critical_stale else ("BLOCK" if stale_sources else "ALLOW")
+    return {
+        "freshness_status": "pass" if not stale_sources else "fail",
+        "stale_sources": stale_sources,
+        "critical_stale_sources": critical_stale,
+        "freshness_action": action,
+    }
+
+
+
+def build_context_bundle_artifact(
+    *,
+    trace_id: str,
+    run_id: str,
+    components: Mapping[str, Mapping[str, Any]],
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    items: list[dict[str, Any]] = []
+    for component_type in CRITICAL_COMPONENTS:
+        payload = dict(components.get(component_type, {}))
+        source_ref = str(payload.get("source_ref") or f"{component_type}_artifact")
+        captured_at = str(payload.get("captured_at") or created_at or _utc_now_iso())
+        statements = payload.get("statements") if isinstance(payload.get("statements"), list) else []
+        content = payload.get("content", {})
+        items.append(
+            {
+                "component_type": component_type,
+                "required": True,
+                "source_type": component_type,
+                "source_ref": source_ref,
+                "captured_at": captured_at,
+                "content_hash": stable_hash(content),
+                "statements": statements,
+                "provenance": {
+                    "source_uri": str(payload.get("source_uri") or f"artifact://{source_ref}"),
+                    "source_system": str(payload.get("source_system") or "wpg"),
+                    "collected_by": str(payload.get("collected_by") or "wpg_context_governance"),
+                    "collected_at": captured_at,
+                    "attribution": str(payload.get("attribution") or source_ref),
+                },
+            }
+        )
+
+    artifact = {
+        "artifact_type": "context_bundle_artifact",
+        "schema_version": "1.0.0",
+        "context_bundle_id": f"ctxb-{stable_hash({'trace_id': trace_id, 'run_id': run_id, 'items': items})[:12]}",
+        "trace": {"trace_id": trace_id, "run_id": run_id},
+        "created_at": created_at or _utc_now_iso(),
+        "components": items,
+    }
+    return artifact
+
+
+
+def evaluate_context_admission(
+    context_bundle_artifact: Mapping[str, Any],
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    components = context_bundle_artifact.get("components")
+    if not isinstance(components, list):
+        components = []
+
+    present_types = {str(item.get("component_type") or "") for item in components if isinstance(item, Mapping)}
+    missing = sorted([name for name in CRITICAL_COMPONENTS if name not in present_types])
+
+    blocking_reasons: list[str] = []
+    if missing:
+        blocking_reasons.extend([f"missing_required_component:{name}" for name in missing])
+
+    provenance_failures = []
+    for item in components:
+        if not isinstance(item, Mapping):
+            continue
+        prov = item.get("provenance")
+        if not isinstance(prov, Mapping):
+            provenance_failures.append(str(item.get("component_type") or "unknown"))
+            continue
+        required_prov = ("source_uri", "source_system", "collected_by", "collected_at", "attribution")
+        if any(not str(prov.get(field) or "").strip() for field in required_prov):
+            provenance_failures.append(str(item.get("component_type") or "unknown"))
+    if provenance_failures:
+        blocking_reasons.extend([f"missing_provenance:{name}" for name in sorted(set(provenance_failures))])
+
+    contradictions = detect_context_contradictions([item for item in components if isinstance(item, Mapping)])
+    if contradictions:
+        blocking_reasons.append("unresolved_context_contradiction")
+
+    freshness = enforce_context_freshness([item for item in components if isinstance(item, Mapping)], now=now)
+
+    admission_status = "pass"
+    enforcement = "ALLOW"
+    if blocking_reasons:
+        admission_status = "fail"
+        enforcement = "BLOCK"
+    elif freshness["freshness_action"] == "FREEZE":
+        admission_status = "fail"
+        enforcement = "FREEZE"
+    elif freshness["freshness_action"] == "BLOCK":
+        admission_status = "fail"
+        enforcement = "BLOCK"
+
+    return {
+        "artifact_type": "context_admission_result",
+        "schema_version": "1.0.0",
+        "admission_id": f"ctxa-{stable_hash({'bundle': context_bundle_artifact.get('context_bundle_id', ''), 'status': admission_status, 'reasons': blocking_reasons, 'freshness': freshness['stale_sources'], 'contradictions': contradictions})[:12]}",
+        "context_bundle_id": str(context_bundle_artifact.get("context_bundle_id") or ""),
+        "trace": dict(context_bundle_artifact.get("trace") or {}),
+        "admission_status": admission_status,
+        "enforcement_action": enforcement,
+        "blocking_reasons": sorted(set(blocking_reasons)),
+        "stale_sources": freshness["stale_sources"],
+        "contradictions": contradictions,
+        "created_at": _utc_now_iso(now),
+        "checks": {
+            "completeness": len(missing) == 0,
+            "freshness": freshness["freshness_status"] == "pass",
+            "contradiction": len(contradictions) == 0,
+            "provenance": len(provenance_failures) == 0,
+        },
+    }
+
+
+
+def build_context_redteam_findings(*, trace_id: str) -> dict[str, Any]:
+    findings = [
+        {"case_id": "ctx-rt-01", "failure_class": "stale_data", "expected_action": "FREEZE"},
+        {"case_id": "ctx-rt-02", "failure_class": "missing_sources", "expected_action": "BLOCK"},
+        {"case_id": "ctx-rt-03", "failure_class": "conflicting_inputs", "expected_action": "BLOCK"},
+        {"case_id": "ctx-rt-04", "failure_class": "prompt_like_injection", "expected_action": "BLOCK"},
+    ]
+    return {
+        "artifact_type": "context_redteam_findings",
+        "schema_version": "1.0.0",
+        "trace_id": trace_id,
+        "findings": findings,
+    }
+
+
+
+def evaluate_context_readiness_integration(admission_result: Mapping[str, Any]) -> dict[str, Any]:
+    status = str(admission_result.get("admission_status") or "fail")
+    return {
+        "artifact_type": "context_readiness_integration",
+        "schema_version": "1.0.0",
+        "admission_status": status,
+        "readiness_decision": "BLOCK" if status != "pass" else "ALLOW",
+        "blocking_reasons": list(admission_result.get("blocking_reasons") or []),
+        "enforcement_action": str(admission_result.get("enforcement_action") or "BLOCK"),
+    }
+
+
+__all__ = [
+    "CRITICAL_COMPONENTS",
+    "ContextGovernanceError",
+    "build_context_bundle_artifact",
+    "build_context_redteam_findings",
+    "detect_context_contradictions",
+    "enforce_context_freshness",
+    "evaluate_context_admission",
+    "evaluate_context_readiness_integration",
+]

--- a/spectrum_systems/modules/wpg/redteam.py
+++ b/spectrum_systems/modules/wpg/redteam.py
@@ -15,6 +15,24 @@ def _highest_control_outcome(actions: List[str]) -> str:
     return "proceed"
 
 
+def _context_bundle(trace_id: str, run_id: str) -> Dict[str, Any]:
+    return {
+        "artifact_type": "context_bundle_artifact",
+        "schema_version": "1.0.0",
+        "context_bundle_id": f"ctxb-{run_id}",
+        "trace": {"trace_id": trace_id, "run_id": run_id},
+        "created_at": "2026-04-18T00:00:00Z",
+        "components": [
+            {"component_type": "transcript", "required": True, "source_type": "transcript", "source_ref": "transcript_artifact", "captured_at": "2026-04-18T00:00:00Z", "content_hash": "h1", "provenance": {"source_uri": "artifact://transcript_artifact", "source_system": "wpg", "collected_by": "redteam", "collected_at": "2026-04-18T00:00:00Z", "attribution": "transcript_artifact"}},
+            {"component_type": "meeting_minutes", "required": True, "source_type": "meeting_minutes", "source_ref": "meeting_minutes_artifact", "captured_at": "2026-04-18T00:00:00Z", "content_hash": "h2", "provenance": {"source_uri": "artifact://meeting_minutes_artifact", "source_system": "wpg", "collected_by": "redteam", "collected_at": "2026-04-18T00:00:00Z", "attribution": "meeting_minutes_artifact"}},
+            {"component_type": "slides", "required": True, "source_type": "slides", "source_ref": "slides_artifact", "captured_at": "2026-04-18T00:00:00Z", "content_hash": "h3", "provenance": {"source_uri": "artifact://slides_artifact", "source_system": "wpg", "collected_by": "redteam", "collected_at": "2026-04-18T00:00:00Z", "attribution": "slides_artifact"}},
+            {"component_type": "critique_artifacts", "required": True, "source_type": "critique_artifacts", "source_ref": "critique_artifact", "captured_at": "2026-04-18T00:00:00Z", "content_hash": "h4", "provenance": {"source_uri": "artifact://critique_artifact", "source_system": "wpg", "collected_by": "redteam", "collected_at": "2026-04-18T00:00:00Z", "attribution": "critique_artifact"}},
+            {"component_type": "prior_wpg_outputs", "required": True, "source_type": "prior_wpg_outputs", "source_ref": "prior_working_paper_artifact", "captured_at": "2026-04-18T00:00:00Z", "content_hash": "h5", "provenance": {"source_uri": "artifact://prior_working_paper_artifact", "source_system": "wpg", "collected_by": "redteam", "collected_at": "2026-04-18T00:00:00Z", "attribution": "prior_working_paper_artifact"}},
+            {"component_type": "eval_outputs", "required": True, "source_type": "eval_outputs", "source_ref": "eval_outputs_artifact", "captured_at": "2026-04-18T00:00:00Z", "content_hash": "h6", "provenance": {"source_uri": "artifact://eval_outputs_artifact", "source_system": "wpg", "collected_by": "redteam", "collected_at": "2026-04-18T00:00:00Z", "attribution": "eval_outputs_artifact"}},
+        ],
+    }
+
+
 def run_wpg_redteam_suite() -> Dict[str, Any]:
     findings_artifact = run_redteam_eval_blind_spots()
     return {
@@ -68,6 +86,10 @@ def run_redteam_eval_blind_spots() -> Dict[str, Any]:
             run_id=f"rtx-28-{scenario['scenario_id']}",
             trace_id=f"rtx-28-{scenario['scenario_id']}",
             mode="working_paper",
+            context_bundle_artifact=_context_bundle(
+                trace_id=f"rtx-28-{scenario['scenario_id']}",
+                run_id=f"rtx-28-{scenario['scenario_id']}",
+            ),
         )
         actions = [
             artifact.get("evaluation_refs", {}).get("control_decision", {}).get("enforcement", {}).get("action")

--- a/spectrum_systems/orchestration/wpg_pipeline.py
+++ b/spectrum_systems/orchestration/wpg_pipeline.py
@@ -54,6 +54,12 @@ from spectrum_systems.modules.runtime.bottleneck_alerts import compute_bottlenec
 from spectrum_systems.modules.runtime.semantic_eval import evaluate_semantic_classes, summarize_semantic_evidence
 from spectrum_systems.modules.runtime.failure_to_eval import convert_failures_to_eval_cases
 from spectrum_systems.modules.runtime.evaluation_control import build_evaluation_control_decision
+from spectrum_systems.modules.wpg.context_governance import (
+    build_context_bundle_artifact,
+    build_context_redteam_findings,
+    evaluate_context_admission,
+    evaluate_context_readiness_integration,
+)
 
 
 REQUIRED_ENFORCEMENT = {"ALLOW": "proceed", "WARN": "annotate", "BLOCK": "trigger_repair", "FREEZE": "halt"}
@@ -546,6 +552,7 @@ def run_wpg_pipeline(
     comment_artifact: Dict[str, Any] | None = None,
     phase_checkpoint_record: Dict[str, Any] | None = None,
     phase_registry: Dict[str, Any] | None = None,
+    context_bundle_artifact: Dict[str, Any] | None = None,
 ) -> Dict[str, Any]:
     ctx = StageContext(run_id=run_id, trace_id=trace_id)
     registry = ensure_contract(phase_registry, "phase_registry") if phase_registry else default_phase_registry(trace_id)
@@ -573,6 +580,49 @@ def run_wpg_pipeline(
 
     transcript_artifact = ensure_contract(normalize_transcript_payload(transcript_payload, trace_id=trace_id), "transcript_artifact")
     meeting_normalized = _normalize_meeting_payload(meeting_artifact or {}, trace_id=trace_id)
+    initial_context_bundle = context_bundle_artifact or build_context_bundle_artifact(
+        trace_id=trace_id,
+        run_id=run_id,
+        components={
+            "transcript": {
+                "source_ref": "transcript_artifact",
+                "content": transcript_artifact.get("outputs", {}),
+                "source_uri": "artifact://transcript_artifact",
+                "source_system": "wpg_pipeline",
+            },
+            "meeting_minutes": {
+                "source_ref": "meeting_artifact",
+                "content": meeting_normalized.get("outputs", {}),
+                "source_uri": "artifact://meeting_artifact",
+                "source_system": "wpg_pipeline",
+            },
+            "slides": {
+                "source_ref": "slides_artifact_input",
+                "content": {"status": "not_provided", "fallback": "pipeline_managed"},
+                "source_uri": "artifact://slides_artifact_input",
+            },
+            "critique_artifacts": {
+                "source_ref": "critique_artifacts_input",
+                "content": {"status": "not_provided", "fallback": "pipeline_managed"},
+                "source_uri": "artifact://critique_artifacts_input",
+            },
+            "prior_wpg_outputs": {
+                "source_ref": "prior_working_paper_artifact",
+                "content": prior_working_paper or {"status": "no_prior_outputs"},
+                "source_uri": "artifact://prior_working_paper_artifact",
+            },
+            "eval_outputs": {
+                "source_ref": "eval_outputs_input",
+                "content": {"status": "pending_runtime_eval"},
+                "source_uri": "artifact://eval_outputs_input",
+            },
+        },
+    )
+    context_admission_result = evaluate_context_admission(initial_context_bundle)
+    if context_admission_result["admission_status"] != "pass":
+        reasons = ",".join(context_admission_result["blocking_reasons"]) or context_admission_result["enforcement_action"]
+        raise WPGError(f"context admission blocked pipeline execution: {reasons}")
+
     meeting_minutes_artifact = _build_meeting_minutes(transcript_artifact, meeting_normalized, trace_id, run_id)
     action_item_artifact = _extract_action_items(transcript_artifact, meeting_minutes_artifact, trace_id, run_id)
 
@@ -689,6 +739,12 @@ def run_wpg_pipeline(
             "checkpoint": checkpoint,
         },
     )
+    context_readiness = evaluate_context_readiness_integration(context_admission_result)
+    if context_readiness["readiness_decision"] == "BLOCK":
+        readiness_pack["readiness"]["outputs"]["decision"] = "BLOCK"
+        readiness_pack["readiness"]["outputs"]["blocking_reasons"] = sorted(
+            set(readiness_pack["readiness"]["outputs"].get("blocking_reasons", []) + ["context_admission_invalid"])
+        )
     promotion_profile = ensure_contract(
         {
             "artifact_type": "promotion_requirement_profile",
@@ -765,6 +821,10 @@ def run_wpg_pipeline(
         "phase_registry": registry,
         "phase_checkpoint_record": checkpoint,
         "phase_transition_policy_result": transition,
+        "context_bundle_artifact": initial_context_bundle,
+        "context_admission_result": context_admission_result,
+        "context_readiness_integration": context_readiness,
+        "context_redteam_findings": build_context_redteam_findings(trace_id=trace_id),
     }
     phase_resume = build_phase_resume_record(
         checkpoint=checkpoint,
@@ -967,6 +1027,7 @@ def run_wpg_pipeline_from_file(input_path: Path, output_dir: Path, mode: str = "
     comment_artifact = payload.get("comment_artifact")
     phase_checkpoint_record = payload.get("phase_checkpoint_record")
     phase_registry = payload.get("phase_registry")
+    context_bundle_artifact = payload.get("context_bundle_artifact")
 
     bundle = run_wpg_pipeline(
         transcript,
@@ -979,6 +1040,7 @@ def run_wpg_pipeline_from_file(input_path: Path, output_dir: Path, mode: str = "
         comment_artifact=comment_artifact,
         phase_checkpoint_record=phase_checkpoint_record,
         phase_registry=phase_registry,
+        context_bundle_artifact=context_bundle_artifact,
     )
 
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/spectrum_systems/orchestration/wpg_pipeline.py
+++ b/spectrum_systems/orchestration/wpg_pipeline.py
@@ -580,43 +580,55 @@ def run_wpg_pipeline(
 
     transcript_artifact = ensure_contract(normalize_transcript_payload(transcript_payload, trace_id=trace_id), "transcript_artifact")
     meeting_normalized = _normalize_meeting_payload(meeting_artifact or {}, trace_id=trace_id)
+    derived_components: Dict[str, Dict[str, Any]] = {
+        "transcript": {
+            "source_ref": "transcript_artifact",
+            "content": transcript_artifact.get("outputs", {}),
+            "source_uri": "artifact://transcript_artifact",
+            "source_system": "wpg_pipeline",
+            "captured_at": transcript_artifact.get("outputs", {}).get("captured_at"),
+        },
+        "meeting_minutes": {
+            "source_ref": "meeting_artifact",
+            "content": meeting_normalized.get("outputs", {}),
+            "source_uri": "artifact://meeting_artifact",
+            "source_system": "wpg_pipeline",
+            "captured_at": meeting_normalized.get("outputs", {}).get("date"),
+        },
+    }
+    if isinstance(prior_working_paper, dict):
+        derived_components["prior_wpg_outputs"] = {
+            "source_ref": "prior_working_paper_artifact",
+            "content": prior_working_paper,
+            "source_uri": "artifact://prior_working_paper_artifact",
+            "captured_at": prior_working_paper.get("created_at"),
+        }
+    if isinstance(transcript_payload, dict):
+        if isinstance(transcript_payload.get("slides"), dict):
+            derived_components["slides"] = {
+                "source_ref": "slides_artifact_input",
+                "content": transcript_payload.get("slides", {}),
+                "source_uri": "artifact://slides_artifact_input",
+                "captured_at": transcript_payload.get("slides", {}).get("captured_at"),
+            }
+        if isinstance(transcript_payload.get("critique_artifacts"), dict):
+            derived_components["critique_artifacts"] = {
+                "source_ref": "critique_artifacts_input",
+                "content": transcript_payload.get("critique_artifacts", {}),
+                "source_uri": "artifact://critique_artifacts_input",
+                "captured_at": transcript_payload.get("critique_artifacts", {}).get("captured_at"),
+            }
+        if isinstance(transcript_payload.get("eval_outputs"), dict):
+            derived_components["eval_outputs"] = {
+                "source_ref": "eval_outputs_input",
+                "content": transcript_payload.get("eval_outputs", {}),
+                "source_uri": "artifact://eval_outputs_input",
+                "captured_at": transcript_payload.get("eval_outputs", {}).get("captured_at"),
+            }
     initial_context_bundle = context_bundle_artifact or build_context_bundle_artifact(
         trace_id=trace_id,
         run_id=run_id,
-        components={
-            "transcript": {
-                "source_ref": "transcript_artifact",
-                "content": transcript_artifact.get("outputs", {}),
-                "source_uri": "artifact://transcript_artifact",
-                "source_system": "wpg_pipeline",
-            },
-            "meeting_minutes": {
-                "source_ref": "meeting_artifact",
-                "content": meeting_normalized.get("outputs", {}),
-                "source_uri": "artifact://meeting_artifact",
-                "source_system": "wpg_pipeline",
-            },
-            "slides": {
-                "source_ref": "slides_artifact_input",
-                "content": {"status": "not_provided", "fallback": "pipeline_managed"},
-                "source_uri": "artifact://slides_artifact_input",
-            },
-            "critique_artifacts": {
-                "source_ref": "critique_artifacts_input",
-                "content": {"status": "not_provided", "fallback": "pipeline_managed"},
-                "source_uri": "artifact://critique_artifacts_input",
-            },
-            "prior_wpg_outputs": {
-                "source_ref": "prior_working_paper_artifact",
-                "content": prior_working_paper or {"status": "no_prior_outputs"},
-                "source_uri": "artifact://prior_working_paper_artifact",
-            },
-            "eval_outputs": {
-                "source_ref": "eval_outputs_input",
-                "content": {"status": "pending_runtime_eval"},
-                "source_uri": "artifact://eval_outputs_input",
-            },
-        },
+        components=derived_components,
     )
     context_admission_result = evaluate_context_admission(initial_context_bundle)
     if context_admission_result["admission_status"] != "pass":

--- a/tests/fixtures/wpg/sample_transcript.json
+++ b/tests/fixtures/wpg/sample_transcript.json
@@ -30,5 +30,107 @@
         "resolution": "Added explicit policy citation to section 1."
       }
     ]
+  },
+  "context_bundle_artifact": {
+    "artifact_type": "context_bundle_artifact",
+    "schema_version": "1.0.0",
+    "context_bundle_id": "ctxb-wpg-run-001",
+    "trace": {
+      "trace_id": "wpg-trace-001",
+      "run_id": "wpg-run-001"
+    },
+    "created_at": "2026-04-18T00:00:00Z",
+    "components": [
+      {
+        "component_type": "transcript",
+        "required": true,
+        "source_type": "transcript",
+        "source_ref": "transcript_artifact",
+        "captured_at": "2026-04-18T00:00:00Z",
+        "content_hash": "h1",
+        "provenance": {
+          "source_uri": "artifact://transcript_artifact",
+          "source_system": "wpg",
+          "collected_by": "fixture",
+          "collected_at": "2026-04-18T00:00:00Z",
+          "attribution": "transcript_artifact"
+        }
+      },
+      {
+        "component_type": "meeting_minutes",
+        "required": true,
+        "source_type": "meeting_minutes",
+        "source_ref": "meeting_minutes_artifact",
+        "captured_at": "2026-04-18T00:00:00Z",
+        "content_hash": "h2",
+        "provenance": {
+          "source_uri": "artifact://meeting_minutes_artifact",
+          "source_system": "wpg",
+          "collected_by": "fixture",
+          "collected_at": "2026-04-18T00:00:00Z",
+          "attribution": "meeting_minutes_artifact"
+        }
+      },
+      {
+        "component_type": "slides",
+        "required": true,
+        "source_type": "slides",
+        "source_ref": "slides_artifact",
+        "captured_at": "2026-04-18T00:00:00Z",
+        "content_hash": "h3",
+        "provenance": {
+          "source_uri": "artifact://slides_artifact",
+          "source_system": "wpg",
+          "collected_by": "fixture",
+          "collected_at": "2026-04-18T00:00:00Z",
+          "attribution": "slides_artifact"
+        }
+      },
+      {
+        "component_type": "critique_artifacts",
+        "required": true,
+        "source_type": "critique_artifacts",
+        "source_ref": "critique_artifact",
+        "captured_at": "2026-04-18T00:00:00Z",
+        "content_hash": "h4",
+        "provenance": {
+          "source_uri": "artifact://critique_artifact",
+          "source_system": "wpg",
+          "collected_by": "fixture",
+          "collected_at": "2026-04-18T00:00:00Z",
+          "attribution": "critique_artifact"
+        }
+      },
+      {
+        "component_type": "prior_wpg_outputs",
+        "required": true,
+        "source_type": "prior_wpg_outputs",
+        "source_ref": "prior_working_paper_artifact",
+        "captured_at": "2026-04-18T00:00:00Z",
+        "content_hash": "h5",
+        "provenance": {
+          "source_uri": "artifact://prior_working_paper_artifact",
+          "source_system": "wpg",
+          "collected_by": "fixture",
+          "collected_at": "2026-04-18T00:00:00Z",
+          "attribution": "prior_working_paper_artifact"
+        }
+      },
+      {
+        "component_type": "eval_outputs",
+        "required": true,
+        "source_type": "eval_outputs",
+        "source_ref": "eval_outputs_artifact",
+        "captured_at": "2026-04-18T00:00:00Z",
+        "content_hash": "h6",
+        "provenance": {
+          "source_uri": "artifact://eval_outputs_artifact",
+          "source_system": "wpg",
+          "collected_by": "fixture",
+          "collected_at": "2026-04-18T00:00:00Z",
+          "attribution": "eval_outputs_artifact"
+        }
+      }
+    ]
   }
 }

--- a/tests/fixtures/wpg/sample_workflow_loop_input.json
+++ b/tests/fixtures/wpg/sample_workflow_loop_input.json
@@ -6,8 +6,17 @@
     "date": "2026-04-15",
     "topic": "Workflow loop validation",
     "study_context": "Phase B only",
-    "participants": ["WPG", "CRM", "GOV"],
-    "agenda": ["minutes", "actions", "comments", "revisions"],
+    "participants": [
+      "WPG",
+      "CRM",
+      "GOV"
+    ],
+    "agenda": [
+      "minutes",
+      "actions",
+      "comments",
+      "revisions"
+    ],
     "transcript_ref": "transcript_artifact"
   },
   "transcript": {
@@ -54,6 +63,108 @@
       {
         "comment_id": "c-legacy-01",
         "resolution": "Legacy resolution from Phase A."
+      }
+    ]
+  },
+  "context_bundle_artifact": {
+    "artifact_type": "context_bundle_artifact",
+    "schema_version": "1.0.0",
+    "context_bundle_id": "ctxb-wpg-phase-b-001",
+    "trace": {
+      "trace_id": "trace-wpg-phase-b-001",
+      "run_id": "wpg-phase-b-001"
+    },
+    "created_at": "2026-04-18T00:00:00Z",
+    "components": [
+      {
+        "component_type": "transcript",
+        "required": true,
+        "source_type": "transcript",
+        "source_ref": "transcript_artifact",
+        "captured_at": "2026-04-18T00:00:00Z",
+        "content_hash": "sha256:t",
+        "provenance": {
+          "source_uri": "artifact://transcript_artifact",
+          "source_system": "wpg_pipeline",
+          "collected_by": "fixture",
+          "collected_at": "2026-04-18T00:00:00Z",
+          "attribution": "transcript_artifact"
+        }
+      },
+      {
+        "component_type": "meeting_minutes",
+        "required": true,
+        "source_type": "meeting_minutes",
+        "source_ref": "meeting_minutes_artifact",
+        "captured_at": "2026-04-18T00:00:00Z",
+        "content_hash": "sha256:m",
+        "provenance": {
+          "source_uri": "artifact://meeting_minutes_artifact",
+          "source_system": "wpg_pipeline",
+          "collected_by": "fixture",
+          "collected_at": "2026-04-18T00:00:00Z",
+          "attribution": "meeting_minutes_artifact"
+        }
+      },
+      {
+        "component_type": "slides",
+        "required": true,
+        "source_type": "slides",
+        "source_ref": "slides_artifact",
+        "captured_at": "2026-04-18T00:00:00Z",
+        "content_hash": "sha256:s",
+        "provenance": {
+          "source_uri": "artifact://slides_artifact",
+          "source_system": "wpg_pipeline",
+          "collected_by": "fixture",
+          "collected_at": "2026-04-18T00:00:00Z",
+          "attribution": "slides_artifact"
+        }
+      },
+      {
+        "component_type": "critique_artifacts",
+        "required": true,
+        "source_type": "critique_artifacts",
+        "source_ref": "stakeholder_critique_artifact",
+        "captured_at": "2026-04-18T00:00:00Z",
+        "content_hash": "sha256:c",
+        "provenance": {
+          "source_uri": "artifact://stakeholder_critique_artifact",
+          "source_system": "wpg_pipeline",
+          "collected_by": "fixture",
+          "collected_at": "2026-04-18T00:00:00Z",
+          "attribution": "stakeholder_critique_artifact"
+        }
+      },
+      {
+        "component_type": "prior_wpg_outputs",
+        "required": true,
+        "source_type": "prior_wpg_outputs",
+        "source_ref": "prior_working_paper_artifact",
+        "captured_at": "2026-04-10T00:00:00Z",
+        "content_hash": "sha256:p",
+        "provenance": {
+          "source_uri": "artifact://prior_working_paper_artifact",
+          "source_system": "wpg_pipeline",
+          "collected_by": "fixture",
+          "collected_at": "2026-04-10T00:00:00Z",
+          "attribution": "prior_working_paper_artifact"
+        }
+      },
+      {
+        "component_type": "eval_outputs",
+        "required": true,
+        "source_type": "eval_outputs",
+        "source_ref": "eval_outputs_artifact",
+        "captured_at": "2026-04-18T00:00:00Z",
+        "content_hash": "sha256:e",
+        "provenance": {
+          "source_uri": "artifact://eval_outputs_artifact",
+          "source_system": "wpg_pipeline",
+          "collected_by": "fixture",
+          "collected_at": "2026-04-18T00:00:00Z",
+          "attribution": "eval_outputs_artifact"
+        }
       }
     ]
   }

--- a/tests/test_context_admission_policy.py
+++ b/tests/test_context_admission_policy.py
@@ -124,3 +124,31 @@ def test_context_admission_policy_freezes_for_stale_critical_source() -> None:
     result = evaluate_context_admission(bundle, now=datetime(2026, 4, 18, tzinfo=timezone.utc))
     assert result["admission_status"] == "fail"
     assert result["enforcement_action"] == "FREEZE"
+
+
+def test_context_admission_policy_blocks_when_slides_missing() -> None:
+    bundle = _bundle()
+    bundle["components"] = [item for item in bundle["components"] if item["component_type"] != "slides"]
+    result = evaluate_context_admission(bundle, now=datetime(2026, 4, 18, tzinfo=timezone.utc))
+    assert result["admission_status"] == "fail"
+    assert "missing_required_component:slides" in result["blocking_reasons"]
+
+
+def test_context_admission_policy_blocks_when_critique_missing() -> None:
+    bundle = _bundle()
+    bundle["components"] = [item for item in bundle["components"] if item["component_type"] != "critique_artifacts"]
+    result = evaluate_context_admission(bundle, now=datetime(2026, 4, 18, tzinfo=timezone.utc))
+    assert result["admission_status"] == "fail"
+    assert "missing_required_component:critique_artifacts" in result["blocking_reasons"]
+
+
+def test_context_admission_policy_rejects_placeholder_component() -> None:
+    bundle = _bundle()
+    for component in bundle["components"]:
+        if component["component_type"] == "slides":
+            component["source_ref"] = "slides_artifact_input"
+            component["provenance"]["source_uri"] = "artifact://slides_artifact_input"
+            component["provenance"]["attribution"] = "slides_artifact_input"
+    result = evaluate_context_admission(bundle, now=datetime(2026, 4, 18, tzinfo=timezone.utc))
+    assert result["admission_status"] == "fail"
+    assert "missing_required_component:slides" in result["blocking_reasons"]

--- a/tests/test_context_admission_policy.py
+++ b/tests/test_context_admission_policy.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from spectrum_systems.contracts import load_example, validate_artifact
+from spectrum_systems.modules.wpg.context_governance import evaluate_context_admission
+
+
+def _bundle() -> dict:
+    return {
+        "artifact_type": "context_bundle_artifact",
+        "schema_version": "1.0.0",
+        "context_bundle_id": "ctxb-001",
+        "trace": {"trace_id": "trace-1", "run_id": "run-1"},
+        "created_at": "2026-04-18T00:00:00Z",
+        "components": [
+            {
+                "component_type": "transcript",
+                "required": True,
+                "source_type": "transcript",
+                "source_ref": "transcript_artifact",
+                "captured_at": "2026-04-18T00:00:00Z",
+                "content_hash": "h1",
+                "provenance": {
+                    "source_uri": "artifact://transcript_artifact",
+                    "source_system": "wpg",
+                    "collected_by": "test",
+                    "collected_at": "2026-04-18T00:00:00Z",
+                    "attribution": "transcript_artifact",
+                },
+            },
+            {
+                "component_type": "meeting_minutes",
+                "required": True,
+                "source_type": "meeting_minutes",
+                "source_ref": "meeting_minutes_artifact",
+                "captured_at": "2026-04-18T00:00:00Z",
+                "content_hash": "h2",
+                "provenance": {
+                    "source_uri": "artifact://meeting_minutes_artifact",
+                    "source_system": "wpg",
+                    "collected_by": "test",
+                    "collected_at": "2026-04-18T00:00:00Z",
+                    "attribution": "meeting_minutes_artifact",
+                },
+            },
+            {
+                "component_type": "slides",
+                "required": True,
+                "source_type": "slides",
+                "source_ref": "slides_artifact",
+                "captured_at": "2026-04-18T00:00:00Z",
+                "content_hash": "h3",
+                "provenance": {
+                    "source_uri": "artifact://slides_artifact",
+                    "source_system": "wpg",
+                    "collected_by": "test",
+                    "collected_at": "2026-04-18T00:00:00Z",
+                    "attribution": "slides_artifact",
+                },
+            },
+            {
+                "component_type": "critique_artifacts",
+                "required": True,
+                "source_type": "critique_artifacts",
+                "source_ref": "critique_artifact",
+                "captured_at": "2026-04-18T00:00:00Z",
+                "content_hash": "h4",
+                "provenance": {
+                    "source_uri": "artifact://critique_artifact",
+                    "source_system": "wpg",
+                    "collected_by": "test",
+                    "collected_at": "2026-04-18T00:00:00Z",
+                    "attribution": "critique_artifact",
+                },
+            },
+            {
+                "component_type": "prior_wpg_outputs",
+                "required": True,
+                "source_type": "prior_wpg_outputs",
+                "source_ref": "prior_output",
+                "captured_at": "2026-04-10T00:00:00Z",
+                "content_hash": "h5",
+                "provenance": {
+                    "source_uri": "artifact://prior_output",
+                    "source_system": "wpg",
+                    "collected_by": "test",
+                    "collected_at": "2026-04-10T00:00:00Z",
+                    "attribution": "prior_output",
+                },
+            },
+            {
+                "component_type": "eval_outputs",
+                "required": True,
+                "source_type": "eval_outputs",
+                "source_ref": "eval_output",
+                "captured_at": "2026-04-18T00:00:00Z",
+                "content_hash": "h6",
+                "provenance": {
+                    "source_uri": "artifact://eval_output",
+                    "source_system": "wpg",
+                    "collected_by": "test",
+                    "collected_at": "2026-04-18T00:00:00Z",
+                    "attribution": "eval_output",
+                },
+            },
+        ],
+    }
+
+
+def test_context_admission_result_example_validates() -> None:
+    validate_artifact(load_example("context_admission_result"), "context_admission_result")
+
+
+def test_context_admission_policy_passes_for_complete_fresh_traceable_bundle() -> None:
+    result = evaluate_context_admission(_bundle(), now=datetime(2026, 4, 18, tzinfo=timezone.utc))
+    assert result["admission_status"] == "pass"
+    assert result["enforcement_action"] == "ALLOW"
+
+
+def test_context_admission_policy_freezes_for_stale_critical_source() -> None:
+    bundle = _bundle()
+    bundle["components"][0]["captured_at"] = "2026-04-10T00:00:00Z"
+    result = evaluate_context_admission(bundle, now=datetime(2026, 4, 18, tzinfo=timezone.utc))
+    assert result["admission_status"] == "fail"
+    assert result["enforcement_action"] == "FREEZE"

--- a/tests/test_context_bundle_artifact.py
+++ b/tests/test_context_bundle_artifact.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from spectrum_systems.contracts import load_example, validate_artifact
+from spectrum_systems.modules.wpg.context_governance import build_context_bundle_artifact, evaluate_context_admission
+
+
+def test_context_bundle_artifact_example_validates() -> None:
+    validate_artifact(load_example("context_bundle_artifact"), "context_bundle_artifact")
+
+
+def test_context_bundle_artifact_blocks_when_required_component_missing() -> None:
+    bundle = build_context_bundle_artifact(
+        trace_id="trace-ctx-001",
+        run_id="run-ctx-001",
+        components={
+            "transcript": {"content": {"segments": []}},
+        },
+        created_at="2026-04-18T00:00:00Z",
+    )
+    bundle["components"] = [c for c in bundle["components"] if c["component_type"] != "slides"]
+    result = evaluate_context_admission(bundle, now=datetime(2026, 4, 18, tzinfo=timezone.utc))
+    assert result["admission_status"] == "fail"
+    assert "missing_required_component:slides" in result["blocking_reasons"]

--- a/tests/test_context_bundle_artifact.py
+++ b/tests/test_context_bundle_artifact.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-import pytest
-
 from spectrum_systems.contracts import load_example, validate_artifact
 from spectrum_systems.modules.wpg.context_governance import build_context_bundle_artifact, evaluate_context_admission
 
@@ -22,6 +20,51 @@ def test_context_bundle_artifact_blocks_when_required_component_missing() -> Non
         created_at="2026-04-18T00:00:00Z",
     )
     bundle["components"] = [c for c in bundle["components"] if c["component_type"] != "slides"]
+    result = evaluate_context_admission(bundle, now=datetime(2026, 4, 18, tzinfo=timezone.utc))
+    assert result["admission_status"] == "fail"
+    assert "missing_required_component:slides" in result["blocking_reasons"]
+
+
+def test_context_bundle_artifact_placeholder_component_does_not_satisfy_completeness() -> None:
+    bundle = {
+        "artifact_type": "context_bundle_artifact",
+        "schema_version": "1.0.0",
+        "context_bundle_id": "ctxb-ph-1",
+        "trace": {"trace_id": "trace-ph", "run_id": "run-ph"},
+        "created_at": "2026-04-18T00:00:00Z",
+        "components": [
+            {
+                "component_type": "transcript",
+                "required": True,
+                "source_type": "transcript",
+                "source_ref": "transcript_artifact",
+                "captured_at": "2026-04-18T00:00:00Z",
+                "content_hash": "h1",
+                "provenance": {
+                    "source_uri": "artifact://transcript_artifact",
+                    "source_system": "wpg",
+                    "collected_by": "test",
+                    "collected_at": "2026-04-18T00:00:00Z",
+                    "attribution": "transcript_artifact",
+                },
+            },
+            {
+                "component_type": "slides",
+                "required": True,
+                "source_type": "slides",
+                "source_ref": "slides_artifact_input",
+                "captured_at": "2026-04-18T00:00:00Z",
+                "content_hash": "h2",
+                "provenance": {
+                    "source_uri": "artifact://slides_artifact_input",
+                    "source_system": "wpg",
+                    "collected_by": "test",
+                    "collected_at": "2026-04-18T00:00:00Z",
+                    "attribution": "slides_artifact_input",
+                },
+            },
+        ],
+    }
     result = evaluate_context_admission(bundle, now=datetime(2026, 4, 18, tzinfo=timezone.utc))
     assert result["admission_status"] == "fail"
     assert "missing_required_component:slides" in result["blocking_reasons"]

--- a/tests/test_context_contradiction_detection.py
+++ b/tests/test_context_contradiction_detection.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from spectrum_systems.modules.wpg.context_governance import detect_context_contradictions, evaluate_context_admission
+
+
+def test_context_contradiction_detection_finds_cross_source_conflict() -> None:
+    contradictions = detect_context_contradictions(
+        [
+            {
+                "component_type": "transcript",
+                "source_ref": "transcript_artifact",
+                "statements": [{"topic": "deployment", "polarity": "affirm", "text": "Deployment can start"}],
+            },
+            {
+                "component_type": "critique_artifacts",
+                "source_ref": "critique_artifact",
+                "statements": [{"topic": "deployment", "polarity": "deny", "text": "Deployment cannot start"}],
+            },
+        ]
+    )
+    assert contradictions
+    assert contradictions[0]["topic"] == "deployment"
+
+
+def test_context_contradiction_detection_blocks_unresolved_conflict() -> None:
+    bundle = {
+        "artifact_type": "context_bundle_artifact",
+        "schema_version": "1.0.0",
+        "context_bundle_id": "ctxb-1",
+        "trace": {"trace_id": "t", "run_id": "r"},
+        "created_at": "2026-04-18T00:00:00Z",
+        "components": [
+            {
+                "component_type": "transcript",
+                "required": True,
+                "source_type": "transcript",
+                "source_ref": "transcript_artifact",
+                "captured_at": "2026-04-18T00:00:00Z",
+                "content_hash": "h1",
+                "statements": [{"topic": "deployment", "polarity": "affirm", "text": "yes"}],
+                "provenance": {"source_uri": "artifact://t", "source_system": "wpg", "collected_by": "t", "collected_at": "2026-04-18T00:00:00Z", "attribution": "t"},
+            },
+            {
+                "component_type": "meeting_minutes",
+                "required": True,
+                "source_type": "meeting_minutes",
+                "source_ref": "meeting_minutes_artifact",
+                "captured_at": "2026-04-18T00:00:00Z",
+                "content_hash": "h2",
+                "provenance": {"source_uri": "artifact://m", "source_system": "wpg", "collected_by": "t", "collected_at": "2026-04-18T00:00:00Z", "attribution": "m"},
+            },
+            {
+                "component_type": "slides",
+                "required": True,
+                "source_type": "slides",
+                "source_ref": "slides_artifact",
+                "captured_at": "2026-04-18T00:00:00Z",
+                "content_hash": "h3",
+                "provenance": {"source_uri": "artifact://s", "source_system": "wpg", "collected_by": "t", "collected_at": "2026-04-18T00:00:00Z", "attribution": "s"},
+            },
+            {
+                "component_type": "critique_artifacts",
+                "required": True,
+                "source_type": "critique_artifacts",
+                "source_ref": "critique_artifact",
+                "captured_at": "2026-04-18T00:00:00Z",
+                "content_hash": "h4",
+                "statements": [{"topic": "deployment", "polarity": "deny", "text": "no"}],
+                "provenance": {"source_uri": "artifact://c", "source_system": "wpg", "collected_by": "t", "collected_at": "2026-04-18T00:00:00Z", "attribution": "c"},
+            },
+            {
+                "component_type": "prior_wpg_outputs",
+                "required": True,
+                "source_type": "prior_wpg_outputs",
+                "source_ref": "prior",
+                "captured_at": "2026-04-18T00:00:00Z",
+                "content_hash": "h5",
+                "provenance": {"source_uri": "artifact://p", "source_system": "wpg", "collected_by": "t", "collected_at": "2026-04-18T00:00:00Z", "attribution": "p"},
+            },
+            {
+                "component_type": "eval_outputs",
+                "required": True,
+                "source_type": "eval_outputs",
+                "source_ref": "eval",
+                "captured_at": "2026-04-18T00:00:00Z",
+                "content_hash": "h6",
+                "provenance": {"source_uri": "artifact://e", "source_system": "wpg", "collected_by": "t", "collected_at": "2026-04-18T00:00:00Z", "attribution": "e"},
+            },
+        ],
+    }
+    result = evaluate_context_admission(bundle, now=datetime(2026, 4, 18, tzinfo=timezone.utc))
+    assert result["admission_status"] == "fail"
+    assert result["enforcement_action"] == "BLOCK"
+    assert "unresolved_context_contradiction" in result["blocking_reasons"]

--- a/tests/test_context_freshness.py
+++ b/tests/test_context_freshness.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from spectrum_systems.modules.wpg.context_governance import enforce_context_freshness
+
+
+def test_context_freshness_classification_and_freeze_for_stale_critical() -> None:
+    output = enforce_context_freshness(
+        [
+            {
+                "source_type": "transcript",
+                "source_ref": "transcript_artifact",
+                "captured_at": "2026-04-15T00:00:00Z",
+            },
+            {
+                "source_type": "prior_wpg_outputs",
+                "source_ref": "prior_working_paper_artifact",
+                "captured_at": "2026-03-01T00:00:00Z",
+            },
+        ],
+        now=datetime(2026, 4, 18, tzinfo=timezone.utc),
+    )
+    assert output["freshness_status"] == "fail"
+    assert output["freshness_action"] == "FREEZE"
+    assert any(row["source_ref"] == "transcript_artifact" for row in output["critical_stale_sources"])

--- a/tests/test_context_freshness.py
+++ b/tests/test_context_freshness.py
@@ -24,3 +24,19 @@ def test_context_freshness_classification_and_freeze_for_stale_critical() -> Non
     assert output["freshness_status"] == "fail"
     assert output["freshness_action"] == "FREEZE"
     assert any(row["source_ref"] == "transcript_artifact" for row in output["critical_stale_sources"])
+
+
+def test_context_freshness_missing_timestamp_is_fail_closed() -> None:
+    output = enforce_context_freshness(
+        [
+            {
+                "source_type": "transcript",
+                "source_ref": "transcript_artifact",
+                "captured_at": "",
+            }
+        ],
+        now=datetime(2026, 4, 18, tzinfo=timezone.utc),
+    )
+    assert output["freshness_status"] == "fail"
+    assert output["freshness_action"] == "FREEZE"
+    assert output["stale_sources"][0]["reason"] == "invalid_or_missing_timestamp"

--- a/tests/test_context_readiness_integration.py
+++ b/tests/test_context_readiness_integration.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from spectrum_systems.modules.wpg.context_governance import evaluate_context_readiness_integration
+
+
+def test_context_readiness_integration_blocks_when_context_invalid() -> None:
+    admission_result = {
+        "admission_status": "fail",
+        "enforcement_action": "BLOCK",
+        "blocking_reasons": ["missing_required_component:slides"],
+    }
+    readiness = evaluate_context_readiness_integration(admission_result)
+    assert readiness["readiness_decision"] == "BLOCK"
+    assert "missing_required_component:slides" in readiness["blocking_reasons"]

--- a/tests/test_context_regressions.py
+++ b/tests/test_context_regressions.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from spectrum_systems.modules.wpg.context_governance import evaluate_context_admission
+
+
+def _base_component(component_type: str) -> dict:
+    return {
+        "component_type": component_type,
+        "required": True,
+        "source_type": component_type,
+        "source_ref": f"{component_type}_artifact",
+        "captured_at": "2026-04-18T00:00:00Z",
+        "content_hash": "hash",
+        "provenance": {
+            "source_uri": f"artifact://{component_type}",
+            "source_system": "wpg",
+            "collected_by": "test",
+            "collected_at": "2026-04-18T00:00:00Z",
+            "attribution": component_type,
+        },
+    }
+
+
+def test_context_regressions_repeated_missing_source_failure_remains_blocking() -> None:
+    components = [
+        _base_component("transcript"),
+        _base_component("meeting_minutes"),
+        _base_component("slides"),
+        _base_component("critique_artifacts"),
+        _base_component("prior_wpg_outputs"),
+        _base_component("eval_outputs"),
+    ]
+    bundle = {
+        "artifact_type": "context_bundle_artifact",
+        "schema_version": "1.0.0",
+        "context_bundle_id": "ctxb-r1",
+        "trace": {"trace_id": "trace-r1", "run_id": "run-r1"},
+        "created_at": "2026-04-18T00:00:00Z",
+        "components": [c for c in components if c["component_type"] != "eval_outputs"],
+    }
+    first = evaluate_context_admission(bundle, now=datetime(2026, 4, 18, tzinfo=timezone.utc))
+    second = evaluate_context_admission(bundle, now=datetime(2026, 4, 18, tzinfo=timezone.utc))
+
+    assert first["enforcement_action"] == "BLOCK"
+    assert second["enforcement_action"] == "BLOCK"
+    assert "missing_required_component:eval_outputs" in second["blocking_reasons"]

--- a/tests/test_context_regressions.py
+++ b/tests/test_context_regressions.py
@@ -46,3 +46,29 @@ def test_context_regressions_repeated_missing_source_failure_remains_blocking() 
     assert first["enforcement_action"] == "BLOCK"
     assert second["enforcement_action"] == "BLOCK"
     assert "missing_required_component:eval_outputs" in second["blocking_reasons"]
+
+
+def test_context_regressions_placeholder_source_failure_remains_blocking() -> None:
+    components = [
+        _base_component("transcript"),
+        _base_component("meeting_minutes"),
+        _base_component("slides"),
+        _base_component("critique_artifacts"),
+        _base_component("prior_wpg_outputs"),
+        _base_component("eval_outputs"),
+    ]
+    for item in components:
+        if item["component_type"] == "critique_artifacts":
+            item["source_ref"] = "critique_artifacts_input"
+            item["provenance"]["source_uri"] = "artifact://critique_artifacts_input"
+    bundle = {
+        "artifact_type": "context_bundle_artifact",
+        "schema_version": "1.0.0",
+        "context_bundle_id": "ctxb-r2",
+        "trace": {"trace_id": "trace-r2", "run_id": "run-r2"},
+        "created_at": "2026-04-18T00:00:00Z",
+        "components": components,
+    }
+    result = evaluate_context_admission(bundle, now=datetime(2026, 4, 18, tzinfo=timezone.utc))
+    assert result["enforcement_action"] == "BLOCK"
+    assert "missing_required_component:critique_artifacts" in result["blocking_reasons"]

--- a/tests/test_crm_comment_ingestion.py
+++ b/tests/test_crm_comment_ingestion.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from spectrum_systems.orchestration.wpg_pipeline import run_wpg_pipeline
+from tests.wpg_context_helpers import build_complete_context_bundle
 
 FIXTURE = Path("tests/fixtures/wpg/sample_workflow_loop_input.json")
 
@@ -22,6 +23,7 @@ def test_crm07_comment_ingestion_accepts_governed_comments() -> None:
         trace_id="crm-ingest",
         meeting_artifact=payload["meeting_artifact"],
         comment_artifact=payload["comment_artifact"],
+        context_bundle_artifact=build_complete_context_bundle(trace_id="crm-ingest", run_id="crm-ingest"),
     )
     comments = bundle["artifact_chain"]["comment_artifact"]
     assert comments["artifact_type"] == "comment_artifact"
@@ -32,4 +34,11 @@ def test_crm07_invalid_comment_blocks() -> None:
     payload = _payload()
     invalid = {"comments": [{"comment_id": "c-1", "text": "", "severity": "normal", "critical": False}]}
     with pytest.raises(Exception):
-        run_wpg_pipeline(payload["transcript"], run_id="crm-invalid", trace_id="crm-invalid", meeting_artifact=payload["meeting_artifact"], comment_artifact=invalid)
+        run_wpg_pipeline(
+            payload["transcript"],
+            run_id="crm-invalid",
+            trace_id="crm-invalid",
+            meeting_artifact=payload["meeting_artifact"],
+            comment_artifact=invalid,
+            context_bundle_artifact=build_complete_context_bundle(trace_id="crm-invalid", run_id="crm-invalid"),
+        )

--- a/tests/test_crm_comment_mapping.py
+++ b/tests/test_crm_comment_mapping.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 from spectrum_systems.orchestration.wpg_pipeline import run_wpg_pipeline
+from tests.wpg_context_helpers import build_complete_context_bundle
 
 FIXTURE = Path("tests/fixtures/wpg/sample_workflow_loop_input.json")
 
@@ -16,6 +17,7 @@ def test_crm09_comment_mapping_traceability_present() -> None:
         trace_id="crm-map",
         meeting_artifact=payload["meeting_artifact"],
         comment_artifact=payload["comment_artifact"],
+        context_bundle_artifact=build_complete_context_bundle(trace_id="crm-map", run_id="crm-map"),
     )
     mapping = bundle["artifact_chain"]["comment_mapping_record"]
     assert mapping["outputs"]["mappings"]

--- a/tests/test_crm_disposition_tracking.py
+++ b/tests/test_crm_disposition_tracking.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 from spectrum_systems.orchestration.wpg_pipeline import run_wpg_pipeline
+from tests.wpg_context_helpers import build_complete_context_bundle
 
 FIXTURE = Path("tests/fixtures/wpg/sample_workflow_loop_input.json")
 
@@ -16,6 +17,7 @@ def test_crm12_disposition_tracking_explicit_state() -> None:
         trace_id="crm-disposition",
         meeting_artifact=payload["meeting_artifact"],
         comment_artifact=payload["comment_artifact"],
+        context_bundle_artifact=build_complete_context_bundle(trace_id="crm-disposition", run_id="crm-disposition"),
     )
     disposition = bundle["artifact_chain"]["comment_disposition_record"]
     assert "resolved" in disposition["outputs"]["state_counts"]

--- a/tests/test_crm_resolution_matrix.py
+++ b/tests/test_crm_resolution_matrix.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 from spectrum_systems.orchestration.wpg_pipeline import run_wpg_pipeline
+from tests.wpg_context_helpers import build_complete_context_bundle
 
 FIXTURE = Path("tests/fixtures/wpg/sample_workflow_loop_input.json")
 
@@ -16,6 +17,7 @@ def test_crm08_resolution_matrix_is_valid_and_structured() -> None:
         trace_id="crm-matrix",
         meeting_artifact=payload["meeting_artifact"],
         comment_artifact=payload["comment_artifact"],
+        context_bundle_artifact=build_complete_context_bundle(trace_id="crm-matrix", run_id="crm-matrix"),
     )
     matrix = bundle["artifact_chain"]["comment_resolution_matrix"]
     assert matrix["artifact_type"] == "comment_resolution_matrix"

--- a/tests/test_crm_revision_application.py
+++ b/tests/test_crm_revision_application.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 from spectrum_systems.orchestration.wpg_pipeline import run_wpg_pipeline
+from tests.wpg_context_helpers import build_complete_context_bundle
 
 FIXTURE = Path("tests/fixtures/wpg/sample_workflow_loop_input.json")
 
@@ -16,6 +17,7 @@ def test_crm11_revision_application_controlled_and_replayable() -> None:
         trace_id="crm-apply",
         meeting_artifact=payload["meeting_artifact"],
         comment_artifact=payload["comment_artifact"],
+        context_bundle_artifact=build_complete_context_bundle(trace_id="crm-apply", run_id="crm-apply"),
     )
     applied = bundle["artifact_chain"]["revision_application_record"]
     assert "revised_content" in applied["outputs"]

--- a/tests/test_crm_revision_plan.py
+++ b/tests/test_crm_revision_plan.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 from spectrum_systems.orchestration.wpg_pipeline import run_wpg_pipeline
+from tests.wpg_context_helpers import build_complete_context_bundle
 
 FIXTURE = Path("tests/fixtures/wpg/sample_workflow_loop_input.json")
 
@@ -16,6 +17,7 @@ def test_crm10_revision_plan_generated_before_execution() -> None:
         trace_id="crm-plan",
         meeting_artifact=payload["meeting_artifact"],
         comment_artifact=payload["comment_artifact"],
+        context_bundle_artifact=build_complete_context_bundle(trace_id="crm-plan", run_id="crm-plan"),
     )
     plan = bundle["artifact_chain"]["revision_plan_artifact"]
     assert isinstance(plan["outputs"]["tasks"], list)

--- a/tests/test_eval_regressions.py
+++ b/tests/test_eval_regressions.py
@@ -1,4 +1,5 @@
 from spectrum_systems.orchestration.wpg_pipeline import run_wpg_pipeline
+from tests.wpg_context_helpers import build_complete_context_bundle
 
 
 def test_regression_eval_cases_bound_and_canonical_owner_emits_control_decision() -> None:
@@ -8,7 +9,12 @@ def test_regression_eval_cases_bound_and_canonical_owner_emits_control_decision(
             {"segment_id": "r2", "speaker": "B", "agency": "DoD", "text": "Can we deploy now? No we cannot deploy now."},
         ]
     }
-    bundle = run_wpg_pipeline(transcript, run_id="run-reg", trace_id="trace-reg")
+    bundle = run_wpg_pipeline(
+        transcript,
+        run_id="run-reg",
+        trace_id="trace-reg",
+        context_bundle_artifact=build_complete_context_bundle(trace_id="trace-reg", run_id="run-reg"),
+    )
     regressions = bundle["artifact_chain"]["regression_eval_cases"]["outputs"]
     assert regressions["repeated_failure_class_blocked"] is True
     assert regressions["cases"]

--- a/tests/test_redteam_context_failures.py
+++ b/tests/test_redteam_context_failures.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from spectrum_systems.modules.wpg.context_governance import build_context_redteam_findings
+
+
+def test_redteam_context_failures_include_required_adversarial_classes() -> None:
+    findings = build_context_redteam_findings(trace_id="trace-ctx-rtx")
+    classes = {row["failure_class"] for row in findings["findings"]}
+    assert {"stale_data", "missing_sources", "conflicting_inputs", "prompt_like_injection"}.issubset(classes)

--- a/tests/test_system_registry_guard.py
+++ b/tests/test_system_registry_guard.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
+from scripts import run_system_registry_guard as registry_guard_script
 from spectrum_systems.modules.governance.system_registry_guard import (
     evaluate_system_registry_guard,
     load_guard_policy,
@@ -307,3 +310,31 @@ def test_current_fix02_changed_surface_passes_with_non_authority_classification(
     )
     assert result["status"] == "pass"
     assert result["normalized_reason_codes"] == []
+
+
+def test_resolve_changed_files_uses_diff_tree_for_zero_base_sha(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def _fake_run(command: list[str]) -> tuple[int, str]:
+        calls.append(command)
+        return 0, "a.py\nb.py\na.py\n"
+
+    monkeypatch.setattr(registry_guard_script, "_run", _fake_run)
+    files = registry_guard_script._resolve_changed_files("0" * 40, "HEAD", [])
+
+    assert calls == [["git", "diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD"]]
+    assert files == ["a.py", "b.py"]
+
+
+def test_resolve_changed_files_uses_normal_diff_for_non_zero_base(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def _fake_run(command: list[str]) -> tuple[int, str]:
+        calls.append(command)
+        return 0, "x.py\ny.py\nx.py\n"
+
+    monkeypatch.setattr(registry_guard_script, "_run", _fake_run)
+    files = registry_guard_script._resolve_changed_files("origin/main", "HEAD", [])
+
+    assert calls == [["git", "diff", "--name-only", "origin/main..HEAD"]]
+    assert files == ["x.py", "y.py"]

--- a/tests/test_wpg_action_items.py
+++ b/tests/test_wpg_action_items.py
@@ -4,13 +4,20 @@ import json
 from pathlib import Path
 
 from spectrum_systems.orchestration.wpg_pipeline import run_wpg_pipeline
+from tests.wpg_context_helpers import build_complete_context_bundle
 
 FIXTURE = Path("tests/fixtures/wpg/sample_workflow_loop_input.json")
 
 
 def test_wpg33_action_items_structured_and_traceable() -> None:
     payload = json.loads(FIXTURE.read_text(encoding="utf-8"))
-    bundle = run_wpg_pipeline(payload["transcript"], run_id="actions", trace_id="actions", meeting_artifact=payload["meeting_artifact"])
+    bundle = run_wpg_pipeline(
+        payload["transcript"],
+        run_id="actions",
+        trace_id="actions",
+        meeting_artifact=payload["meeting_artifact"],
+        context_bundle_artifact=build_complete_context_bundle(trace_id="actions", run_id="actions"),
+    )
     actions = bundle["artifact_chain"]["action_item_artifact"]["outputs"]
     assert isinstance(actions["action_items"], list)
     assert actions["explicit_empty"] is False

--- a/tests/test_wpg_action_linkage.py
+++ b/tests/test_wpg_action_linkage.py
@@ -4,13 +4,20 @@ import json
 from pathlib import Path
 
 from spectrum_systems.orchestration.wpg_pipeline import run_wpg_pipeline
+from tests.wpg_context_helpers import build_complete_context_bundle
 
 FIXTURE = Path("tests/fixtures/wpg/sample_workflow_loop_input.json")
 
 
 def test_wpg34_action_linkage_emits_linked_records() -> None:
     payload = json.loads(FIXTURE.read_text(encoding="utf-8"))
-    bundle = run_wpg_pipeline(payload["transcript"], run_id="linkage", trace_id="linkage", meeting_artifact=payload["meeting_artifact"])
+    bundle = run_wpg_pipeline(
+        payload["transcript"],
+        run_id="linkage",
+        trace_id="linkage",
+        meeting_artifact=payload["meeting_artifact"],
+        context_bundle_artifact=build_complete_context_bundle(trace_id="linkage", run_id="linkage"),
+    )
     linkage = bundle["artifact_chain"]["action_linkage_record"]
     assert linkage["outputs"]["required_unlinked"] >= 0
     assert isinstance(linkage["outputs"]["linkages"], list)

--- a/tests/test_wpg_meeting_artifact.py
+++ b/tests/test_wpg_meeting_artifact.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from spectrum_systems.orchestration.wpg_pipeline import run_wpg_pipeline
+from tests.wpg_context_helpers import build_complete_context_bundle
 
 FIXTURE = Path("tests/fixtures/wpg/sample_workflow_loop_input.json")
 
@@ -21,6 +22,7 @@ def test_wpg31_meeting_artifact_ingested_as_governed_input() -> None:
         run_id=payload["run_id"],
         trace_id=payload["trace_id"],
         meeting_artifact=payload["meeting_artifact"],
+        context_bundle_artifact=build_complete_context_bundle(trace_id=payload["trace_id"], run_id=payload["run_id"]),
     )
     meeting = bundle["artifact_chain"]["meeting_artifact"]
     assert meeting["artifact_type"] == "meeting_artifact"
@@ -32,4 +34,10 @@ def test_wpg31_invalid_meeting_artifact_blocks() -> None:
     bad_meeting = dict(payload["meeting_artifact"])
     bad_meeting.pop("participants", None)
     with pytest.raises(Exception):
-        run_wpg_pipeline(payload["transcript"], run_id="bad-meeting", trace_id="bad-meeting", meeting_artifact=bad_meeting)
+        run_wpg_pipeline(
+            payload["transcript"],
+            run_id="bad-meeting",
+            trace_id="bad-meeting",
+            meeting_artifact=bad_meeting,
+            context_bundle_artifact=build_complete_context_bundle(trace_id="bad-meeting", run_id="bad-meeting"),
+        )

--- a/tests/test_wpg_minutes_generation.py
+++ b/tests/test_wpg_minutes_generation.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 from spectrum_systems.orchestration.wpg_pipeline import run_wpg_pipeline
+from tests.wpg_context_helpers import build_complete_context_bundle
 
 FIXTURE = Path("tests/fixtures/wpg/sample_workflow_loop_input.json")
 
@@ -14,7 +15,13 @@ def _payload() -> dict:
 
 def test_wpg32_minutes_generation_has_required_sections() -> None:
     payload = _payload()
-    bundle = run_wpg_pipeline(payload["transcript"], run_id="minutes", trace_id="minutes", meeting_artifact=payload["meeting_artifact"])
+    bundle = run_wpg_pipeline(
+        payload["transcript"],
+        run_id="minutes",
+        trace_id="minutes",
+        meeting_artifact=payload["meeting_artifact"],
+        context_bundle_artifact=build_complete_context_bundle(trace_id="minutes", run_id="minutes"),
+    )
     minutes = bundle["artifact_chain"]["meeting_minutes_artifact"]
     assert minutes["outputs"]["summary"]
     assert minutes["outputs"]["decisions"]

--- a/tests/test_wpg_phase_aware_execution.py
+++ b/tests/test_wpg_phase_aware_execution.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from spectrum_systems.orchestration.wpg_pipeline import run_wpg_pipeline
+from tests.wpg_context_helpers import build_complete_context_bundle
 
 
 def test_wpg_pipeline_emits_phase_governance_artifacts() -> None:
@@ -10,6 +11,7 @@ def test_wpg_pipeline_emits_phase_governance_artifacts() -> None:
         {"segments": [{"segment_id": "s1", "speaker": "A", "agency": "FCC", "text": "Can we proceed? Yes we can proceed."}]},
         run_id="phase-aware",
         trace_id="phase-aware",
+        context_bundle_artifact=build_complete_context_bundle(trace_id="phase-aware", run_id="phase-aware"),
     )
     assert "phase_transition_policy_result" in bundle["artifact_chain"]
     assert "phase_resume_record" in bundle["artifact_chain"]

--- a/tests/test_wpg_phase_b_regressions.py
+++ b/tests/test_wpg_phase_b_regressions.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from spectrum_systems.contracts import load_example, validate_artifact
 from spectrum_systems.orchestration.wpg_pipeline import run_wpg_pipeline
+from tests.wpg_context_helpers import build_complete_context_bundle
 
 FIXTURE = Path("tests/fixtures/wpg/sample_workflow_loop_input.json")
 
@@ -26,6 +27,7 @@ def test_fix16_revision_loop_fail_closed() -> None:
         trace_id="phase-b-reg",
         meeting_artifact=payload["meeting_artifact"],
         comment_artifact=payload["comment_artifact"],
+        context_bundle_artifact=build_complete_context_bundle(trace_id="phase-b-reg", run_id="phase-b-reg"),
     )
     critical_unresolved = bundle["artifact_chain"]["comment_disposition_record"]["outputs"]["critical_unresolved"]
     decision = bundle["artifact_chain"]["comment_disposition_record"]["evaluation_refs"]["control_decision"]["decision"]

--- a/tests/test_wpg_pipeline.py
+++ b/tests/test_wpg_pipeline.py
@@ -7,6 +7,7 @@ import pytest
 
 from spectrum_systems.modules.wpg.redteam import run_wpg_redteam_suite
 from spectrum_systems.orchestration.wpg_pipeline import run_wpg_pipeline, run_wpg_pipeline_from_file
+from tests.wpg_context_helpers import build_complete_context_bundle
 
 
 FIXTURE = Path("tests/fixtures/wpg/sample_transcript.json")
@@ -24,6 +25,7 @@ def test_pipeline_outputs_all_artifacts() -> None:
         trace_id=payload["trace_id"],
         mode="working_paper",
         resolved_comments=payload["resolved_comments"],
+        context_bundle_artifact=build_complete_context_bundle(trace_id=payload["trace_id"], run_id=payload["run_id"]),
     )
     expected = {
         "question_set_artifact",
@@ -46,21 +48,28 @@ def test_pipeline_outputs_all_artifacts() -> None:
 
 def test_replay_is_deterministic() -> None:
     payload = _load()
-    a = run_wpg_pipeline(payload["transcript"], run_id="r1", trace_id="t1", mode="working_paper")
-    b = run_wpg_pipeline(payload["transcript"], run_id="r1", trace_id="t1", mode="working_paper")
+    context = build_complete_context_bundle(trace_id="t1", run_id="r1")
+    a = run_wpg_pipeline(payload["transcript"], run_id="r1", trace_id="t1", mode="working_paper", context_bundle_artifact=context)
+    b = run_wpg_pipeline(payload["transcript"], run_id="r1", trace_id="t1", mode="working_paper", context_bundle_artifact=context)
     assert a["replay"]["signature"] == b["replay"]["signature"]
 
 
 def test_output_modes_supported() -> None:
     payload = _load()
     for mode in ("working_paper", "executive_summary", "FAQ_brief", "slide_outline"):
-        bundle = run_wpg_pipeline(payload["transcript"], run_id="r2", trace_id=f"t-{mode}", mode=mode)
+        bundle = run_wpg_pipeline(
+            payload["transcript"],
+            run_id="r2",
+            trace_id=f"t-{mode}",
+            mode=mode,
+            context_bundle_artifact=build_complete_context_bundle(trace_id=f"t-{mode}", run_id="r2"),
+        )
         assert bundle["artifact_chain"]["working_paper_artifact"]["outputs"]["mode"] == mode
 
 
 def test_control_and_enforcement_on_each_stage() -> None:
     payload = _load()
-    bundle = run_wpg_pipeline(payload["transcript"], run_id="r3", trace_id="t3")
+    bundle = run_wpg_pipeline(payload["transcript"], run_id="r3", trace_id="t3", context_bundle_artifact=build_complete_context_bundle(trace_id="t3", run_id="r3"))
     for artifact in bundle["artifact_chain"].values():
         if "evaluation_refs" not in artifact:
             continue
@@ -71,7 +80,7 @@ def test_control_and_enforcement_on_each_stage() -> None:
 
 def test_confidence_and_unknowns_present() -> None:
     payload = _load()
-    bundle = run_wpg_pipeline(payload["transcript"], run_id="r4", trace_id="t4")
+    bundle = run_wpg_pipeline(payload["transcript"], run_id="r4", trace_id="t4", context_bundle_artifact=build_complete_context_bundle(trace_id="t4", run_id="r4"))
     confidence = bundle["artifact_chain"]["faq_confidence_artifact"]["outputs"]["confidence_rows"]
     unknowns = bundle["artifact_chain"]["unknowns_artifact"]["outputs"]["unknowns"]
     assert confidence
@@ -83,6 +92,7 @@ def test_unknown_input_cannot_allow_with_full_confidence() -> None:
         {"segments": [{"segment_id": "u-1", "speaker": "Ops", "agency": "NOAA", "text": "When does this complete? Unknown pending validation."}]},
         run_id="r-unknown",
         trace_id="t-unknown",
+        context_bundle_artifact=build_complete_context_bundle(trace_id="t-unknown", run_id="r-unknown"),
     )
     rows = bundle["artifact_chain"]["faq_confidence_artifact"]["outputs"]["confidence_rows"]
     assert rows[0]["unknown"] is True
@@ -97,7 +107,12 @@ def test_semantic_conflict_detection_non_empty() -> None:
             {"segment_id": "c-2", "speaker": "B", "agency": "DoD", "text": "Can deployment start now? No deployment cannot start now."},
         ]
     }
-    bundle = run_wpg_pipeline(transcript, run_id="r-conflict", trace_id="t-conflict")
+    bundle = run_wpg_pipeline(
+        transcript,
+        run_id="r-conflict",
+        trace_id="t-conflict",
+        context_bundle_artifact=build_complete_context_bundle(trace_id="t-conflict", run_id="r-conflict"),
+    )
     conflicts = bundle["artifact_chain"]["faq_conflict_artifact"]["outputs"]["conflicts"]
     assert conflicts
 
@@ -109,16 +124,22 @@ def test_invalid_transcript_is_blocked() -> None:
 
 def test_narrative_order_has_justification() -> None:
     payload = _load()
-    bundle = run_wpg_pipeline(payload["transcript"], run_id="r5", trace_id="t5")
+    bundle = run_wpg_pipeline(payload["transcript"], run_id="r5", trace_id="t5", context_bundle_artifact=build_complete_context_bundle(trace_id="t5", run_id="r5"))
     sections = bundle["artifact_chain"]["working_section_artifact"]["outputs"]["sections"]
     assert all(section.get("chronology", {}).get("justification") for section in sections)
 
 
 def test_delta_identical_input_same_hash() -> None:
     payload = _load()
-    first = run_wpg_pipeline(payload["transcript"], run_id="r6", trace_id="t6")
+    first = run_wpg_pipeline(payload["transcript"], run_id="r6", trace_id="t6", context_bundle_artifact=build_complete_context_bundle(trace_id="t6", run_id="r6"))
     prior = first["artifact_chain"]["working_paper_artifact"]
-    second = run_wpg_pipeline(payload["transcript"], run_id="r6", trace_id="t6", prior_working_paper=prior)
+    second = run_wpg_pipeline(
+        payload["transcript"],
+        run_id="r6",
+        trace_id="t6",
+        prior_working_paper=prior,
+        context_bundle_artifact=build_complete_context_bundle(trace_id="t6", run_id="r6"),
+    )
     delta = second["artifact_chain"]["wpg_delta_artifact"]["outputs"]
     assert delta["previous_hash"] == delta["current_hash"]
     assert delta["changed"] is False
@@ -128,14 +149,15 @@ def test_delta_identical_input_same_hash() -> None:
 
 def test_transcript_ingress_deterministic_identity() -> None:
     payload = _load()
-    a = run_wpg_pipeline(payload["transcript"], run_id="r-ident", trace_id="t-ident")
-    b = run_wpg_pipeline(payload["transcript"], run_id="r-ident", trace_id="t-ident")
+    context = build_complete_context_bundle(trace_id="t-ident", run_id="r-ident")
+    a = run_wpg_pipeline(payload["transcript"], run_id="r-ident", trace_id="t-ident", context_bundle_artifact=context)
+    b = run_wpg_pipeline(payload["transcript"], run_id="r-ident", trace_id="t-ident", context_bundle_artifact=context)
     assert a["artifact_chain"]["transcript_artifact"]["outputs"]["artifact_id"] == b["artifact_chain"]["transcript_artifact"]["outputs"]["artifact_id"]
 
 
 def test_phase_a_assurance_artifacts_emitted() -> None:
     payload = _load()
-    bundle = run_wpg_pipeline(payload["transcript"], run_id="r-assure", trace_id="t-assure")
+    bundle = run_wpg_pipeline(payload["transcript"], run_id="r-assure", trace_id="t-assure", context_bundle_artifact=build_complete_context_bundle(trace_id="t-assure", run_id="r-assure"))
     assert bundle["artifact_chain"]["wpg_grounding_eval_case"]["outputs"]["supported_claim_ratio"] >= 0.0
     assert bundle["artifact_chain"]["wpg_uncertainty_control_record"]["outputs"]["narrative_warning_present"] is True
 
@@ -151,3 +173,19 @@ def test_cli_runner_writes_artifacts(tmp_path: Path) -> None:
     bundle = run_wpg_pipeline_from_file(FIXTURE, tmp_path)
     assert (tmp_path / "wpg_pipeline_bundle.json").is_file()
     assert bundle["artifact_chain"]["working_paper_artifact"]["artifact_type"] == "working_paper_artifact"
+
+
+def test_pipeline_blocks_when_required_context_slides_missing() -> None:
+    payload = _load()
+    context = build_complete_context_bundle(trace_id="t-missing-slides", run_id="r-missing-slides")
+    context["components"] = [c for c in context["components"] if c["component_type"] != "slides"]
+    with pytest.raises(Exception, match="context admission blocked pipeline execution"):
+        run_wpg_pipeline(payload["transcript"], run_id="r-missing-slides", trace_id="t-missing-slides", context_bundle_artifact=context)
+
+
+def test_pipeline_blocks_when_required_context_critique_missing() -> None:
+    payload = _load()
+    context = build_complete_context_bundle(trace_id="t-missing-critique", run_id="r-missing-critique")
+    context["components"] = [c for c in context["components"] if c["component_type"] != "critique_artifacts"]
+    with pytest.raises(Exception, match="context admission blocked pipeline execution"):
+        run_wpg_pipeline(payload["transcript"], run_id="r-missing-critique", trace_id="t-missing-critique", context_bundle_artifact=context)

--- a/tests/wpg_context_helpers.py
+++ b/tests/wpg_context_helpers.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+
+def build_complete_context_bundle(*, trace_id: str, run_id: str) -> dict:
+    return {
+        "artifact_type": "context_bundle_artifact",
+        "schema_version": "1.0.0",
+        "context_bundle_id": f"ctxb-{run_id}",
+        "trace": {"trace_id": trace_id, "run_id": run_id},
+        "created_at": "2026-04-18T00:00:00Z",
+        "components": [
+            {"component_type": "transcript", "required": True, "source_type": "transcript", "source_ref": "transcript_artifact", "captured_at": "2026-04-18T00:00:00Z", "content_hash": "h1", "provenance": {"source_uri": "artifact://transcript_artifact", "source_system": "wpg", "collected_by": "test", "collected_at": "2026-04-18T00:00:00Z", "attribution": "transcript_artifact"}},
+            {"component_type": "meeting_minutes", "required": True, "source_type": "meeting_minutes", "source_ref": "meeting_minutes_artifact", "captured_at": "2026-04-18T00:00:00Z", "content_hash": "h2", "provenance": {"source_uri": "artifact://meeting_minutes_artifact", "source_system": "wpg", "collected_by": "test", "collected_at": "2026-04-18T00:00:00Z", "attribution": "meeting_minutes_artifact"}},
+            {"component_type": "slides", "required": True, "source_type": "slides", "source_ref": "slides_artifact", "captured_at": "2026-04-18T00:00:00Z", "content_hash": "h3", "provenance": {"source_uri": "artifact://slides_artifact", "source_system": "wpg", "collected_by": "test", "collected_at": "2026-04-18T00:00:00Z", "attribution": "slides_artifact"}},
+            {"component_type": "critique_artifacts", "required": True, "source_type": "critique_artifacts", "source_ref": "critique_artifact", "captured_at": "2026-04-18T00:00:00Z", "content_hash": "h4", "provenance": {"source_uri": "artifact://critique_artifact", "source_system": "wpg", "collected_by": "test", "collected_at": "2026-04-18T00:00:00Z", "attribution": "critique_artifact"}},
+            {"component_type": "prior_wpg_outputs", "required": True, "source_type": "prior_wpg_outputs", "source_ref": "prior_working_paper_artifact", "captured_at": "2026-04-18T00:00:00Z", "content_hash": "h5", "provenance": {"source_uri": "artifact://prior_working_paper_artifact", "source_system": "wpg", "collected_by": "test", "collected_at": "2026-04-18T00:00:00Z", "attribution": "prior_working_paper_artifact"}},
+            {"component_type": "eval_outputs", "required": True, "source_type": "eval_outputs", "source_ref": "eval_outputs_artifact", "captured_at": "2026-04-18T00:00:00Z", "content_hash": "h6", "provenance": {"source_uri": "artifact://eval_outputs_artifact", "source_system": "wpg", "collected_by": "test", "collected_at": "2026-04-18T00:00:00Z", "attribution": "eval_outputs_artifact"}},
+        ],
+    }


### PR DESCRIPTION
### Motivation
- Make context a governed, versioned, and validated artifact to eliminate ungoverned/stale/conflicting inputs before WPG execution. 
- Enforce fail-closed behavior so missing, stale, or contradictory context blocks or freezes pipeline runs. 
- Provide deterministic validation, red-team coverage, and integration of admission results into readiness/promotions.

### Description
- Add new governed contracts and examples: `contracts/schemas/context_bundle_artifact.schema.json`, `contracts/examples/context_bundle_artifact.json`, `contracts/schemas/context_admission_result.schema.json`, and `contracts/examples/context_admission_result.json`, and register them in `contracts/standards-manifest.json`.
- Implement `spectrum_systems/modules/wpg/context_governance.py` with `build_context_bundle_artifact`, `evaluate_context_admission`, contradiction detection, freshness enforcement, red-team findings, and readiness integration.
- Wire context admission into the orchestration by updating `spectrum_systems/orchestration/wpg_pipeline.py` to build/accept a `context_bundle_artifact`, run admission pre-execution, fail-closed on invalid context, and include context artifacts in the output chain.
- Add plan and deterministic tests plus fixture updates: `docs/review-actions/PLAN-CTX-01-EXEC-2026-04-18.md`, updated `tests/fixtures/wpg/sample_workflow_loop_input.json`, and tests under `tests/test_context_*.py` covering bundle/schema, admission, contradictions, freshness, red-team, regressions, and readiness integration.

### Testing
- Ran the new context tests with `pytest -q tests/test_context_bundle_artifact.py tests/test_context_admission_policy.py tests/test_context_contradiction_detection.py tests/test_context_freshness.py tests/test_redteam_context_failures.py tests/test_context_regressions.py tests/test_context_readiness_integration.py` and they all passed.
- Ran contract and enforcement suites with `pytest -q tests/test_contracts.py` and `pytest -q tests/test_contract_enforcement.py` and both succeeded (no failures reported).
- Ran module and pipeline checks with `pytest -q tests/test_module_architecture.py` and `pytest -q tests/test_wpg_pipeline.py tests/test_wpg_phase_aware_execution.py` and they passed.
- Executed `python scripts/run_contract_enforcement.py` and `python scripts/run_wpg_pipeline.py --input tests/fixtures/wpg/sample_workflow_loop_input.json` and both completed successfully with expected artifacts emitted.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3cf3ce3408329a7f0d4b173b4bb50)