### PR TITLE
Introduce canonical changed-files resolver and migrate CI guards to use it (fail-closed)

### DIFF
--- a/docs/review-actions/PLAN-ALG-02-2026-04-18.md
+++ b/docs/review-actions/PLAN-ALG-02-2026-04-18.md
@@ -1,0 +1,40 @@
+# Plan — ALG-02 — 2026-04-18
+
+## Prompt type
+PLAN
+
+## Roadmap item
+ALG-02
+
+## Objective
+Centralize changed-file resolution into a single canonical helper and migrate CI-facing governance guard scripts to consume it with deterministic fallback behavior.
+
+## Declared files
+| File | Change type | Reason |
+| --- | --- | --- |
+| spectrum_systems/modules/governance/changed_files.py | CREATE | Canonical shared helper for changed-file retrieval and fallback handling |
+| scripts/run_system_registry_guard.py | MODIFY | Replace local git plumbing with shared helper |
+| scripts/run_authority_leak_guard.py | MODIFY | Replace local git plumbing with shared helper |
+| scripts/run_three_letter_system_enforcement_audit.py | MODIFY | Migrate sibling CI-facing guard to shared helper |
+| tests/test_governance_changed_files.py | CREATE | Unit coverage for shared helper fallback and ordering behavior |
+| tests/test_run_system_registry_guard_resolution.py | MODIFY | Validate SRG script integration with shared helper |
+| tests/test_run_authority_leak_guard.py | CREATE | Validate authority leak guard integration with shared helper |
+| tests/test_run_three_letter_system_enforcement_audit.py | CREATE | Validate 3LS audit script integration with shared helper |
+
+## Contracts touched
+None.
+
+## Tests that must pass after execution
+1. `pytest tests/test_governance_changed_files.py`
+2. `pytest tests/test_run_system_registry_guard_resolution.py`
+3. `pytest tests/test_run_authority_leak_guard.py`
+4. `pytest tests/test_run_three_letter_system_enforcement_audit.py`
+5. `pytest tests/test_authority_leak_detection.py`
+
+## Scope exclusions
+- Do not change policy evaluation semantics in guard modules.
+- Do not modify contracts, schemas, or roadmap documents.
+- Do not add network-based changed-file retrieval.
+
+## Dependencies
+- None.

--- a/docs/review-actions/PLAN-ALG-03-2026-04-18.md
+++ b/docs/review-actions/PLAN-ALG-03-2026-04-18.md
@@ -1,0 +1,35 @@
+# Plan — ALG-03 — 2026-04-18
+
+## Prompt type
+PLAN
+
+## Roadmap item
+ALG-03
+
+## Objective
+Remove fail-open changed-file fallback behavior so unresolved git revision state fails closed across migrated governance guards.
+
+## Declared files
+| File | Change type | Reason |
+| --- | --- | --- |
+| spectrum_systems/modules/governance/changed_files.py | MODIFY | Remove unsafe working-tree fallback and tighten fail-closed semantics/documentation |
+| tests/test_governance_changed_files.py | MODIFY | Update helper expectations to require raise on unresolved state |
+| tests/test_run_system_registry_guard_resolution.py | MODIFY | Preserve integration mapping of shared helper failures |
+| tests/test_run_authority_leak_guard.py | MODIFY | Preserve integration mapping of shared helper failures |
+
+## Contracts touched
+None.
+
+## Tests that must pass after execution
+1. `pytest tests/test_governance_changed_files.py`
+2. `pytest tests/test_run_system_registry_guard_resolution.py`
+3. `pytest tests/test_run_authority_leak_guard.py`
+4. `pytest tests/test_run_three_letter_system_enforcement_audit.py`
+5. `pytest tests/test_authority_leak_detection.py`
+
+## Scope exclusions
+- Do not change policy logic for SRG, authority leak, or 3LS guard decisions.
+- Do not redesign changed-file resolution beyond removing fail-open behavior.
+
+## Dependencies
+- None.

--- a/scripts/run_authority_leak_guard.py
+++ b/scripts/run_authority_leak_guard.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import subprocess
 import sys
 from pathlib import Path
 
@@ -15,24 +14,14 @@ if str(REPO_ROOT) not in sys.path:
 
 from scripts.authority_leak_rules import find_forbidden_vocabulary, load_authority_registry
 from scripts.authority_shape_detector import detect_authority_shapes
+from spectrum_systems.modules.governance.changed_files import (
+    ChangedFilesResolutionError,
+    resolve_changed_files,
+)
 
 
 class AuthorityLeakGuardError(ValueError):
     """Raised when authority leak guard cannot complete deterministically."""
-
-
-def _run(command: list[str]) -> tuple[int, str]:
-    proc = subprocess.run(command, cwd=REPO_ROOT, check=False, capture_output=True, text=True)
-    return proc.returncode, proc.stdout.strip() or proc.stderr.strip()
-
-
-def _resolve_changed_files(base_ref: str, head_ref: str, explicit: list[str]) -> list[str]:
-    if explicit:
-        return sorted(set(path.strip() for path in explicit if path.strip()))
-    code, output = _run(["git", "diff", "--name-only", f"{base_ref}..{head_ref}"])
-    if code != 0:
-        raise AuthorityLeakGuardError(f"failed to resolve changed files from {base_ref}..{head_ref}: {output}")
-    return sorted(set(line.strip() for line in output.splitlines() if line.strip()))
 
 
 def _parse_args() -> argparse.Namespace:
@@ -55,7 +44,15 @@ def _parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = _parse_args()
-    changed_files = _resolve_changed_files(args.base_ref, args.head_ref, list(args.changed_files or []))
+    try:
+        changed_files = resolve_changed_files(
+            repo_root=REPO_ROOT,
+            base_ref=args.base_ref,
+            head_ref=args.head_ref,
+            explicit_changed_files=list(args.changed_files or []),
+        )
+    except ChangedFilesResolutionError as exc:
+        raise AuthorityLeakGuardError(str(exc)) from exc
 
     registry_path = REPO_ROOT / args.registry
     if not registry_path.is_file():

--- a/scripts/run_system_registry_guard.py
+++ b/scripts/run_system_registry_guard.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import subprocess
 import sys
 from pathlib import Path
 
@@ -19,75 +18,10 @@ from spectrum_systems.modules.governance.system_registry_guard import (  # noqa:
     load_guard_policy,
     parse_system_registry,
 )
-
-
-def _run(command: list[str]) -> tuple[int, str]:
-    proc = subprocess.run(command, cwd=REPO_ROOT, check=False, capture_output=True, text=True)
-    return proc.returncode, proc.stdout.strip() or proc.stderr.strip()
-
-
-def _ref_exists(ref: str) -> bool:
-    code, _ = _run(["git", "rev-parse", "--verify", f"{ref}^{{commit}}"])
-    return code == 0
-
-
-def _diff_name_only(range_expr: str) -> tuple[list[str] | None, str | None]:
-    code, output = _run(["git", "diff", "--name-only", range_expr])
-    if code != 0:
-        return None, output
-    files = sorted(set(line.strip() for line in output.splitlines() if line.strip()))
-    return files, None
-
-
-def _resolve_changed_files(base_ref: str, head_ref: str, explicit: list[str]) -> list[str]:
-    if explicit:
-        return sorted(set(path.strip() for path in explicit if path.strip()))
-
-    requested_range = f"{base_ref}..{head_ref}"
-    files, error = _diff_name_only(requested_range)
-    if files is not None:
-        return files
-
-    attempted_fallbacks: list[str] = [f"requested_range={requested_range} failed: {error}"]
-
-    if _ref_exists("origin/main") and _ref_exists("HEAD"):
-        fallback_range = "origin/main...HEAD"
-        files, fallback_error = _diff_name_only(fallback_range)
-        if files is not None:
-            return files
-        attempted_fallbacks.append(f"fallback_origin_main_triple_dot={fallback_range} failed: {fallback_error}")
-
-        merge_base_code, merge_base_output = _run(["git", "merge-base", "origin/main", "HEAD"])
-        if merge_base_code == 0 and merge_base_output:
-            merge_base = merge_base_output.splitlines()[0].strip()
-            merge_range = f"{merge_base}..HEAD"
-            files, merge_error = _diff_name_only(merge_range)
-            if files is not None:
-                return files
-            attempted_fallbacks.append(f"fallback_merge_base={merge_range} failed: {merge_error}")
-        else:
-            attempted_fallbacks.append(
-                "fallback_merge_base=origin/main HEAD failed: "
-                + (merge_base_output or "merge-base resolution failed")
-            )
-    else:
-        attempted_fallbacks.append("fallback_origin_main_triple_dot skipped: missing origin/main or HEAD commit")
-        attempted_fallbacks.append("fallback_merge_base skipped: missing origin/main or HEAD commit")
-
-    if _ref_exists("HEAD~1"):
-        head_parent_range = "HEAD~1..HEAD"
-        files, head_parent_error = _diff_name_only(head_parent_range)
-        if files is not None:
-            return files
-        attempted_fallbacks.append(f"fallback_head_parent={head_parent_range} failed: {head_parent_error}")
-    else:
-        attempted_fallbacks.append("fallback_head_parent skipped: missing HEAD~1 commit")
-
-    raise SystemRegistryGuardError(
-        "failed to resolve changed files; "
-        f"requested_range={requested_range}; "
-        "attempts=" + " | ".join(attempted_fallbacks)
-    )
+from spectrum_systems.modules.governance.changed_files import (  # noqa: E402
+    ChangedFilesResolutionError,
+    resolve_changed_files,
+)
 
 
 def _parse_args() -> argparse.Namespace:
@@ -105,7 +39,15 @@ def _parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = _parse_args()
-    changed_files = _resolve_changed_files(args.base_ref, args.head_ref, list(args.changed_files or []))
+    try:
+        changed_files = resolve_changed_files(
+            repo_root=REPO_ROOT,
+            base_ref=args.base_ref,
+            head_ref=args.head_ref,
+            explicit_changed_files=list(args.changed_files or []),
+        )
+    except ChangedFilesResolutionError as exc:
+        raise SystemRegistryGuardError(str(exc)) from exc
 
     policy = load_guard_policy(REPO_ROOT / "contracts" / "governance" / "system_registry_guard_policy.json")
     registry = parse_system_registry(REPO_ROOT / "docs" / "architecture" / "system_registry.md")

--- a/scripts/run_three_letter_system_enforcement_audit.py
+++ b/scripts/run_three_letter_system_enforcement_audit.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import subprocess
 import sys
 from pathlib import Path
 
@@ -17,20 +16,9 @@ from spectrum_systems.modules.governance.system_registry_guard import parse_syst
 from spectrum_systems.modules.governance.three_letter_system_enforcement import (  # noqa: E402
     evaluate_three_letter_system_enforcement,
 )
-
-
-def _run(command: list[str]) -> tuple[int, str]:
-    proc = subprocess.run(command, cwd=REPO_ROOT, check=False, capture_output=True, text=True)
-    return proc.returncode, proc.stdout.strip() or proc.stderr.strip()
-
-
-def _resolve_changed_files(base_ref: str, head_ref: str, explicit: list[str]) -> list[str]:
-    if explicit:
-        return sorted(set(path.strip() for path in explicit if path.strip()))
-    code, output = _run(["git", "diff", "--name-only", f"{base_ref}..{head_ref}"])
-    if code != 0:
-        raise RuntimeError(f"failed to resolve changed files from {base_ref}..{head_ref}: {output}")
-    return sorted(set(line.strip() for line in output.splitlines() if line.strip()))
+from spectrum_systems.modules.governance.changed_files import (  # noqa: E402
+    resolve_changed_files,
+)
 
 
 def _parse_args() -> argparse.Namespace:
@@ -45,7 +33,12 @@ def _parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = _parse_args()
-    changed_files = _resolve_changed_files(args.base_ref, args.head_ref, list(args.changed_files or []))
+    changed_files = resolve_changed_files(
+        repo_root=REPO_ROOT,
+        base_ref=args.base_ref,
+        head_ref=args.head_ref,
+        explicit_changed_files=list(args.changed_files or []),
+    )
 
     policy_path = REPO_ROOT / args.policy_path
     policy = json.loads(policy_path.read_text(encoding="utf-8"))

--- a/spectrum_systems/modules/governance/changed_files.py
+++ b/spectrum_systems/modules/governance/changed_files.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+"""Canonical changed-file resolution for CI-facing governance guards.
+
+Fallback order is deterministic and shared across migrated scripts:
+1. Explicit CLI changed files (passthrough, normalized + deduplicated).
+2. Requested git diff range: ``<base_ref>..<head_ref>``.
+3. ``origin/main...HEAD`` when both commits are locally resolvable.
+4. ``merge-base(origin/main, HEAD)..HEAD`` when merge-base resolves.
+5. ``HEAD~1..HEAD`` when parent commit exists (shallow/rebased fallback).
+
+If every step fails, resolution raises ``ChangedFilesResolutionError`` with
+attempt details so callers can fail closed with actionable diagnostics.
+Working-tree-only inspection is intentionally rejected because governance
+guards require a trustworthy commit-range change set.
+"""
+
+import subprocess
+from pathlib import Path
+
+
+class ChangedFilesResolutionError(ValueError):
+    """Raised when changed-file resolution cannot complete deterministically."""
+
+
+def _run(command: list[str], *, repo_root: Path) -> tuple[int, str]:
+    proc = subprocess.run(command, cwd=repo_root, check=False, capture_output=True, text=True)
+    return proc.returncode, proc.stdout.strip() or proc.stderr.strip()
+
+
+def _normalize(paths: list[str]) -> list[str]:
+    return sorted({path.strip() for path in paths if path and path.strip()})
+
+
+def _ref_exists(ref: str, *, repo_root: Path, runner: callable) -> bool:
+    code, _ = runner(["git", "rev-parse", "--verify", f"{ref}^{{commit}}"], repo_root=repo_root)
+    return code == 0
+
+
+def _diff_name_only(range_expr: str, *, repo_root: Path, runner: callable) -> tuple[list[str] | None, str | None]:
+    code, output = runner(["git", "diff", "--name-only", range_expr], repo_root=repo_root)
+    if code != 0:
+        return None, output
+    return _normalize(output.splitlines()), None
+
+
+def resolve_changed_files(
+    *,
+    repo_root: Path,
+    base_ref: str,
+    head_ref: str,
+    explicit_changed_files: list[str],
+    runner=None,
+) -> list[str]:
+    """Resolve changed files using a single fail-closed fallback policy."""
+    active_runner = runner or _run
+
+    explicit = _normalize(explicit_changed_files)
+    if explicit:
+        return explicit
+
+    requested_range = f"{base_ref}..{head_ref}"
+    files, error = _diff_name_only(requested_range, repo_root=repo_root, runner=active_runner)
+    if files is not None:
+        return files
+
+    attempted_fallbacks: list[str] = [f"requested_range={requested_range} failed: {error}"]
+
+    if _ref_exists("origin/main", repo_root=repo_root, runner=active_runner) and _ref_exists(
+        "HEAD", repo_root=repo_root, runner=active_runner
+    ):
+        triple_dot_range = "origin/main...HEAD"
+        files, triple_dot_error = _diff_name_only(triple_dot_range, repo_root=repo_root, runner=active_runner)
+        if files is not None:
+            return files
+        attempted_fallbacks.append(
+            f"fallback_origin_main_triple_dot={triple_dot_range} failed: {triple_dot_error}"
+        )
+
+        merge_base_code, merge_base_output = active_runner(
+            ["git", "merge-base", "origin/main", "HEAD"], repo_root=repo_root
+        )
+        if merge_base_code == 0 and merge_base_output:
+            merge_base = merge_base_output.splitlines()[0].strip()
+            merge_range = f"{merge_base}..HEAD"
+            files, merge_error = _diff_name_only(merge_range, repo_root=repo_root, runner=active_runner)
+            if files is not None:
+                return files
+            attempted_fallbacks.append(f"fallback_merge_base={merge_range} failed: {merge_error}")
+        else:
+            attempted_fallbacks.append(
+                "fallback_merge_base=origin/main HEAD failed: "
+                + (merge_base_output or "merge-base resolution failed")
+            )
+    else:
+        attempted_fallbacks.append("fallback_origin_main_triple_dot skipped: missing origin/main or HEAD commit")
+        attempted_fallbacks.append("fallback_merge_base skipped: missing origin/main or HEAD commit")
+
+    if _ref_exists("HEAD~1", repo_root=repo_root, runner=active_runner):
+        head_parent_range = "HEAD~1..HEAD"
+        files, head_parent_error = _diff_name_only(head_parent_range, repo_root=repo_root, runner=active_runner)
+        if files is not None:
+            return files
+        attempted_fallbacks.append(f"fallback_head_parent={head_parent_range} failed: {head_parent_error}")
+    else:
+        attempted_fallbacks.append("fallback_head_parent skipped: missing HEAD~1 commit")
+
+    raise ChangedFilesResolutionError(
+        "failed to resolve changed files; "
+        f"requested_range={requested_range}; "
+        "attempts=" + " | ".join(attempted_fallbacks)
+    )

--- a/tests/test_governance_changed_files.py
+++ b/tests/test_governance_changed_files.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from spectrum_systems.modules.governance import changed_files as cf
+
+
+def test_explicit_changed_files_passthrough_is_normalized() -> None:
+    out = cf.resolve_changed_files(
+        repo_root=Path('.'),
+        base_ref='base',
+        head_ref='head',
+        explicit_changed_files=['b.py', 'a.py', 'a.py', ''],
+    )
+    assert out == ['a.py', 'b.py']
+
+
+def test_valid_base_head_diff_is_used(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(command: list[str], *, repo_root: Path) -> tuple[int, str]:
+        assert repo_root == Path('.')
+        if command == ['git', 'diff', '--name-only', 'base..head']:
+            return 0, 'z.py\na.py\n'
+        raise AssertionError(command)
+
+    out = cf.resolve_changed_files(
+        repo_root=Path('.'),
+        base_ref='base',
+        head_ref='head',
+        explicit_changed_files=[],
+        runner=fake_run,
+    )
+    assert out == ['a.py', 'z.py']
+
+
+def test_invalid_revision_range_falls_back_to_origin_main_triple_dot() -> None:
+    def fake_run(command: list[str], *, repo_root: Path) -> tuple[int, str]:
+        if command == ['git', 'diff', '--name-only', 'base..head']:
+            return 128, 'invalid revision range'
+        if command == ['git', 'rev-parse', '--verify', 'origin/main^{commit}']:
+            return 0, 'ok'
+        if command == ['git', 'rev-parse', '--verify', 'HEAD^{commit}']:
+            return 0, 'ok'
+        if command == ['git', 'diff', '--name-only', 'origin/main...HEAD']:
+            return 0, 'contracts/a.json\ncontracts/b.json\n'
+        raise AssertionError(command)
+
+    out = cf.resolve_changed_files(
+        repo_root=Path('.'),
+        base_ref='base',
+        head_ref='head',
+        explicit_changed_files=[],
+        runner=fake_run,
+    )
+    assert out == ['contracts/a.json', 'contracts/b.json']
+
+
+def test_unresolved_git_state_raises_instead_of_returning_empty_list() -> None:
+    def fake_run(command: list[str], *, repo_root: Path) -> tuple[int, str]:
+        if command == ['git', 'diff', '--name-only', 'base..head']:
+            return 128, 'missing'
+        if command == ['git', 'rev-parse', '--verify', 'origin/main^{commit}']:
+            return 1, 'missing'
+        if command == ['git', 'rev-parse', '--verify', 'HEAD~1^{commit}']:
+            return 1, 'missing'
+        raise AssertionError(command)
+
+    with pytest.raises(cf.ChangedFilesResolutionError):
+        cf.resolve_changed_files(
+            repo_root=Path('.'),
+            base_ref='base',
+            head_ref='head',
+            explicit_changed_files=[],
+            runner=fake_run,
+        )
+
+
+def test_failure_raises_with_attempt_details() -> None:
+    def fake_run(command: list[str], *, repo_root: Path) -> tuple[int, str]:
+        if command[:3] == ['git', 'diff', '--name-only']:
+            return 128, 'bad revision'
+        if command[:3] == ['git', 'rev-parse', '--verify']:
+            return 1, 'missing'
+        raise AssertionError(command)
+
+    with pytest.raises(cf.ChangedFilesResolutionError) as exc:
+        cf.resolve_changed_files(
+            repo_root=Path('.'),
+            base_ref='base',
+            head_ref='head',
+            explicit_changed_files=[],
+            runner=fake_run,
+        )
+
+    message = str(exc.value)
+    assert 'requested_range=base..head' in message
+    assert 'fallback_head_parent' in message

--- a/tests/test_run_authority_leak_guard.py
+++ b/tests/test_run_authority_leak_guard.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import run_authority_leak_guard as alg
+
+
+def test_authority_guard_uses_shared_changed_file_helper(monkeypatch, tmp_path: Path) -> None:
+    output_path = tmp_path / 'authority_result.json'
+
+    monkeypatch.setattr(
+        alg,
+        '_parse_args',
+        lambda: type(
+            'Args',
+            (),
+            {
+                'base_ref': 'base',
+                'head_ref': 'head',
+                'changed_files': [],
+                'registry': 'contracts/governance/authority_registry.json',
+                'output': str(output_path),
+            },
+        )(),
+    )
+
+    called: dict[str, object] = {}
+
+    def fake_resolve_changed_files(**kwargs):
+        called.update(kwargs)
+        return ['README.md']
+
+    monkeypatch.setattr(alg, 'resolve_changed_files', fake_resolve_changed_files)
+    monkeypatch.setattr(alg, 'load_authority_registry', lambda _path: {'owners': []})
+    monkeypatch.setattr(alg, 'find_forbidden_vocabulary', lambda _path, _registry: [])
+    monkeypatch.setattr(alg, 'detect_authority_shapes', lambda _path, _registry: [])
+
+    rc = alg.main()
+    assert rc == 0
+    assert called['base_ref'] == 'base'
+    assert called['head_ref'] == 'head'
+
+    payload = json.loads(output_path.read_text(encoding='utf-8'))
+    assert payload['changed_files'] == ['README.md']
+
+
+def test_authority_guard_maps_shared_helper_errors(monkeypatch: object) -> None:
+    monkeypatch.setattr(
+        alg,
+        '_parse_args',
+        lambda: type(
+            'Args',
+            (),
+            {
+                'base_ref': 'base',
+                'head_ref': 'head',
+                'changed_files': [],
+                'registry': 'contracts/governance/authority_registry.json',
+                'output': 'outputs/authority_leak_guard/test_result.json',
+            },
+        )(),
+    )
+
+    monkeypatch.setattr(
+        alg,
+        'resolve_changed_files',
+        lambda **kwargs: (_ for _ in ()).throw(alg.ChangedFilesResolutionError('bad refs')),
+    )
+
+    try:
+        alg.main()
+    except alg.AuthorityLeakGuardError as exc:
+        assert 'bad refs' in str(exc)
+    else:
+        raise AssertionError('expected AuthorityLeakGuardError')

--- a/tests/test_run_system_registry_guard_resolution.py
+++ b/tests/test_run_system_registry_guard_resolution.py
@@ -1,75 +1,48 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from scripts import run_system_registry_guard as srg
 from spectrum_systems.modules.governance.system_registry_guard import SystemRegistryGuardError
 
 
-def test_resolve_changed_files_prefers_explicit_inputs() -> None:
-    out = srg._resolve_changed_files("base", "head", ["b.py", "a.py", "a.py", ""])
-    assert out == ["a.py", "b.py"]
+def test_resolve_changed_files_passthrough_to_shared_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
 
+    def fake_resolve_changed_files(**kwargs):
+        captured.update(kwargs)
+        return ['a.py', 'b.py']
 
-def test_resolve_changed_files_uses_requested_range_when_available(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        srg,
-        "_diff_name_only",
-        lambda range_expr: (["x.py", "a.py"], None) if range_expr == "base..head" else (None, "unexpected"),
+    monkeypatch.setattr(srg, 'resolve_changed_files', fake_resolve_changed_files)
+    changed_files = srg.resolve_changed_files(
+        repo_root=Path('.'),
+        base_ref='base',
+        head_ref='head',
+        explicit_changed_files=['b.py', 'a.py'],
     )
 
-    out = srg._resolve_changed_files("base", "head", [])
-    assert out == ["x.py", "a.py"]
+    assert changed_files == ['a.py', 'b.py']
+    assert captured['base_ref'] == 'base'
+    assert captured['head_ref'] == 'head'
 
 
-def test_resolve_changed_files_falls_back_to_origin_main_triple_dot(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fake_diff(range_expr: str) -> tuple[list[str] | None, str | None]:
-        if range_expr == "base..head":
-            return None, "invalid revision range"
-        if range_expr == "origin/main...HEAD":
-            return ["fallback.py"], None
-        return None, "unexpected"
+def test_main_maps_shared_helper_error_to_guard_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(srg, '_parse_args', lambda: type('Args', (), {
+        'base_ref': 'base',
+        'head_ref': 'head',
+        'changed_files': [],
+        'output': 'outputs/system_registry_guard/test_resolution.json',
+    })())
 
-    monkeypatch.setattr(srg, "_diff_name_only", fake_diff)
-    monkeypatch.setattr(srg, "_ref_exists", lambda ref: ref in {"origin/main", "HEAD"})
-
-    out = srg._resolve_changed_files("base", "head", [])
-    assert out == ["fallback.py"]
-
-
-def test_resolve_changed_files_uses_merge_base_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fake_diff(range_expr: str) -> tuple[list[str] | None, str | None]:
-        if range_expr in {"base..head", "origin/main...HEAD"}:
-            return None, "invalid"
-        if range_expr == "abc123..HEAD":
-            return ["merge_base_file.py"], None
-        return None, "unexpected"
-
-    monkeypatch.setattr(srg, "_diff_name_only", fake_diff)
-    monkeypatch.setattr(srg, "_ref_exists", lambda ref: ref in {"origin/main", "HEAD"})
-    monkeypatch.setattr(srg, "_run", lambda command: (0, "abc123") if command == ["git", "merge-base", "origin/main", "HEAD"] else (1, "unexpected"))
-
-    out = srg._resolve_changed_files("base", "head", [])
-    assert out == ["merge_base_file.py"]
-
-
-def test_resolve_changed_files_uses_head_parent_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(srg, "_diff_name_only", lambda range_expr: (["head_parent.py"], None) if range_expr == "HEAD~1..HEAD" else (None, "invalid"))
-    monkeypatch.setattr(srg, "_ref_exists", lambda ref: ref == "HEAD~1")
-
-    out = srg._resolve_changed_files("base", "head", [])
-    assert out == ["head_parent.py"]
-
-
-def test_resolve_changed_files_raises_with_attempt_details(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(srg, "_diff_name_only", lambda range_expr: (None, f"{range_expr} failed"))
-    monkeypatch.setattr(srg, "_ref_exists", lambda ref: False)
+    monkeypatch.setattr(
+        srg,
+        'resolve_changed_files',
+        lambda **kwargs: (_ for _ in ()).throw(srg.ChangedFilesResolutionError('resolution failed')),
+    )
 
     with pytest.raises(SystemRegistryGuardError) as exc:
-        srg._resolve_changed_files("base", "head", [])
+        srg.main()
 
-    message = str(exc.value)
-    assert "requested_range=base..head" in message
-    assert "fallback_origin_main_triple_dot" in message
-    assert "fallback_merge_base" in message
-    assert "fallback_head_parent" in message
+    assert 'resolution failed' in str(exc.value)

--- a/tests/test_run_three_letter_system_enforcement_audit.py
+++ b/tests/test_run_three_letter_system_enforcement_audit.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import run_three_letter_system_enforcement_audit as tle
+
+
+def test_three_letter_audit_uses_shared_changed_file_helper(monkeypatch, tmp_path: Path) -> None:
+    output_path = tmp_path / 'three_letter.json'
+
+    monkeypatch.setattr(
+        tle,
+        '_parse_args',
+        lambda: type(
+            'Args',
+            (),
+            {
+                'base_ref': 'base',
+                'head_ref': 'head',
+                'changed_files': [],
+                'policy_path': 'docs/governance/three_letter_system_policy.json',
+                'output': str(output_path),
+            },
+        )(),
+    )
+
+    seen: dict[str, object] = {}
+
+    def fake_resolve_changed_files(**kwargs):
+        seen.update(kwargs)
+        return ['docs/architecture/system_registry.md']
+
+    monkeypatch.setattr(tle, 'resolve_changed_files', fake_resolve_changed_files)
+    monkeypatch.setattr(tle, 'parse_system_registry', lambda _path: {'systems': []})
+    monkeypatch.setattr(
+        tle,
+        'evaluate_three_letter_system_enforcement',
+        lambda **kwargs: {'final_decision': 'ALLOW', 'violations': [], 'changed_files': kwargs['changed_files']},
+    )
+
+    rc = tle.main()
+    assert rc == 0
+    assert seen['base_ref'] == 'base'
+    assert seen['head_ref'] == 'head'
+
+    payload = json.loads(output_path.read_text(encoding='utf-8'))
+    assert payload['changed_files'] == ['docs/architecture/system_registry.md']


### PR DESCRIPTION
### Motivation
- Centralize changed-file resolution logic for CI-facing governance guards to ensure deterministic fallback behavior and avoid ad-hoc git plumbing spread across scripts.
- Remove unsafe fail-open/working-tree fallbacks so unresolved git revision state fails closed and surfaces actionable diagnostics.

### Description
- Add `spectrum_systems.modules.governance.changed_files` which implements `resolve_changed_files` and raises `ChangedFilesResolutionError` when resolution cannot complete deterministically, with a documented fallback order. 
- Replace local `git` subprocess plumbing in `scripts/run_system_registry_guard.py`, `scripts/run_authority_leak_guard.py`, and `scripts/run_three_letter_system_enforcement_audit.py` with imports of `resolve_changed_files` and map `ChangedFilesResolutionError` to the scripts' guard-level errors. 
- Add unit tests `tests/test_governance_changed_files.py` that validate normalization, fallback ordering, and fail-closed behavior, and add/modify integration tests `tests/test_run_system_registry_guard_resolution.py`, `tests/test_run_authority_leak_guard.py`, and `tests/test_run_three_letter_system_enforcement_audit.py` to assert the scripts use the shared helper and correctly map errors.

### Testing
- Ran `pytest tests/test_governance_changed_files.py` and the helper unit tests passed. 
- Ran `pytest tests/test_run_system_registry_guard_resolution.py`, `pytest tests/test_run_authority_leak_guard.py`, and `pytest tests/test_run_three_letter_system_enforcement_audit.py` and the integration tests passed, validating script integration and error mapping.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e40a036a388329944170a3475c96fc)