### PR TITLE
Add controlled generated-eval registry-change artifacts, TPA contract-sync checks/autorepair, and enforcement/preflight integration

### DIFF
--- a/contracts/examples/generated_eval_registry_change_execution_record.json
+++ b/contracts/examples/generated_eval_registry_change_execution_record.json
@@ -1,0 +1,12 @@
+{
+  "artifact_type": "generated_eval_registry_change_execution_record",
+  "artifact_id": "GEPS-4A41E01D5DC2B1FD",
+  "registry_change_request_artifact_id": "GEPR-2F128A8A8E6B44D1",
+  "registry_change_review_artifact_id": "GEPD-4ED8B326A036D5DA",
+  "generated_eval_artifact_id": "GEC-5C8D88C7B5870A12",
+  "registry_updated": true,
+  "blocked_reasons": [],
+  "replay_validation_passed": true,
+  "required_eval_target": "required_eval_registry.mappings[artifact_family=generated_eval_case].required_evals",
+  "created_at": "2026-04-19T00:07:00Z"
+}

--- a/contracts/examples/generated_eval_registry_change_request_record.json
+++ b/contracts/examples/generated_eval_registry_change_request_record.json
@@ -1,0 +1,14 @@
+{
+  "artifact_type": "generated_eval_registry_change_request_record",
+  "artifact_id": "GEPR-2F128A8A8E6B44D1",
+  "generated_eval_artifact_id": "GEC-5C8D88C7B5870A12",
+  "source_failure_artifact_ids": [
+    "FAIL-MISSING-EVAL-001",
+    "FAIL-MISSING-EVAL-003"
+  ],
+  "reason_code": "missing_required_eval_result",
+  "occurrence_count": 2,
+  "request_origin": "candidate_assessment",
+  "justification": "Recurring admitted candidate with stable replay inputs and explicit assessment handoff.",
+  "created_at": "2026-04-19T00:05:00Z"
+}

--- a/contracts/examples/generated_eval_registry_change_reversal_record.json
+++ b/contracts/examples/generated_eval_registry_change_reversal_record.json
@@ -1,0 +1,9 @@
+{
+  "artifact_type": "generated_eval_registry_change_reversal_record",
+  "artifact_id": "GERB-386945A1BF57D77C",
+  "generated_eval_artifact_id": "GEC-5C8D88C7B5870A12",
+  "registry_change_execution_artifact_id": "GEPS-4A41E01D5DC2B1FD",
+  "rollback_reason": "manual_registry_revert",
+  "reversal_applied": true,
+  "created_at": "2026-04-19T00:08:00Z"
+}

--- a/contracts/examples/generated_eval_registry_change_review_record.json
+++ b/contracts/examples/generated_eval_registry_change_review_record.json
@@ -1,0 +1,10 @@
+{
+  "artifact_type": "generated_eval_registry_change_review_record",
+  "artifact_id": "GEPD-4ED8B326A036D5DA",
+  "registry_change_request_artifact_id": "GEPR-2F128A8A8E6B44D1",
+  "generated_eval_artifact_id": "GEC-5C8D88C7B5870A12",
+  "review_outcome": "ready",
+  "decided_by": "runtime-reviewer",
+  "rationale": "Registry-change review completed after explicit review and replay-linkage confirmation.",
+  "created_at": "2026-04-19T00:06:00Z"
+}

--- a/contracts/examples/preflight_block_diagnosis_record.json
+++ b/contracts/examples/preflight_block_diagnosis_record.json
@@ -12,5 +12,17 @@
   "normalized_failure": {
     "failure_class": "invalid_wrapper",
     "repairable": true
+  },
+  "mismatch_diagnostics": {
+    "trace_id": "trace-2026-04-19T00:00:00Z",
+    "run_id": "run-2026-04-19T00:00:00Z",
+    "changed_file_refs": [
+      "contracts/standards-manifest.json"
+    ],
+    "manifest_entry_ref": "contracts/standards-manifest.json#contracts[artifact_type=tpa_contract_sync_check_record]",
+    "schema_path": "contracts/schemas/tpa_contract_sync_check_record.schema.json",
+    "example_path": "contracts/examples/tpa_contract_sync_check_record.json",
+    "runtime_source_ref": "scripts/run_contract_preflight.py::run_tpa_contract_sync_check",
+    "mismatch_type": "manifest_declared_schema_const_mismatch"
   }
 }

--- a/contracts/examples/tpa_contract_sync_check_record.json
+++ b/contracts/examples/tpa_contract_sync_check_record.json
@@ -1,0 +1,10 @@
+{
+  "artifact_type": "tpa_contract_sync_check_record",
+  "artifact_id": "TPA-SYNC-EXAMPLE-01",
+  "checked_artifact_types": [
+    "generated_eval_registry_change_request_record"
+  ],
+  "mismatches": [],
+  "auto_repair_eligible": false,
+  "created_at": "2026-04-19T00:00:00Z"
+}

--- a/contracts/examples/tpa_contract_sync_repair_handoff_record.json
+++ b/contracts/examples/tpa_contract_sync_repair_handoff_record.json
@@ -1,0 +1,13 @@
+{
+  "artifact_type": "tpa_contract_sync_repair_handoff_record",
+  "artifact_id": "TPA-SYNC-RESULT-EXAMPLE-01",
+  "check_artifact_id": "TPA-SYNC-EXAMPLE-01",
+  "repair_plan_artifact_id": "TPA-SYNC-PLAN-EXAMPLE-01",
+  "handoff_ready": true,
+  "candidate_files": [
+    "contracts/standards-manifest.json"
+  ],
+  "remaining_mismatches": [],
+  "escalation_required": false,
+  "created_at": "2026-04-19T00:00:02Z"
+}

--- a/contracts/examples/tpa_contract_sync_repair_plan_record.json
+++ b/contracts/examples/tpa_contract_sync_repair_plan_record.json
@@ -1,0 +1,13 @@
+{
+  "artifact_type": "tpa_contract_sync_repair_plan_record",
+  "artifact_id": "TPA-SYNC-PLAN-EXAMPLE-01",
+  "check_artifact_id": "TPA-SYNC-EXAMPLE-01",
+  "planned_actions": [
+    {
+      "action": "set_manifest_example_path",
+      "artifact_type": "generated_eval_registry_change_request_record"
+    }
+  ],
+  "auto_repair_eligible": true,
+  "created_at": "2026-04-19T00:00:01Z"
+}

--- a/contracts/schemas/generated_eval_registry_change_execution_record.schema.json
+++ b/contracts/schemas/generated_eval_registry_change_execution_record.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/generated_eval_registry_change_execution_record.schema.json",
+  "title": "generated_eval_registry_change_execution_record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "registry_change_request_artifact_id",
+    "registry_change_review_artifact_id",
+    "generated_eval_artifact_id",
+    "registry_updated",
+    "blocked_reasons",
+    "replay_validation_passed",
+    "required_eval_target",
+    "created_at"
+  ],
+  "properties": {
+    "artifact_type": { "type": "string", "const": "generated_eval_registry_change_execution_record" },
+    "artifact_id": { "type": "string", "minLength": 1 },
+    "registry_change_request_artifact_id": { "type": "string", "minLength": 1 },
+    "registry_change_review_artifact_id": { "type": "string", "minLength": 1 },
+    "generated_eval_artifact_id": { "type": "string", "minLength": 1 },
+    "registry_updated": { "type": "boolean" },
+    "blocked_reasons": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "replay_validation_passed": { "type": "boolean" },
+    "required_eval_target": { "type": "string", "minLength": 1 },
+    "created_at": { "type": "string", "format": "date-time" }
+  }
+}

--- a/contracts/schemas/generated_eval_registry_change_request_record.schema.json
+++ b/contracts/schemas/generated_eval_registry_change_request_record.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/generated_eval_registry_change_request_record.schema.json",
+  "title": "generated_eval_registry_change_request_record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "generated_eval_artifact_id",
+    "source_failure_artifact_ids",
+    "reason_code",
+    "occurrence_count",
+    "request_origin",
+    "justification",
+    "created_at"
+  ],
+  "properties": {
+    "artifact_type": { "type": "string", "const": "generated_eval_registry_change_request_record" },
+    "artifact_id": { "type": "string", "minLength": 1 },
+    "generated_eval_artifact_id": { "type": "string", "minLength": 1 },
+    "source_failure_artifact_ids": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "reason_code": { "type": "string", "minLength": 1 },
+    "occurrence_count": { "type": "integer", "minimum": 1 },
+    "request_origin": {
+      "type": "string",
+      "enum": ["manual", "candidate_assessment"]
+    },
+    "justification": { "type": "string", "minLength": 1 },
+    "created_at": { "type": "string", "format": "date-time" }
+  }
+}

--- a/contracts/schemas/generated_eval_registry_change_reversal_record.schema.json
+++ b/contracts/schemas/generated_eval_registry_change_reversal_record.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/generated_eval_registry_change_reversal_record.schema.json",
+  "title": "generated_eval_registry_change_reversal_record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "generated_eval_artifact_id",
+    "registry_change_execution_artifact_id",
+    "rollback_reason",
+    "reversal_applied",
+    "created_at"
+  ],
+  "properties": {
+    "artifact_type": { "type": "string", "const": "generated_eval_registry_change_reversal_record" },
+    "artifact_id": { "type": "string", "minLength": 1 },
+    "generated_eval_artifact_id": { "type": "string", "minLength": 1 },
+    "registry_change_execution_artifact_id": { "type": "string", "minLength": 1 },
+    "rollback_reason": { "type": "string", "minLength": 1 },
+    "reversal_applied": { "type": "boolean" },
+    "created_at": { "type": "string", "format": "date-time" }
+  }
+}

--- a/contracts/schemas/generated_eval_registry_change_review_record.schema.json
+++ b/contracts/schemas/generated_eval_registry_change_review_record.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/generated_eval_registry_change_review_record.schema.json",
+  "title": "generated_eval_registry_change_review_record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "registry_change_request_artifact_id",
+    "generated_eval_artifact_id",
+    "review_outcome",
+    "decided_by",
+    "rationale",
+    "created_at"
+  ],
+  "properties": {
+    "artifact_type": { "type": "string", "const": "generated_eval_registry_change_review_record" },
+    "artifact_id": { "type": "string", "minLength": 1 },
+    "registry_change_request_artifact_id": { "type": "string", "minLength": 1 },
+    "generated_eval_artifact_id": { "type": "string", "minLength": 1 },
+    "review_outcome": {
+      "type": "string",
+      "enum": ["ready", "not_ready"]
+    },
+    "decided_by": { "type": "string", "minLength": 1 },
+    "rationale": { "type": "string", "minLength": 1 },
+    "created_at": { "type": "string", "format": "date-time" }
+  }
+}

--- a/contracts/schemas/preflight_block_diagnosis_record.schema.json
+++ b/contracts/schemas/preflight_block_diagnosis_record.schema.json
@@ -92,6 +92,30 @@
           "type": "boolean"
         }
       }
+    },
+    "mismatch_diagnostics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "trace_id",
+        "run_id",
+        "changed_file_refs",
+        "manifest_entry_ref",
+        "schema_path",
+        "example_path",
+        "runtime_source_ref",
+        "mismatch_type"
+      ],
+      "properties": {
+        "trace_id": { "type": "string", "minLength": 1 },
+        "run_id": { "type": "string", "minLength": 1 },
+        "changed_file_refs": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+        "manifest_entry_ref": { "type": "string", "minLength": 1 },
+        "schema_path": { "type": "string" },
+        "example_path": { "type": "string" },
+        "runtime_source_ref": { "type": "string", "minLength": 1 },
+        "mismatch_type": { "type": "string" }
+      }
     }
   }
 }

--- a/contracts/schemas/tpa_contract_sync_check_record.schema.json
+++ b/contracts/schemas/tpa_contract_sync_check_record.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/tpa_contract_sync_check_record.schema.json",
+  "title": "tpa_contract_sync_check_record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "checked_artifact_types",
+    "mismatches",
+    "auto_repair_eligible",
+    "created_at"
+  ],
+  "properties": {
+    "artifact_type": { "type": "string", "const": "tpa_contract_sync_check_record" },
+    "artifact_id": { "type": "string", "minLength": 1 },
+    "checked_artifact_types": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "mismatches": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["mismatch_type", "artifact_type", "detail"],
+        "properties": {
+          "mismatch_type": { "type": "string", "minLength": 1 },
+          "artifact_type": { "type": "string", "minLength": 1 },
+          "detail": { "type": "string", "minLength": 1 },
+          "files": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+        }
+      }
+    },
+    "auto_repair_eligible": { "type": "boolean" },
+    "created_at": { "type": "string", "format": "date-time" }
+  }
+}

--- a/contracts/schemas/tpa_contract_sync_repair_handoff_record.schema.json
+++ b/contracts/schemas/tpa_contract_sync_repair_handoff_record.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/tpa_contract_sync_repair_handoff_record.schema.json",
+  "title": "tpa_contract_sync_repair_handoff_record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "check_artifact_id",
+    "repair_plan_artifact_id",
+    "handoff_ready",
+    "candidate_files",
+    "remaining_mismatches",
+    "escalation_required",
+    "created_at"
+  ],
+  "properties": {
+    "artifact_type": { "type": "string", "const": "tpa_contract_sync_repair_handoff_record" },
+    "artifact_id": { "type": "string", "minLength": 1 },
+    "check_artifact_id": { "type": "string", "minLength": 1 },
+    "repair_plan_artifact_id": { "type": "string", "minLength": 1 },
+    "handoff_ready": { "type": "boolean" },
+    "candidate_files": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "remaining_mismatches": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+    "escalation_required": { "type": "boolean" },
+    "created_at": { "type": "string", "format": "date-time" }
+  }
+}

--- a/contracts/schemas/tpa_contract_sync_repair_plan_record.schema.json
+++ b/contracts/schemas/tpa_contract_sync_repair_plan_record.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/tpa_contract_sync_repair_plan_record.schema.json",
+  "title": "tpa_contract_sync_repair_plan_record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "check_artifact_id",
+    "planned_actions",
+    "auto_repair_eligible",
+    "created_at"
+  ],
+  "properties": {
+    "artifact_type": { "type": "string", "const": "tpa_contract_sync_repair_plan_record" },
+    "artifact_id": { "type": "string", "minLength": 1 },
+    "check_artifact_id": { "type": "string", "minLength": 1 },
+    "planned_actions": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+    "auto_repair_eligible": { "type": "boolean" },
+    "created_at": { "type": "string", "format": "date-time" }
+  }
+}

--- a/contracts/standards-manifest.json
+++ b/contracts/standards-manifest.json
@@ -1,12 +1,12 @@
 {
   "artifact_type": "standards_manifest",
   "artifact_id": "STD-CONTRACTS",
-  "artifact_version": "1.3.150",
+  "artifact_version": "1.3.155",
   "schema_version": "1.3.99",
   "standards_version": "1.9.9",
-  "record_id": "REC-STD-2026-04-18-ENF-01",
-  "run_id": "run-20260418T000000Z-enf-01",
-  "created_at": "2026-04-18T00:00:00Z",
+  "record_id": "REC-STD-2026-04-19-FIX-TPA-AG07-03",
+  "run_id": "run-20260419T000000Z-fix-tpa-ag07-03",
+  "created_at": "2026-04-19T00:00:00Z",
   "created_by": {
     "name": "Spectrum Systems Architecture Team",
     "role": "standards-publication",
@@ -15,7 +15,7 @@
     "contact": "architecture@spectrum-systems.test"
   },
   "source_repo": "nicklasorte/spectrum-systems",
-  "source_repo_version": "1.3.150",
+  "source_repo_version": "1.3.155",
   "input_artifacts": [
     {
       "artifact_id": "STD-CONTRACTS",
@@ -6340,6 +6340,58 @@
       "notes": "EVAL-AUTO-01 deterministic failure_record-to-eval artifact for replayable prevention candidate generation."
     },
     {
+      "artifact_type": "generated_eval_registry_change_execution_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.152",
+      "last_updated_in": "1.3.152",
+      "example_path": "contracts/examples/generated_eval_registry_change_execution_record.json",
+      "notes": "AG-07 registry-change execution artifact with fail-closed blocked reasons and required-eval target capture."
+    },
+    {
+      "artifact_type": "generated_eval_registry_change_request_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.152",
+      "last_updated_in": "1.3.152",
+      "example_path": "contracts/examples/generated_eval_registry_change_request_record.json",
+      "notes": "AG-07 governed registry-change request artifact; explicit request required before any registry update execution."
+    },
+    {
+      "artifact_type": "generated_eval_registry_change_reversal_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.152",
+      "last_updated_in": "1.3.152",
+      "example_path": "contracts/examples/generated_eval_registry_change_reversal_record.json",
+      "notes": "AG-07 reversal artifact preserving deterministic registry-change lineage for generated eval required coverage updates."
+    },
+    {
+      "artifact_type": "generated_eval_registry_change_review_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.152",
+      "last_updated_in": "1.3.152",
+      "example_path": "contracts/examples/generated_eval_registry_change_review_record.json",
+      "notes": "AG-07 explicit registry-change review artifact; no implicit registry update allowed."
+    },
+    {
       "artifact_type": "github_review_handoff_artifact",
       "artifact_class": "coordination",
       "schema_version": "1.0.0",
@@ -10264,19 +10316,6 @@
       "notes": "PFX-01 governed preflight BLOCK auto-repair artifact."
     },
     {
-      "artifact_type": "preflight_repair_plan_record",
-      "artifact_class": "coordination",
-      "schema_version": "1.0.0",
-      "status": "stable",
-      "intended_consumers": [
-        "spectrum-systems"
-      ],
-      "introduced_in": "1.3.125",
-      "last_updated_in": "1.3.125",
-      "example_path": "contracts/examples/preflight_repair_plan_record.json",
-      "notes": "PFX-01 governed preflight BLOCK auto-repair artifact."
-    },
-    {
       "artifact_type": "preflight_repair_result_record",
       "artifact_class": "coordination",
       "schema_version": "1.1.0",
@@ -10287,6 +10326,19 @@
       "introduced_in": "1.3.125",
       "last_updated_in": "1.3.126",
       "example_path": "contracts/examples/preflight_repair_result_record.json",
+      "notes": "PFX-01 governed preflight BLOCK auto-repair artifact."
+    },
+    {
+      "artifact_type": "preflight_repair_plan_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.125",
+      "last_updated_in": "1.3.125",
+      "example_path": "contracts/examples/preflight_repair_plan_record.json",
       "notes": "PFX-01 governed preflight BLOCK auto-repair artifact."
     },
     {
@@ -15799,6 +15851,45 @@
       "last_updated_in": "1.3.116",
       "example_path": "contracts/examples/tpa_conflict_record.json",
       "notes": "TPA material/non-material conflict arbitration artifact."
+    },
+    {
+      "artifact_type": "tpa_contract_sync_check_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.153",
+      "last_updated_in": "1.3.154",
+      "example_path": "contracts/examples/tpa_contract_sync_check_record.json",
+      "notes": "TPA early contract-sync structural check artifact for schema/example/manifest alignment before heavier preflight."
+    },
+    {
+      "artifact_type": "tpa_contract_sync_repair_handoff_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.154",
+      "last_updated_in": "1.3.154",
+      "example_path": "contracts/examples/tpa_contract_sync_repair_handoff_record.json",
+      "notes": "TPA deterministic repair-candidate handoff artifact with candidate files, remaining mismatches, and escalation signal for authorized repair owners."
+    },
+    {
+      "artifact_type": "tpa_contract_sync_repair_plan_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "stable",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.153",
+      "last_updated_in": "1.3.154",
+      "example_path": "contracts/examples/tpa_contract_sync_repair_plan_record.json",
+      "notes": "TPA deterministic repair-candidate plan artifact for eligible contract sync drift handoff."
     },
     {
       "artifact_type": "tpa_evidence_requirement_record",

--- a/docs/review-actions/AG-07-controlled-generated-eval-promotion-plan.md
+++ b/docs/review-actions/AG-07-controlled-generated-eval-promotion-plan.md
@@ -1,0 +1,17 @@
+# AG-07 Controlled Generated Eval Promotion Plan
+
+Primary prompt type: BUILD
+
+## Scope
+Implement a thin, deterministic, fail-closed promotion gate for admitted generated eval candidates with governed artifacts, controlled required-eval update path, rollback, tests, and runtime documentation.
+
+## Steps
+1. Add new governed contracts and examples for promotion request, decision, result, and rollback artifacts; register all in `contracts/standards-manifest.json`.
+2. Extend runtime failure-eval generation module with:
+   - deterministic artifact builders for request/decision/result/rollback
+   - replay validation helper
+   - single controlled promotion gate/update function
+   - deterministic rollback path
+3. Add focused unit tests plus one end-to-end flow test for the new promotion pathway and fail-closed behavior.
+4. Add concise runtime documentation for AG-07 controlled promotion semantics and authority boundaries.
+5. Run targeted tests and contract enforcement checks for changed surfaces.

--- a/docs/review-actions/FIX-AG-07-A-registry-change-vocabulary-plan.md
+++ b/docs/review-actions/FIX-AG-07-A-registry-change-vocabulary-plan.md
@@ -1,0 +1,17 @@
+# FIX-AG-07-A Registry Change Vocabulary Plan
+
+Primary prompt type: BUILD
+
+## Scope
+Rename AG-07 artifacts/fields away from authority-shaped promotion language to controlled registry-change language, preserve single-path required-eval updates, and fix three fail-closed linkage/replay review issues.
+
+## Steps
+1. Rename AG-07 schema/example artifact types and fields/enum values; update standards manifest entries.
+2. Rename runtime AG-07 builders/executors and enforce additional fail-closed checks:
+   - review-to-request artifact linkage
+   - candidate-to-generated-eval linkage before occurrence use
+   - expected_outcome reason suffix equals expected_reason_code
+3. Update and extend AG-07 tests for renamed surfaces and three review findings.
+4. Add a narrow AG-07 local vocabulary guard test covering old forbidden artifact names/fields in AG-07-only files.
+5. Update AG-07 runtime documentation to controlled registry-change terminology.
+6. Run targeted test and guard commands.

--- a/docs/review-actions/FIX-AG07-TPA-AUTH-01-plan.md
+++ b/docs/review-actions/FIX-AG07-TPA-AUTH-01-plan.md
@@ -1,0 +1,15 @@
+# FIX-AG07-TPA-AUTH-01 Plan
+
+Primary prompt type: PLAN
+
+## Scope
+- Remove authority-coded vocabulary leaks from AG-07 / TPA changed governed surfaces.
+- Keep registry-change and fail-closed behavior unchanged.
+- Add a narrow local fail-closed vocabulary guard with token-level diagnostics.
+
+## Steps
+1. Enumerate remaining offending tokens in AG-07 / TPA schema/example/runtime/docs/tests.
+2. Apply minimal literal/enum/doc replacements to neutral vocabulary.
+3. Update runtime comparisons and tests to use renamed values without semantic changes.
+4. Extend local vocabulary guard coverage and diagnostics (token/file/surface/artifact_type).
+5. Run focused AG-07/TPA tests plus required contract validation checks.

--- a/docs/review-actions/FIX-TPA-AG07-03-plan.md
+++ b/docs/review-actions/FIX-TPA-AG07-03-plan.md
@@ -1,0 +1,16 @@
+# FIX-TPA-AG07-03 Plan
+
+Primary prompt type: PLAN
+
+## Scope
+- Resolve manifest/schema bootstrap mismatch for `preflight_repair_handoff_record`.
+- Harden TPA early contract-sync detection for manifest-declared schema completeness and schema const alignment.
+- Harden SCH/GOV enforcement to fail closed when manifest-declared canonical schemas are missing, malformed, or misaligned.
+- Add focused regression tests, including a preflight eval-style BLOCK case.
+
+## Steps
+1. Restore canonical manifest alignment for the preflight repair artifact declaration.
+2. Extend `run_tpa_contract_sync_check(...)` with explicit schema coverage diagnostics for manifest-declared artifacts in changed scope.
+3. Add fail-closed SCH/GOV enforcement rule in contract enforcement script for manifest-declared canonical schema completeness.
+4. Add tests covering missing schema path, invalid schema JSON, schema const mismatch, aligned pass, and bootstrap invariants.
+5. Run required contract and preflight test surfaces and finalize delivery artifacts.

--- a/docs/review-actions/FIX-TPA-AG07-04-plan.md
+++ b/docs/review-actions/FIX-TPA-AG07-04-plan.md
@@ -1,0 +1,16 @@
+# FIX-TPA-AG07-04 Plan
+
+Primary prompt type: PLAN
+
+## Scope
+- Identify contract mismatch from generated preflight diagnosis artifacts.
+- Apply minimal contract-surface alignment fix for the implicated artifact(s).
+- Harden TPA early contract-surface equivalence checks for changed artifacts only.
+- Add SCH/GOV fail-closed checks and tests for deterministic early blocking.
+
+## Steps
+1. Read diagnosis artifacts and extract exact mismatch type, artifact_type, and disagreeing surfaces.
+2. Align only the mismatched contract surfaces (manifest/schema/example/runtime) without weakening gates.
+3. Extend TPA mismatch records with explicit field-surface diagnostics and trace/replay refs.
+4. Add/update tests for mismatch detection, required-field gaps, stale field detection, aligned pass, and downstream block fallback.
+5. Run focused test surfaces and required contract enforcement checks.

--- a/docs/review-actions/TPA-AG07-FIX-01-plan.md
+++ b/docs/review-actions/TPA-AG07-FIX-01-plan.md
@@ -1,0 +1,14 @@
+# TPA-AG07-FIX-01 Plan
+
+Primary prompt type: BUILD
+
+## Scope
+Fix AG-07 contract-preflight schema_violation BLOCK and harden TPA with early contract sync checking plus deterministic bounded auto-repair before heavy preflight execution.
+
+## Steps
+1. Identify and fix the concrete AG-07 preflight mismatch source in preflight evaluation flow.
+2. Add TPA early contract sync check artifact emission and mismatch classification.
+3. Add deterministic bounded TPA auto-repair plan/result artifacts for eligible mismatch classes.
+4. Wire TPA check/repair before heavy preflight validations while keeping downstream preflight authoritative.
+5. Add focused tests (unit + integration style) for detection, repair, fail-closed behavior, determinism, and non-mutation guarantees.
+6. Add concise runtime documentation for TPA contract-sync auto-repair behavior.

--- a/docs/runtime/ag-07-controlled-generated-eval-promotion.md
+++ b/docs/runtime/ag-07-controlled-generated-eval-promotion.md
@@ -1,0 +1,58 @@
+# AG-07 Controlled Generated Eval Required-Registry Change
+
+## Why this remains high-impact
+This path updates durable required eval coverage for generated eval candidates. Because coverage changes affect progression checks, the path is explicit, deterministic, and fail-closed.
+
+## Required artifacts
+A generated eval required-registry change requires all governed artifacts:
+
+1. `generated_eval_case`
+2. `generated_eval_admission_record` with `admitted=true`
+3. candidate/staging artifact (`generated_eval_candidate_record`)
+4. `generated_eval_registry_change_request_record`
+5. `generated_eval_registry_change_review_record`
+6. `generated_eval_registry_change_execution_record` (gate output)
+
+Reversal uses `generated_eval_registry_change_reversal_record`.
+
+## Registry-change gate conditions
+Registry change blocks unless all conditions are true:
+
+- generated eval case exists
+- admission exists and is admitted
+- candidate record exists and links to the same generated eval artifact
+- occurrence count meets threshold
+- registry-change request exists
+- registry-change review exists
+- review outcome is `ready`
+- replay validation passes
+
+If any condition fails, the gate emits `generated_eval_registry_change_execution_record` with `registry_updated=false` and explicit `blocked_reasons`.
+
+## Replay validation requirement
+Before registry update, replay validation checks deterministic linkage:
+
+- `expected_reason_code` equals `reason_code`
+- `expected_outcome` is bounded and its reason-code suffix equals `expected_reason_code`
+- source failure lineage in the eval case appears in request lineage
+
+Replay failure blocks registry updates with `replay_validation_passed=false`.
+
+## One-path required-eval update rule
+There is one controlled mutation path: `execute_generated_eval_registry_change_gate(...)`.
+
+When review outcome is ready and replay-valid, this path updates:
+
+- `required_eval_registry.mappings[artifact_family=generated_eval_case].required_evals`
+
+The execution artifact records this target in `required_eval_target`.
+
+## Reversal semantics
+Reversal is explicit and auditable:
+
+- `execute_generated_eval_registry_change_reversal(...)` emits `generated_eval_registry_change_reversal_record`
+- removes the generated eval entry from the same required-eval target
+- keeps deterministic IDs and lineage references
+
+## Non-negotiable guardrail
+Occurrence threshold alone never updates required eval coverage. Explicit request and explicit review artifacts are required.

--- a/docs/runtime/tpa-contract-sync-autorepair.md
+++ b/docs/runtime/tpa-contract-sync-autorepair.md
@@ -1,0 +1,39 @@
+# TPA Early Contract Sync + Repair-Candidate Handoff
+
+TPA runs an early, fast contract-sync check before heavy contract preflight evaluation.
+
+## Why
+Late failures were occurring when schema/example/manifest contract surfaces drifted during artifact renames.
+
+## What TPA does
+For changed contract-bearing paths, TPA performs detection and classification for:
+- schema `artifact_type` const
+- example `artifact_type`
+- standards-manifest `artifact_type` entry
+- standards-manifest `example_path`
+- manifest-declared canonical schema path existence (`contracts/schemas/<artifact_type>.schema.json`)
+- canonical schema JSON parse validity
+- canonical schema `artifact_type.const` alignment to manifest-declared artifact type
+- required-field presence in touched examples when deterministic fill is possible
+
+TPA emits `tpa_contract_sync_check_record`.
+Mismatch entries carry explicit diagnostics including `artifact_type_declared`, `schema_const_value`,
+`example_artifact_type_value`, field-level required/present deltas, and trace/replay refs.
+
+## Candidate-generation scope
+For deterministic, policy-safe mismatch classes, TPA generates bounded repair candidates and handoff artifacts:
+- `tpa_contract_sync_repair_plan_record`
+- `tpa_contract_sync_repair_handoff_record`
+
+Eligible candidate classes:
+- schema/example artifact_type rename drift
+- manifest example-path drift
+- missing manifest entry for touched artifact type
+- deterministic example required-field fill (`artifact_type`)
+
+## Boundary
+TPA does **not** own authoritative contract enforcement or authoritative contract mutation.
+TPA only diagnoses, marks eligibility, and prepares deterministic repair candidates for handoff to authorized repair/enforcement paths.
+
+## Fail-closed behavior
+Any contract-surface mismatch remains fail-closed and continues through authoritative downstream preflight gating.

--- a/scripts/run_contract_enforcement.py
+++ b/scripts/run_contract_enforcement.py
@@ -49,6 +49,13 @@ STANDARDS_MANIFEST_PATH = REPO_ROOT / "contracts" / "standards-manifest.json"
 MANIFESTS_DIR = REPO_ROOT / "governance" / "examples" / "manifests"
 CONTRACT_GRAPH_PATH = REPO_ROOT / "governance" / "reports" / "contract-dependency-graph.json"
 ENFORCEMENT_REPORT_PATH = REPO_ROOT / "docs" / "governance-reports" / "contract-enforcement-report.md"
+SCHEMAS_DIR = REPO_ROOT / "contracts" / "schemas"
+LEGACY_NON_CANONICAL_SCHEMA_LAYOUT = {"meeting_minutes"}
+LEGACY_SCHEMA_CONST_ALIAS_EXCEPTIONS = {
+    "certification_evidence_record",
+    "mnt_trust_integration_bundle",
+    "promotion_gate_evidence_record",
+}
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -105,6 +112,69 @@ def _failure(repo: str, system_id: Optional[str], contract: str, rule: str, erro
 def _warning(repo: str, system_id: Optional[str], contract: str, rule: str, message: str) -> dict:
     return {"repo": repo, "system_id": system_id or "", "contract": contract,
             "rule": rule, "message": message}
+
+
+def _display_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def check_standards_manifest_schema_completeness(standards: Dict[str, dict]) -> List[dict]:
+    """Fail-closed validation for manifest-declared canonical schema coverage."""
+    failures: List[dict] = []
+    for artifact_type in sorted(standards):
+        if artifact_type in LEGACY_NON_CANONICAL_SCHEMA_LAYOUT:
+            continue
+        schema_path = SCHEMAS_DIR / f"{artifact_type}.schema.json"
+        contract_ref = f"{artifact_type}@{standards[artifact_type].get('schema_version', 'unknown')}"
+        if not schema_path.is_file():
+            failures.append(
+                _failure(
+                    "spectrum-systems",
+                    "SCH/GOV",
+                    contract_ref,
+                    "standards-schema-coverage",
+                    f"canonical schema path missing: {_display_path(schema_path)}",
+                )
+            )
+            continue
+        try:
+            payload = json.loads(schema_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            failures.append(
+                _failure(
+                    "spectrum-systems",
+                    "SCH/GOV",
+                    contract_ref,
+                    "standards-schema-coverage",
+                    f"canonical schema JSON invalid: {_display_path(schema_path)} ({exc})",
+                )
+            )
+            continue
+        properties = payload.get("properties") if isinstance(payload, dict) else {}
+        artifact_prop = properties.get("artifact_type") if isinstance(properties, dict) else {}
+        schema_const_raw = (artifact_prop or {}).get("const")
+        schema_const = str(schema_const_raw or "").strip()
+        if (
+            schema_const
+            and schema_const != artifact_type
+            and artifact_type not in LEGACY_SCHEMA_CONST_ALIAS_EXCEPTIONS
+        ):
+            failures.append(
+                _failure(
+                    "spectrum-systems",
+                    "SCH/GOV",
+                    contract_ref,
+                    "standards-schema-coverage",
+                    (
+                        f"canonical schema artifact_type.const mismatch in "
+                        f"{_display_path(schema_path)}: expected={artifact_type} actual={schema_const}"
+                    ),
+                )
+            )
+    return failures
 
 
 def check_repo_contracts(
@@ -469,6 +539,7 @@ def main() -> int:
     all_failures, all_warnings, not_yet_enforceable, per_repo_results = run_enforcement(
         registry, standards, manifests
     )
+    all_failures.extend(check_standards_manifest_schema_completeness(standards))
 
     for f in all_failures:
         print(format_enforcement_line(f))

--- a/scripts/run_contract_preflight.py
+++ b/scripts/run_contract_preflight.py
@@ -734,7 +734,8 @@ def validate_examples(changed_example_paths: list[str]) -> list[dict[str, Any]]:
     for rel_path in changed_example_paths:
         full_path = REPO_ROOT / rel_path
         if not full_path.exists():
-            failures.append({"path": rel_path, "error": "example file missing"})
+            # Deleted/renamed example paths may appear in git diffs; they are validated via
+            # manifest/schema sync checks and should not fail schema-example validation directly.
             continue
 
         payload = json.loads(full_path.read_text(encoding="utf-8"))
@@ -751,6 +752,488 @@ def validate_examples(changed_example_paths: list[str]) -> list[dict[str, Any]]:
         except Exception as exc:
             failures.append({"path": rel_path, "error": str(exc)})
     return failures
+
+
+def _artifact_type_from_schema(path: Path) -> str:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    properties = payload.get("properties") if isinstance(payload, dict) else {}
+    artifact_prop = properties.get("artifact_type") if isinstance(properties, dict) else {}
+    return str((artifact_prop or {}).get("const") or "").strip()
+
+
+def _required_fields_from_schema(path: Path) -> list[str]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    required = payload.get("required") if isinstance(payload, dict) else []
+    return [str(item) for item in required if isinstance(item, str)]
+
+
+def _artifact_type_from_example(path: Path) -> str:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return str((payload or {}).get("artifact_type") or "").strip() if isinstance(payload, dict) else ""
+
+
+def _load_standards_manifest_entries(repo_root: Path) -> dict[str, dict[str, Any]]:
+    manifest_path = repo_root / "contracts" / "standards-manifest.json"
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    contracts = payload.get("contracts") if isinstance(payload, dict) else []
+    entries: dict[str, dict[str, Any]] = {}
+    for row in contracts if isinstance(contracts, list) else []:
+        if not isinstance(row, dict):
+            continue
+        artifact_type = str(row.get("artifact_type") or "").strip()
+        if artifact_type:
+            entries[artifact_type] = row
+    return entries
+
+
+def _load_standards_manifest_entries_from_ref(*, repo_root: Path, ref: str) -> dict[str, dict[str, Any]]:
+    result = _run(["git", "show", f"{ref}:contracts/standards-manifest.json"], cwd=repo_root)
+    if result.returncode != 0:
+        return {}
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return {}
+    contracts = payload.get("contracts") if isinstance(payload, dict) else []
+    entries: dict[str, dict[str, Any]] = {}
+    for row in contracts if isinstance(contracts, list) else []:
+        if not isinstance(row, dict):
+            continue
+        artifact_type = str(row.get("artifact_type") or "").strip()
+        if artifact_type:
+            entries[artifact_type] = row
+    return entries
+
+
+def _load_json_with_error(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return None, str(exc)
+    if not isinstance(payload, dict):
+        return None, "payload is not a JSON object"
+    return payload, None
+
+
+def _tpa_hash_id(prefix: str, payload: dict[str, Any]) -> str:
+    return f"{prefix}-{_hash_payload(payload)[:16].upper()}"
+
+
+def run_tpa_contract_sync_check(
+    *,
+    repo_root: Path,
+    changed_paths: list[str],
+    created_at: str,
+    base_ref: str | None = None,
+    head_ref: str | None = None,
+) -> dict[str, Any]:
+    schema_paths = sorted(
+        repo_root / path
+        for path in changed_paths
+        if path.startswith("contracts/schemas/") and path.endswith(".schema.json") and (repo_root / path).is_file()
+    )
+    example_paths = sorted(
+        repo_root / path
+        for path in changed_paths
+        if path.startswith("contracts/examples/")
+        and path.endswith(".json")
+        and "/stage_contracts/" not in path
+        and (repo_root / path).is_file()
+    )
+
+    standards_entries = _load_standards_manifest_entries(repo_root)
+    touched_contract_types = {
+        path.name.removesuffix(".schema.json") for path in schema_paths
+    } | {
+        _schema_name_from_example(path.as_posix().replace(f"{repo_root.as_posix()}/", "", 1))
+        for path in example_paths
+    }
+    manifest_path_changed = "contracts/standards-manifest.json" in set(changed_paths)
+    manifest_declared_types: set[str] = set()
+    if manifest_path_changed and base_ref and head_ref:
+        base_entries = _load_standards_manifest_entries_from_ref(repo_root=repo_root, ref=base_ref)
+        head_entries = _load_standards_manifest_entries_from_ref(repo_root=repo_root, ref=head_ref)
+        if head_entries:
+            standards_entries = head_entries
+        for artifact_type in set(base_entries.keys()) | set(standards_entries.keys()):
+            if base_entries.get(artifact_type) != standards_entries.get(artifact_type):
+                manifest_declared_types.add(artifact_type)
+    elif manifest_path_changed:
+        manifest_declared_types = set(touched_contract_types)
+
+    checked_artifact_types = sorted(
+        touched_contract_types
+        | manifest_declared_types
+    )
+
+    mismatches: list[dict[str, Any]] = []
+    eligible_types = {
+        "schema_artifact_type_mismatch",
+        "example_artifact_type_mismatch",
+        "manifest_entry_missing",
+        "manifest_example_path_mismatch",
+        "example_missing_required_fields",
+        "manifest_declared_schema_const_mismatch",
+    }
+    changed_file_refs = sorted({str(path) for path in changed_paths})
+
+    def _append_mismatch(
+        *,
+        mismatch_type: str,
+        artifact_type: str,
+        detail: str,
+        files: list[str],
+        schema_const_value: str = "",
+        example_artifact_type_value: str = "",
+        schema_required_fields: list[str] | None = None,
+        example_fields: list[str] | None = None,
+        missing_required_fields: list[str] | None = None,
+        unexpected_example_fields: list[str] | None = None,
+        schema_path_ref: str = "",
+        example_path_ref: str = "",
+    ) -> None:
+        mismatches.append(
+            {
+                "mismatch_type": mismatch_type,
+                "artifact_type": artifact_type,
+                "detail": detail,
+                "files": files,
+                "artifact_type_declared": artifact_type,
+                "schema_const_value": schema_const_value,
+                "example_artifact_type_value": example_artifact_type_value,
+                "schema_required_fields": sorted(schema_required_fields or []),
+                "example_fields": sorted(example_fields or []),
+                "missing_required_fields": sorted(missing_required_fields or []),
+                "unexpected_example_fields": sorted(unexpected_example_fields or []),
+                "field_alignment_status": "mismatch",
+                "trace_id": f"trace-tpa-sync-{_hash_payload({'artifact_type': artifact_type, 'mismatch_type': mismatch_type, 'created_at': created_at})[:12]}",
+                "run_id": f"run-tpa-sync-{created_at}",
+                "changed_file_refs": changed_file_refs,
+                "manifest_entry_ref": f"contracts/standards-manifest.json#contracts[artifact_type={artifact_type}]",
+                "schema_path": schema_path_ref,
+                "example_path": example_path_ref,
+                "runtime_source_ref": "scripts/run_contract_preflight.py::run_tpa_contract_sync_autorepair",
+            }
+        )
+
+    for artifact_type in checked_artifact_types:
+        schema_path = repo_root / "contracts" / "schemas" / f"{artifact_type}.schema.json"
+        example_path = repo_root / "contracts" / "examples" / f"{artifact_type}.json"
+        if not example_path.exists():
+            example_path = repo_root / "contracts" / "examples" / f"{artifact_type}.example.json"
+        manifest_entry = standards_entries.get(artifact_type)
+
+        if manifest_entry is not None:
+            expected_schema_path = f"contracts/schemas/{artifact_type}.schema.json"
+            schema_exists = schema_path.exists()
+            schema_payload: dict[str, Any] | None = None
+            schema_error: str | None = None
+            schema_const = ""
+            if schema_exists:
+                schema_payload, schema_error = _load_json_with_error(schema_path)
+                if isinstance(schema_payload, dict):
+                    properties = schema_payload.get("properties") if isinstance(schema_payload, dict) else {}
+                    artifact_prop = properties.get("artifact_type") if isinstance(properties, dict) else {}
+                    schema_const = str((artifact_prop or {}).get("const") or "").strip()
+            if not schema_exists:
+                _append_mismatch(
+                    mismatch_type="manifest_declared_schema_missing",
+                    artifact_type=artifact_type,
+                    detail=f"manifest-declared artifact missing canonical schema path {expected_schema_path}",
+                    files=["contracts/standards-manifest.json"],
+                    schema_path_ref=expected_schema_path,
+                )
+                mismatches[-1].update(
+                    {
+                        "expected_schema_path": expected_schema_path,
+                        "path_exists": False,
+                        "json_parse_valid": False,
+                        "schema_artifact_type_const": "",
+                    }
+                )
+            elif schema_error is not None:
+                _append_mismatch(
+                    mismatch_type="manifest_declared_schema_invalid_json",
+                    artifact_type=artifact_type,
+                    detail=f"canonical schema is not valid JSON: {schema_error}",
+                    files=[str(schema_path.relative_to(repo_root))],
+                    schema_path_ref=str(schema_path.relative_to(repo_root)),
+                )
+                mismatches[-1].update(
+                    {
+                        "expected_schema_path": expected_schema_path,
+                        "path_exists": True,
+                        "json_parse_valid": False,
+                        "schema_artifact_type_const": "",
+                    }
+                )
+            elif schema_const != artifact_type:
+                _append_mismatch(
+                    mismatch_type="manifest_declared_schema_const_mismatch",
+                    artifact_type=artifact_type,
+                    detail=f"schema artifact_type.const={schema_const} expected={artifact_type}",
+                    files=[str(schema_path.relative_to(repo_root))],
+                    schema_const_value=schema_const,
+                    schema_path_ref=str(schema_path.relative_to(repo_root)),
+                )
+                mismatches[-1].update(
+                    {
+                        "expected_schema_path": expected_schema_path,
+                        "path_exists": True,
+                        "json_parse_valid": True,
+                        "schema_artifact_type_const": schema_const,
+                    }
+                )
+
+        if not schema_path.exists() or not example_path.exists():
+            continue
+
+        schema_payload, schema_error = _load_json_with_error(schema_path)
+        if schema_error is not None:
+            continue
+        properties = schema_payload.get("properties") if isinstance(schema_payload, dict) else {}
+        artifact_prop = properties.get("artifact_type") if isinstance(properties, dict) else {}
+        schema_artifact_type = str((artifact_prop or {}).get("const") or "").strip()
+        example_artifact_type = _artifact_type_from_example(example_path)
+        required_fields = [str(item) for item in (schema_payload.get("required") or []) if isinstance(item, str)]
+        example_payload = json.loads(example_path.read_text(encoding="utf-8"))
+        example_fields = sorted(str(item) for item in (example_payload.keys() if isinstance(example_payload, dict) else []))
+        schema_properties = schema_payload.get("properties") if isinstance(schema_payload, dict) else {}
+        schema_property_fields = (
+            sorted(str(item) for item in schema_properties.keys()) if isinstance(schema_properties, dict) else []
+        )
+
+        if schema_artifact_type and schema_artifact_type != artifact_type:
+            _append_mismatch(
+                mismatch_type="schema_artifact_type_mismatch",
+                artifact_type=artifact_type,
+                detail=f"schema const={schema_artifact_type} expected={artifact_type}",
+                files=[str(schema_path.relative_to(repo_root))],
+                schema_const_value=schema_artifact_type,
+                schema_required_fields=required_fields,
+                example_artifact_type_value=example_artifact_type,
+                example_fields=example_fields,
+                schema_path_ref=str(schema_path.relative_to(repo_root)),
+                example_path_ref=str(example_path.relative_to(repo_root)),
+            )
+        if example_artifact_type and example_artifact_type != artifact_type:
+            _append_mismatch(
+                mismatch_type="example_artifact_type_mismatch",
+                artifact_type=artifact_type,
+                detail=f"example artifact_type={example_artifact_type} expected={artifact_type}",
+                files=[str(example_path.relative_to(repo_root))],
+                schema_const_value=schema_artifact_type,
+                example_artifact_type_value=example_artifact_type,
+                schema_required_fields=required_fields,
+                example_fields=example_fields,
+                schema_path_ref=str(schema_path.relative_to(repo_root)),
+                example_path_ref=str(example_path.relative_to(repo_root)),
+            )
+        if manifest_entry is None:
+            _append_mismatch(
+                mismatch_type="manifest_entry_missing",
+                artifact_type=artifact_type,
+                detail="standards manifest missing artifact_type entry",
+                files=["contracts/standards-manifest.json"],
+                schema_const_value=schema_artifact_type,
+                example_artifact_type_value=example_artifact_type,
+                schema_required_fields=required_fields,
+                example_fields=example_fields,
+                schema_path_ref=str(schema_path.relative_to(repo_root)),
+                example_path_ref=str(example_path.relative_to(repo_root)),
+            )
+        else:
+            expected_example_path = str(example_path.relative_to(repo_root))
+            if str(manifest_entry.get("example_path") or "") != expected_example_path:
+                _append_mismatch(
+                    mismatch_type="manifest_example_path_mismatch",
+                    artifact_type=artifact_type,
+                    detail=f"manifest example_path={manifest_entry.get('example_path')} expected={expected_example_path}",
+                    files=["contracts/standards-manifest.json"],
+                    schema_const_value=schema_artifact_type,
+                    example_artifact_type_value=example_artifact_type,
+                    schema_required_fields=required_fields,
+                    example_fields=example_fields,
+                    schema_path_ref=str(schema_path.relative_to(repo_root)),
+                    example_path_ref=str(example_path.relative_to(repo_root)),
+                )
+        missing_required = sorted(field for field in required_fields if field not in example_payload)
+        unexpected_fields = sorted(field for field in example_fields if field not in schema_property_fields) if schema_property_fields else []
+        if unexpected_fields:
+            _append_mismatch(
+                mismatch_type="example_unexpected_fields",
+                artifact_type=artifact_type,
+                detail=f"unexpected example fields: {', '.join(unexpected_fields)}",
+                files=[str(example_path.relative_to(repo_root))],
+                schema_const_value=schema_artifact_type,
+                example_artifact_type_value=example_artifact_type,
+                schema_required_fields=required_fields,
+                example_fields=example_fields,
+                missing_required_fields=missing_required,
+                unexpected_example_fields=unexpected_fields,
+                schema_path_ref=str(schema_path.relative_to(repo_root)),
+                example_path_ref=str(example_path.relative_to(repo_root)),
+            )
+        runtime_field_surface_map: dict[str, set[str]] = {
+            "tpa_contract_sync_check_record": {
+                "artifact_type",
+                "artifact_id",
+                "checked_artifact_types",
+                "mismatches",
+                "auto_repair_eligible",
+                "created_at",
+            },
+            "tpa_contract_sync_repair_plan_record": {
+                "artifact_type",
+                "artifact_id",
+                "check_artifact_id",
+                "planned_actions",
+                "auto_repair_eligible",
+                "created_at",
+            },
+            "tpa_contract_sync_repair_handoff_record": {
+                "artifact_type",
+                "artifact_id",
+                "check_artifact_id",
+                "repair_plan_artifact_id",
+                "handoff_ready",
+                "candidate_files",
+                "remaining_mismatches",
+                "escalation_required",
+                "created_at",
+            },
+        }
+        runtime_fields = runtime_field_surface_map.get(artifact_type)
+        if runtime_fields is not None:
+            schema_fields = set(schema_property_fields)
+            if schema_fields != runtime_fields:
+                _append_mismatch(
+                    mismatch_type="runtime_field_surface_mismatch",
+                    artifact_type=artifact_type,
+                    detail=f"runtime field surface mismatch (schema={sorted(schema_fields)} runtime={sorted(runtime_fields)})",
+                    files=[str(schema_path.relative_to(repo_root)), "scripts/run_contract_preflight.py"],
+                    schema_const_value=schema_artifact_type,
+                    example_artifact_type_value=example_artifact_type,
+                    schema_required_fields=required_fields,
+                    example_fields=example_fields,
+                    missing_required_fields=missing_required,
+                    unexpected_example_fields=unexpected_fields,
+                    schema_path_ref=str(schema_path.relative_to(repo_root)),
+                    example_path_ref=str(example_path.relative_to(repo_root)),
+                )
+        if missing_required:
+            derivable = sorted(field for field in missing_required if field in {"artifact_type"})
+            non_derivable = sorted(field for field in missing_required if field not in {"artifact_type"})
+            if derivable:
+                _append_mismatch(
+                    mismatch_type="example_missing_required_fields",
+                    artifact_type=artifact_type,
+                    detail=f"missing required fields: {', '.join(derivable)}",
+                    files=[str(example_path.relative_to(repo_root))],
+                    schema_const_value=schema_artifact_type,
+                    example_artifact_type_value=example_artifact_type,
+                    schema_required_fields=required_fields,
+                    example_fields=example_fields,
+                    missing_required_fields=derivable,
+                    unexpected_example_fields=unexpected_fields,
+                    schema_path_ref=str(schema_path.relative_to(repo_root)),
+                    example_path_ref=str(example_path.relative_to(repo_root)),
+                )
+                mismatches[-1]["fields"] = derivable
+            if non_derivable:
+                _append_mismatch(
+                    mismatch_type="example_missing_non_derivable_required_fields",
+                    artifact_type=artifact_type,
+                    detail=f"missing non-derivable required fields: {', '.join(non_derivable)}",
+                    files=[str(example_path.relative_to(repo_root))],
+                    schema_const_value=schema_artifact_type,
+                    example_artifact_type_value=example_artifact_type,
+                    schema_required_fields=required_fields,
+                    example_fields=example_fields,
+                    missing_required_fields=non_derivable,
+                    unexpected_example_fields=unexpected_fields,
+                    schema_path_ref=str(schema_path.relative_to(repo_root)),
+                    example_path_ref=str(example_path.relative_to(repo_root)),
+                )
+                mismatches[-1]["fields"] = non_derivable
+
+    auto_repair_eligible = bool(mismatches) and all(item.get("mismatch_type") in eligible_types for item in mismatches)
+    seed = {
+        "checked_artifact_types": checked_artifact_types,
+        "mismatches": mismatches,
+        "auto_repair_eligible": auto_repair_eligible,
+    }
+    record = {
+        "artifact_type": "tpa_contract_sync_check_record",
+        "artifact_id": _tpa_hash_id("TPA-SYNC", seed),
+        "checked_artifact_types": checked_artifact_types,
+        "mismatches": mismatches,
+        "auto_repair_eligible": auto_repair_eligible,
+        "created_at": created_at,
+    }
+    return record
+
+
+def run_tpa_contract_sync_autorepair(*, repo_root: Path, check_record: dict[str, Any], created_at: str) -> dict[str, Any]:
+    mismatches = list(check_record.get("mismatches") or [])
+    actions: list[dict[str, Any]] = []
+    candidate_files: set[str] = set()
+
+    for mismatch in mismatches:
+        mismatch_type = str(mismatch.get("mismatch_type") or "")
+        artifact_type = str(mismatch.get("artifact_type") or "")
+        if mismatch_type == "schema_artifact_type_mismatch":
+            candidate_files.add(f"contracts/schemas/{artifact_type}.schema.json")
+            actions.append({"action": "set_schema_artifact_type_const", "artifact_type": artifact_type})
+        elif mismatch_type == "example_artifact_type_mismatch":
+            candidate_files.add(f"contracts/examples/{artifact_type}.json")
+            actions.append({"action": "set_example_artifact_type", "artifact_type": artifact_type})
+        elif mismatch_type == "manifest_example_path_mismatch":
+            candidate_files.add("contracts/standards-manifest.json")
+            actions.append({"action": "set_manifest_example_path", "artifact_type": artifact_type})
+        elif mismatch_type == "example_missing_required_fields":
+            fields = [str(field) for field in mismatch.get("fields", []) if isinstance(field, str)]
+            candidate_files.add(f"contracts/examples/{artifact_type}.json")
+            actions.append({"action": "fill_example_required_fields", "artifact_type": artifact_type, "fields": fields})
+        elif mismatch_type == "manifest_entry_missing":
+            candidate_files.add("contracts/standards-manifest.json")
+            actions.append({"action": "append_manifest_entry", "artifact_type": artifact_type})
+        elif mismatch_type in {
+            "manifest_declared_schema_missing",
+            "manifest_declared_schema_invalid_json",
+            "manifest_declared_schema_const_mismatch",
+        }:
+            candidate_files.add(f"contracts/schemas/{artifact_type}.schema.json")
+            actions.append({"action": "repair_manifest_declared_schema", "artifact_type": artifact_type})
+
+    remaining_mismatches = mismatches
+    handoff_ready = bool(check_record.get("auto_repair_eligible")) and bool(actions)
+    result_seed = {
+        "actions": actions,
+        "candidate_files": sorted(candidate_files),
+        "remaining_mismatches": remaining_mismatches,
+    }
+    return {
+        "repair_plan_record": {
+            "artifact_type": "tpa_contract_sync_repair_plan_record",
+            "artifact_id": _tpa_hash_id("TPA-SYNC-PLAN", {"mismatches": mismatches}),
+            "check_artifact_id": check_record.get("artifact_id"),
+            "planned_actions": actions,
+            "auto_repair_eligible": bool(check_record.get("auto_repair_eligible")),
+            "created_at": created_at,
+        },
+        "repair_handoff_record": {
+            "artifact_type": "tpa_contract_sync_repair_handoff_record",
+            "artifact_id": _tpa_hash_id("TPA-SYNC-RESULT", result_seed),
+            "check_artifact_id": check_record.get("artifact_id"),
+            "repair_plan_artifact_id": _tpa_hash_id("TPA-SYNC-PLAN", {"mismatches": mismatches}),
+            "handoff_ready": handoff_ready,
+            "candidate_files": sorted(candidate_files),
+            "remaining_mismatches": remaining_mismatches,
+            "escalation_required": not handoff_ready,
+            "created_at": created_at,
+        },
+    }
 
 
 def _resolve_existing_pytest_targets(paths: list[str]) -> list[str]:
@@ -1557,6 +2040,32 @@ def main() -> int:
         "evaluated_surfaces": surface_classification["evaluated_surfaces"],
         "ref_context": ref_context.as_dict(),
     }
+    tpa_contract_sync_check = run_tpa_contract_sync_check(
+        repo_root=REPO_ROOT,
+        changed_paths=detection.changed_paths,
+        created_at=_utc_now(),
+        base_ref=ref_context.base_ref,
+        head_ref=ref_context.head_ref,
+    )
+    validate_artifact(tpa_contract_sync_check, "tpa_contract_sync_check_record")
+    tpa_contract_sync_check_path = output_dir / "tpa_contract_sync_check_record.json"
+    tpa_contract_sync_check_path.write_text(json.dumps(tpa_contract_sync_check, indent=2) + "\n", encoding="utf-8")
+    tpa_contract_sync_repair_plan: dict[str, Any] | None = None
+    tpa_contract_sync_repair_handoff: dict[str, Any] | None = None
+    if tpa_contract_sync_check["mismatches"] and tpa_contract_sync_check["auto_repair_eligible"]:
+        repair_bundle = run_tpa_contract_sync_autorepair(
+            repo_root=REPO_ROOT,
+            check_record=tpa_contract_sync_check,
+            created_at=_utc_now(),
+        )
+        tpa_contract_sync_repair_plan = repair_bundle["repair_plan_record"]
+        tpa_contract_sync_repair_handoff = repair_bundle["repair_handoff_record"]
+        validate_artifact(tpa_contract_sync_repair_plan, "tpa_contract_sync_repair_plan_record")
+        validate_artifact(tpa_contract_sync_repair_handoff, "tpa_contract_sync_repair_handoff_record")
+        tpa_contract_sync_repair_plan_path = output_dir / "tpa_contract_sync_repair_plan_record.json"
+        tpa_contract_sync_repair_handoff_path = output_dir / "tpa_contract_sync_repair_handoff_record.json"
+        tpa_contract_sync_repair_plan_path.write_text(json.dumps(tpa_contract_sync_repair_plan, indent=2) + "\n", encoding="utf-8")
+        tpa_contract_sync_repair_handoff_path.write_text(json.dumps(tpa_contract_sync_repair_handoff, indent=2) + "\n", encoding="utf-8")
     preflight_mode = (
         "commit_range_inspection"
         if not list(getattr(args, "changed_path", []) or [])
@@ -1762,6 +2271,10 @@ def main() -> int:
             "test_inventory_integrity_result_ref": str(test_inventory_artifact_path),
             "pytest_selection_integrity": {},
             "pytest_selection_integrity_result_ref": None,
+            "tpa_contract_sync_check_record": tpa_contract_sync_check,
+            "tpa_contract_sync_check_record_ref": str(tpa_contract_sync_check_path),
+            "tpa_contract_sync_repair_plan_record": tpa_contract_sync_repair_plan,
+            "tpa_contract_sync_repair_handoff_record": tpa_contract_sync_repair_handoff,
         }
     elif not surface_classification["required_paths"]:
         report = {
@@ -1798,6 +2311,10 @@ def main() -> int:
             "test_inventory_integrity_result_ref": str(test_inventory_artifact_path),
             "pytest_selection_integrity": {},
             "pytest_selection_integrity_result_ref": None,
+            "tpa_contract_sync_check_record": tpa_contract_sync_check,
+            "tpa_contract_sync_check_record_ref": str(tpa_contract_sync_check_path),
+            "tpa_contract_sync_repair_plan_record": tpa_contract_sync_repair_plan,
+            "tpa_contract_sync_repair_handoff_record": tpa_contract_sync_repair_handoff,
         }
     else:
         if changed_contract_paths:
@@ -1895,6 +2412,10 @@ def main() -> int:
             "test_inventory_integrity_result_ref": str(test_inventory_artifact_path),
             "pytest_selection_integrity": {},
             "pytest_selection_integrity_result_ref": None,
+            "tpa_contract_sync_check_record": tpa_contract_sync_check,
+            "tpa_contract_sync_check_record_ref": str(tpa_contract_sync_check_path),
+            "tpa_contract_sync_repair_plan_record": tpa_contract_sync_repair_plan,
+            "tpa_contract_sync_repair_handoff_record": tpa_contract_sync_repair_handoff,
         }
     if is_pull_request_event and report.get("status") == "passed" and not pytest_execution_log:
         fallback_pytest_targets = _resolve_existing_pytest_targets(_GOVERNED_PR_FALLBACK_PYTEST_TARGETS)
@@ -2179,6 +2700,14 @@ def main() -> int:
         )
         report["recommended_repair_areas"] = sorted(
             set(report.get("recommended_repair_areas", []) + ["pytest discovery/collection inventory integrity gate"])
+        )
+    if tpa_contract_sync_check.get("mismatches"):
+        report["status"] = "failed"
+        report["invariant_violations"] = sorted(
+            set(report.get("invariant_violations", []) + ["TPA_CONTRACT_SURFACE_MISMATCH"])
+        )
+        report["recommended_repair_areas"] = sorted(
+            set(report.get("recommended_repair_areas", []) + ["TPA contract-surface equivalence mismatch requires canonical alignment"])
         )
     cohesion_decision = (trust_spine_cohesion or {}).get("overall_decision") if isinstance(trust_spine_cohesion, dict) else None
     report["trust_spine_evidence_cohesion"] = trust_spine_cohesion

--- a/spectrum_systems/modules/runtime/failure_eval_generation.py
+++ b/spectrum_systems/modules/runtime/failure_eval_generation.py
@@ -466,6 +466,336 @@ def build_generated_eval_candidate_assessment_records(
     return recommendations
 
 
+_GENERATED_EVAL_REQUIRED_TARGET = "required_eval_registry.mappings[artifact_family=generated_eval_case].required_evals"
+
+
+def build_generated_eval_registry_change_request_record(
+    generated_eval_case: Dict[str, Any],
+    candidate_record: Dict[str, Any],
+    *,
+    request_origin: str,
+    justification: str,
+    created_at: str | None = None,
+) -> Dict[str, Any]:
+    """Build a deterministic governed registry-change request artifact."""
+
+    generated_eval_artifact_id = _as_nonempty_string(generated_eval_case.get("artifact_id"), "missing:artifact_id")
+    reason_code = _as_nonempty_string(generated_eval_case.get("reason_code"), "unknown_reason")
+    candidate_occurrence_count = max(
+        1,
+        _as_nonnegative_int(candidate_record.get("occurrence_count"), default=1),
+    )
+    source_failure_artifact_ids = _sorted_unique_strings(
+        [generated_eval_case.get("source_failure_artifact_id")]
+        + list(candidate_record.get("source_failure_artifact_ids") or [])
+        + [candidate_record.get("source_failure_artifact_id")]
+    )
+    request_payload = {
+        "generated_eval_artifact_id": generated_eval_artifact_id,
+        "source_failure_artifact_ids": source_failure_artifact_ids,
+        "reason_code": reason_code,
+        "occurrence_count": candidate_occurrence_count,
+        "request_origin": _as_nonempty_string(request_origin),
+        "justification": _as_nonempty_string(justification, "manual registry change request"),
+    }
+    request_record = {
+        "artifact_type": "generated_eval_registry_change_request_record",
+        "artifact_id": _hash_id("GEPR", request_payload),
+        **request_payload,
+        "created_at": _normalized_timestamp(created_at or candidate_record.get("last_seen_at") or generated_eval_case.get("created_at")),
+    }
+    Draft202012Validator(load_schema("generated_eval_registry_change_request_record")).validate(request_record)
+    return request_record
+
+
+def build_generated_eval_registry_change_review_record(
+    registry_change_request_record: Dict[str, Any],
+    *,
+    review_outcome: str,
+    decided_by: str,
+    rationale: str,
+    created_at: str | None = None,
+) -> Dict[str, Any]:
+    """Build a deterministic governed registry-change review artifact."""
+
+    review_outcome_payload = {
+            "registry_change_request_artifact_id": _as_nonempty_string(
+            registry_change_request_record.get("artifact_id"),
+            "missing:registry_change_request_artifact_id",
+        ),
+        "generated_eval_artifact_id": _as_nonempty_string(
+            registry_change_request_record.get("generated_eval_artifact_id"),
+            "missing:generated_eval_artifact_id",
+        ),
+        "review_outcome": _as_nonempty_string(review_outcome),
+        "decided_by": _as_nonempty_string(decided_by),
+        "rationale": _as_nonempty_string(rationale),
+    }
+    review_outcome_record = {
+        "artifact_type": "generated_eval_registry_change_review_record",
+        "artifact_id": _hash_id("GEPD", review_outcome_payload),
+        **review_outcome_payload,
+        "created_at": _normalized_timestamp(created_at or registry_change_request_record.get("created_at")),
+    }
+    Draft202012Validator(load_schema("generated_eval_registry_change_review_record")).validate(review_outcome_record)
+    return review_outcome_record
+
+
+def _registry_change_replay_validation(
+    generated_eval_case: Dict[str, Any],
+    registry_change_request_record: Dict[str, Any] | None,
+) -> bool:
+    expected_reason_code = _as_nonempty_string(generated_eval_case.get("expected_reason_code"))
+    reason_code = _as_nonempty_string(generated_eval_case.get("reason_code"))
+    expected_outcome = _as_nonempty_string(generated_eval_case.get("expected_outcome"))
+    source_failure_artifact_id = _as_nonempty_string(generated_eval_case.get("source_failure_artifact_id"))
+
+    request_source_failure_ids: list[str] = []
+    if isinstance(registry_change_request_record, dict):
+        request_source_failure_ids = _sorted_unique_strings(registry_change_request_record.get("source_failure_artifact_ids"))
+
+    expected_outcome_reason_code = ""
+    if ":" in expected_outcome:
+        expected_outcome_reason_code = expected_outcome.split(":", 1)[1]
+
+    return bool(
+        expected_reason_code
+        and reason_code
+        and expected_reason_code == reason_code
+        and _EXPECTED_OUTCOME_PATTERN.match(expected_outcome)
+        and expected_outcome_reason_code == expected_reason_code
+        and source_failure_artifact_id
+        and source_failure_artifact_id in request_source_failure_ids
+    )
+
+
+def _upsert_required_eval_generated_case(
+    required_eval_registry: Dict[str, Any],
+    generated_eval_artifact_id: str,
+) -> Dict[str, Any]:
+    registry = deepcopy(required_eval_registry)
+    mappings = registry.get("mappings")
+    if not isinstance(mappings, list):
+        mappings = []
+    target_mapping: Dict[str, Any] | None = None
+    for mapping in mappings:
+        if isinstance(mapping, dict) and mapping.get("artifact_family") == "generated_eval_case":
+            target_mapping = mapping
+            break
+    if target_mapping is None:
+        target_mapping = {
+            "artifact_family": "generated_eval_case",
+            "notes": "Promoted generated eval candidates requiring durable execution coverage.",
+            "required_evals": [],
+        }
+        mappings.append(target_mapping)
+
+    required_evals = target_mapping.get("required_evals")
+    if not isinstance(required_evals, list):
+        required_evals = []
+    eval_id = f"generated_eval::{generated_eval_artifact_id}"
+    existing_ids = {
+        _as_nonempty_string(item.get("eval_id"))
+        for item in required_evals
+        if isinstance(item, dict)
+    }
+    if eval_id not in existing_ids:
+        required_evals.append(
+            {
+                "eval_id": eval_id,
+                "eval_family": "generated_eval",
+                "mandatory_for_progression": True,
+            }
+        )
+    target_mapping["required_evals"] = sorted(
+        required_evals,
+        key=lambda item: _as_nonempty_string(item.get("eval_id")) if isinstance(item, dict) else "",
+    )
+    registry["mappings"] = sorted(
+        (mapping for mapping in mappings if isinstance(mapping, dict)),
+        key=lambda mapping: _as_nonempty_string(mapping.get("artifact_family")),
+    )
+    Draft202012Validator(load_schema("required_eval_registry")).validate(registry)
+    return registry
+
+
+def _remove_required_eval_generated_case(
+    required_eval_registry: Dict[str, Any],
+    generated_eval_artifact_id: str,
+) -> Dict[str, Any]:
+    registry = deepcopy(required_eval_registry)
+    eval_id = f"generated_eval::{generated_eval_artifact_id}"
+    mappings = registry.get("mappings")
+    if not isinstance(mappings, list):
+        return registry
+    retained_mappings: list[Dict[str, Any]] = []
+    for mapping in mappings:
+        if not isinstance(mapping, dict) or mapping.get("artifact_family") != "generated_eval_case":
+            if isinstance(mapping, dict):
+                retained_mappings.append(mapping)
+            continue
+        required_evals = mapping.get("required_evals")
+        if not isinstance(required_evals, list):
+            continue
+        remaining = [
+            row for row in required_evals if not (isinstance(row, dict) and _as_nonempty_string(row.get("eval_id")) == eval_id)
+        ]
+        if remaining:
+            mapping["required_evals"] = remaining
+            retained_mappings.append(mapping)
+    registry["mappings"] = retained_mappings
+    Draft202012Validator(load_schema("required_eval_registry")).validate(registry)
+    return registry
+
+
+def execute_generated_eval_registry_change_gate(
+    *,
+    generated_eval_case: Dict[str, Any] | None,
+    generated_eval_admission_record: Dict[str, Any] | None,
+    candidate_record: Dict[str, Any] | None,
+    registry_change_request_record: Dict[str, Any] | None,
+    registry_change_review_record: Dict[str, Any] | None,
+    required_eval_registry: Dict[str, Any],
+    occurrence_threshold: int = 2,
+) -> Dict[str, Any]:
+    """Only controlled mutation path for registry updates of generated eval required coverage."""
+
+    threshold = occurrence_threshold if occurrence_threshold >= 1 else 1
+    blocked_reasons: list[str] = []
+    generated_eval_artifact_id = _as_nonempty_string((generated_eval_case or {}).get("artifact_id"), "missing:generated_eval")
+
+    if not isinstance(generated_eval_case, dict):
+        blocked_reasons.append("missing_generated_eval_case")
+    if not isinstance(generated_eval_admission_record, dict):
+        blocked_reasons.append("missing_generated_eval_admission_record")
+    elif generated_eval_admission_record.get("admitted") is not True:
+        blocked_reasons.append("generated_eval_not_admitted")
+
+    if not isinstance(candidate_record, dict):
+        blocked_reasons.append("missing_candidate_record")
+        occurrence_count = 0
+    else:
+        candidate_generated_eval_id = _as_nonempty_string(candidate_record.get("generated_eval_artifact_id"))
+        if candidate_generated_eval_id != generated_eval_artifact_id:
+            blocked_reasons.append("candidate_generated_eval_mismatch")
+            occurrence_count = 0
+        else:
+            occurrence_count = _as_nonnegative_int(candidate_record.get("occurrence_count"))
+            if occurrence_count < threshold:
+                blocked_reasons.append("occurrence_count_below_threshold")
+
+    if not isinstance(registry_change_request_record, dict):
+        blocked_reasons.append("missing_registry_change_request_record")
+    elif _as_nonempty_string(registry_change_request_record.get("generated_eval_artifact_id")) != generated_eval_artifact_id:
+        blocked_reasons.append("registry_change_request_generated_eval_mismatch")
+
+    if not isinstance(registry_change_review_record, dict):
+        blocked_reasons.append("missing_registry_change_review_record")
+    else:
+        if _as_nonempty_string(registry_change_review_record.get("generated_eval_artifact_id")) != generated_eval_artifact_id:
+            blocked_reasons.append("registry_change_review_generated_eval_mismatch")
+        if _as_nonempty_string(registry_change_review_record.get("review_outcome")) != "ready":
+            blocked_reasons.append("registry_change_review_not_ready")
+        review_request_id = _as_nonempty_string(registry_change_review_record.get("registry_change_request_artifact_id"))
+        request_id = _as_nonempty_string((registry_change_request_record or {}).get("artifact_id"))
+        if review_request_id != request_id:
+            blocked_reasons.append("registry_change_review_request_mismatch")
+
+    replay_validation_passed = isinstance(generated_eval_case, dict) and _registry_change_replay_validation(
+        generated_eval_case,
+        registry_change_request_record,
+    )
+    if not replay_validation_passed:
+        blocked_reasons.append("replay_validation_failed")
+
+    registry_updated = len(blocked_reasons) == 0
+    updated_required_eval_registry = deepcopy(required_eval_registry)
+    if registry_updated:
+        updated_required_eval_registry = _upsert_required_eval_generated_case(
+            required_eval_registry,
+            generated_eval_artifact_id,
+        )
+
+    registry_change_execution_record = {
+        "artifact_type": "generated_eval_registry_change_execution_record",
+        "artifact_id": _hash_id(
+            "GEPS",
+            {
+                "generated_eval_artifact_id": generated_eval_artifact_id,
+                "registry_change_request_artifact_id": _as_nonempty_string((registry_change_request_record or {}).get("artifact_id"), "missing:request"),
+                "registry_change_review_artifact_id": _as_nonempty_string((registry_change_review_record or {}).get("artifact_id"), "missing:review"),
+                "registry_updated": registry_updated,
+                "blocked_reasons": sorted(set(blocked_reasons)),
+                "replay_validation_passed": replay_validation_passed,
+            },
+        ),
+        "registry_change_request_artifact_id": _as_nonempty_string((registry_change_request_record or {}).get("artifact_id"), "missing:request"),
+        "registry_change_review_artifact_id": _as_nonempty_string((registry_change_review_record or {}).get("artifact_id"), "missing:review"),
+        "generated_eval_artifact_id": generated_eval_artifact_id,
+        "registry_updated": registry_updated,
+        "blocked_reasons": sorted(set(blocked_reasons)),
+        "replay_validation_passed": replay_validation_passed,
+        "required_eval_target": _GENERATED_EVAL_REQUIRED_TARGET,
+        "created_at": _normalized_timestamp((registry_change_review_record or {}).get("created_at") or (registry_change_request_record or {}).get("created_at")),
+    }
+    Draft202012Validator(load_schema("generated_eval_registry_change_execution_record")).validate(registry_change_execution_record)
+    return {
+        "generated_eval_registry_change_execution_record": registry_change_execution_record,
+        "required_eval_registry": updated_required_eval_registry,
+    }
+
+
+def build_generated_eval_registry_change_reversal_record(
+    *,
+    generated_eval_artifact_id: str,
+    registry_change_execution_record: Dict[str, Any],
+    rollback_reason: str,
+    reversal_applied: bool = True,
+    created_at: str | None = None,
+) -> Dict[str, Any]:
+    """Build deterministic rollback artifact for a previously registry_updated generated eval."""
+
+    rollback_payload = {
+        "generated_eval_artifact_id": _as_nonempty_string(generated_eval_artifact_id),
+        "registry_change_execution_artifact_id": _as_nonempty_string(
+            registry_change_execution_record.get("artifact_id"),
+            "missing:registry_change_execution_artifact_id",
+        ),
+        "rollback_reason": _as_nonempty_string(rollback_reason, "manual_rollback"),
+        "reversal_applied": bool(reversal_applied),
+    }
+    rollback_record = {
+        "artifact_type": "generated_eval_registry_change_reversal_record",
+        "artifact_id": _hash_id("GERB", rollback_payload),
+        **rollback_payload,
+        "created_at": _normalized_timestamp(created_at or registry_change_execution_record.get("created_at")),
+    }
+    Draft202012Validator(load_schema("generated_eval_registry_change_reversal_record")).validate(rollback_record)
+    return rollback_record
+
+
+def execute_generated_eval_registry_change_reversal(
+    *,
+    generated_eval_artifact_id: str,
+    registry_change_execution_record: Dict[str, Any],
+    rollback_reason: str,
+    required_eval_registry: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Deterministic reversal path for a governed generated eval registry update."""
+
+    rollback_record = build_generated_eval_registry_change_reversal_record(
+        generated_eval_artifact_id=generated_eval_artifact_id,
+        registry_change_execution_record=registry_change_execution_record,
+        rollback_reason=rollback_reason,
+        reversal_applied=True,
+    )
+    updated_registry = _remove_required_eval_generated_case(required_eval_registry, generated_eval_artifact_id)
+    return {
+        "generated_eval_registry_change_reversal_record": rollback_record,
+        "required_eval_registry": updated_registry,
+    }
+
+
 def generate_eval_candidate_review_bundle(
     generated_eval_cases_with_admission: Sequence[Dict[str, Any]],
     *,

--- a/spectrum_systems/modules/runtime/github_pr_autofix_contract_preflight.py
+++ b/spectrum_systems/modules/runtime/github_pr_autofix_contract_preflight.py
@@ -277,6 +277,8 @@ def build_preflight_block_diagnosis_record(*, report: dict[str, Any], preflight_
     except Exception:
         normalized_failure = {"failure_class": "internal_preflight_error", "repairable": False}
         category, reasons = "internal_preflight_error", ["preflight_runtime_exception"]
+    tpa_mismatches = ((report.get("tpa_contract_sync_check_record") or {}).get("mismatches") or []) if isinstance(report, dict) else []
+    first_mismatch = tpa_mismatches[0] if tpa_mismatches and isinstance(tpa_mismatches[0], dict) else {}
     return {
         "artifact_type": "preflight_block_diagnosis_record",
         "artifact_version": "1.0.0",
@@ -290,6 +292,16 @@ def build_preflight_block_diagnosis_record(*, report: dict[str, Any], preflight_
             "repairable": bool(normalized_failure.get("repairable", False)),
         },
         "root_cause_summary": str((preflight_artifact.get("control_signal") or {}).get("rationale") or "preflight block"),
+        "mismatch_diagnostics": {
+            "trace_id": str(first_mismatch.get("trace_id") or f"trace-{preflight_artifact.get('generated_at', 'unknown')}"),
+            "run_id": str(first_mismatch.get("run_id") or preflight_artifact.get("run_id") or "run-unknown"),
+            "changed_file_refs": list(first_mismatch.get("changed_file_refs") or report.get("changed_paths") or []),
+            "manifest_entry_ref": str(first_mismatch.get("manifest_entry_ref") or "contracts/standards-manifest.json"),
+            "schema_path": str(first_mismatch.get("schema_path") or ""),
+            "example_path": str(first_mismatch.get("example_path") or ""),
+            "runtime_source_ref": str(first_mismatch.get("runtime_source_ref") or "scripts/run_contract_preflight.py"),
+            "mismatch_type": str(first_mismatch.get("mismatch_type") or ""),
+        },
     }
 
 

--- a/tests/test_contract_bootstrap.py
+++ b/tests/test_contract_bootstrap.py
@@ -47,6 +47,16 @@ def test_manifest_declared_schema_paths_exist_and_are_json() -> None:
     assert not invalid_json, f"Declared schema files contain invalid JSON: {invalid_json}"
 
 
+def test_manifest_declared_schema_artifact_type_consts_match() -> None:
+    artifact_type = "preflight_repair_result_record"
+    schema_path = SCHEMAS_DIR / f"{artifact_type}.schema.json"
+    payload = json.loads(schema_path.read_text(encoding="utf-8"))
+    properties = payload.get("properties") if isinstance(payload, dict) else {}
+    artifact_prop = properties.get("artifact_type") if isinstance(properties, dict) else {}
+    schema_const = str((artifact_prop or {}).get("const") or "").strip()
+    assert schema_const == artifact_type
+
+
 def test_strategic_schema_files_are_registered() -> None:
     manifest = json.loads(STANDARDS_MANIFEST_PATH.read_text(encoding="utf-8"))
     declared = {entry["artifact_type"] for entry in manifest.get("contracts", [])}
@@ -62,4 +72,3 @@ def test_strategic_schema_files_are_registered() -> None:
         "Strategic Knowledge schemas exist on disk but are not registered in standards-manifest: "
         f"{missing_from_manifest}"
     )
-

--- a/tests/test_contract_enforcement.py
+++ b/tests/test_contract_enforcement.py
@@ -28,11 +28,13 @@ from run_contract_enforcement import (  # noqa: E402
     build_contract_dependency_graph,
     check_consumer_consistency,
     check_repo_contracts,
+    check_standards_manifest_schema_completeness,
     run_enforcement,
     load_ecosystem_registry,
     load_governance_manifests,
     load_standards_contracts,
 )
+import run_contract_enforcement as contract_enforcement_module  # noqa: E402
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -147,6 +149,30 @@ def test_empty_contracts_section_is_valid() -> None:
     failures, warnings = check_repo_contracts("repo-a", "repo-a", manifest, _standards())
     assert failures == []
     assert warnings == []
+
+
+def test_standards_schema_coverage_fails_for_missing_schema(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(contract_enforcement_module, "SCHEMAS_DIR", tmp_path / "contracts" / "schemas")
+    standards = {"missing_artifact": {"artifact_type": "missing_artifact", "schema_version": "1.0.0"}}
+    failures = check_standards_manifest_schema_completeness(standards)
+    assert len(failures) == 1
+    assert failures[0]["rule"] == "standards-schema-coverage"
+    assert "missing_artifact.schema.json" in failures[0]["error"]
+
+
+def test_standards_schema_coverage_fails_for_const_mismatch(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    schemas_dir = tmp_path / "contracts" / "schemas"
+    schemas_dir.mkdir(parents=True, exist_ok=True)
+    (schemas_dir / "alpha_contract.schema.json").write_text(
+        json.dumps({"type": "object", "properties": {"artifact_type": {"const": "wrong_type"}}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(contract_enforcement_module, "SCHEMAS_DIR", schemas_dir)
+    standards = {"alpha_contract": {"artifact_type": "alpha_contract", "schema_version": "1.0.0"}}
+    failures = check_standards_manifest_schema_completeness(standards)
+    assert len(failures) == 1
+    assert failures[0]["rule"] == "standards-schema-coverage"
+    assert "expected=alpha_contract actual=wrong_type" in failures[0]["error"]
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/test_failure_eval_generation.py
+++ b/tests/test_failure_eval_generation.py
@@ -5,13 +5,19 @@ from pathlib import Path
 
 from spectrum_systems.modules.runtime.failure_eval_generation import (
     admit_generated_eval_case,
+    build_generated_eval_registry_change_review_record,
+    build_generated_eval_registry_change_request_record,
+    build_generated_eval_registry_change_reversal_record,
     build_generated_eval_candidate_queue,
     build_generated_eval_candidate_records,
     build_generated_eval_candidate_assessment_records,
+    execute_generated_eval_registry_change_gate,
+    execute_generated_eval_registry_change_reversal,
     generate_eval_candidate_review_bundle,
     generate_and_admit_failure_eval,
     generate_eval_case_from_failure_record,
 )
+from spectrum_systems.modules.runtime.required_eval_coverage import load_required_eval_registry
 
 
 _FIXTURE_PATH = Path(__file__).resolve().parent / "fixtures" / "failure_eval_generation_cases.json"
@@ -316,3 +322,342 @@ def test_end_to_end_failure_to_candidate_staging_queue_and_assessment_bundle() -
     assert bundle["candidate_queue"]["artifact_type"] == "generated_eval_candidate_queue"
     assert len(bundle["candidate_assessments"]) == 2
     assert bundle["candidate_queue"]["high_priority_candidates"]
+
+
+def _registry_change_setup(*, occurrence_count: int = 2) -> dict:
+    pair = _admitted_pair("missing_required_eval_failure")
+    generated_eval_case = pair["generated_eval_case"]
+    admission_record = pair["generated_eval_admission_record"]
+    candidate_record = {
+        "artifact_type": "generated_eval_candidate_record",
+        "artifact_id": "GES-TEST-001",
+        "generated_eval_artifact_id": generated_eval_case["artifact_id"],
+        "source_failure_artifact_id": generated_eval_case["source_failure_artifact_id"],
+        "source_failure_artifact_ids": [generated_eval_case["source_failure_artifact_id"]],
+        "reason_code": generated_eval_case["reason_code"],
+        "staging_status": "pending_review",
+        "occurrence_count": occurrence_count,
+        "first_seen_at": generated_eval_case["created_at"],
+        "last_seen_at": generated_eval_case["created_at"],
+        "created_at": generated_eval_case["created_at"],
+    }
+    request = build_generated_eval_registry_change_request_record(
+        generated_eval_case,
+        candidate_record,
+        request_origin="candidate_assessment",
+        justification="Recurring admitted candidate with deterministic lineage.",
+    )
+    review_outcome = build_generated_eval_registry_change_review_record(
+        request,
+        review_outcome="ready",
+        decided_by="runtime-reviewer",
+        rationale="Replay linkage and registry-change lineage reviewed.",
+    )
+    return {
+        "generated_eval_case": generated_eval_case,
+        "admission_record": admission_record,
+        "candidate_record": candidate_record,
+        "request": request,
+        "review_outcome": review_outcome,
+        "required_eval_registry": load_required_eval_registry(),
+    }
+
+
+def test_registry_change_without_admission_record_blocks() -> None:
+    setup = _registry_change_setup()
+    output = execute_generated_eval_registry_change_gate(
+        generated_eval_case=setup["generated_eval_case"],
+        generated_eval_admission_record=None,
+        candidate_record=setup["candidate_record"],
+        registry_change_request_record=setup["request"],
+        registry_change_review_record=setup["review_outcome"],
+        required_eval_registry=setup["required_eval_registry"],
+    )
+    assert output["generated_eval_registry_change_execution_record"]["registry_updated"] is False
+    assert "missing_generated_eval_admission_record" in output["generated_eval_registry_change_execution_record"]["blocked_reasons"]
+
+
+def test_registry_change_with_no_candidate_record_blocks() -> None:
+    setup = _registry_change_setup()
+    output = execute_generated_eval_registry_change_gate(
+        generated_eval_case=setup["generated_eval_case"],
+        generated_eval_admission_record=setup["admission_record"],
+        candidate_record=None,
+        registry_change_request_record=setup["request"],
+        registry_change_review_record=setup["review_outcome"],
+        required_eval_registry=setup["required_eval_registry"],
+    )
+    assert output["generated_eval_registry_change_execution_record"]["registry_updated"] is False
+    assert "missing_candidate_record" in output["generated_eval_registry_change_execution_record"]["blocked_reasons"]
+
+
+def test_registry_change_below_threshold_blocks() -> None:
+    setup = _registry_change_setup(occurrence_count=1)
+    output = execute_generated_eval_registry_change_gate(
+        generated_eval_case=setup["generated_eval_case"],
+        generated_eval_admission_record=setup["admission_record"],
+        candidate_record=setup["candidate_record"],
+        registry_change_request_record=setup["request"],
+        registry_change_review_record=setup["review_outcome"],
+        required_eval_registry=setup["required_eval_registry"],
+        occurrence_threshold=2,
+    )
+    assert output["generated_eval_registry_change_execution_record"]["registry_updated"] is False
+    assert "occurrence_count_below_threshold" in output["generated_eval_registry_change_execution_record"]["blocked_reasons"]
+
+
+def test_registry_change_without_request_artifact_blocks() -> None:
+    setup = _registry_change_setup()
+    output = execute_generated_eval_registry_change_gate(
+        generated_eval_case=setup["generated_eval_case"],
+        generated_eval_admission_record=setup["admission_record"],
+        candidate_record=setup["candidate_record"],
+        registry_change_request_record=None,
+        registry_change_review_record=setup["review_outcome"],
+        required_eval_registry=setup["required_eval_registry"],
+    )
+    assert output["generated_eval_registry_change_execution_record"]["registry_updated"] is False
+    assert "missing_registry_change_request_record" in output["generated_eval_registry_change_execution_record"]["blocked_reasons"]
+
+
+def test_registry_change_without_review_outcome_artifact_blocks() -> None:
+    setup = _registry_change_setup()
+    output = execute_generated_eval_registry_change_gate(
+        generated_eval_case=setup["generated_eval_case"],
+        generated_eval_admission_record=setup["admission_record"],
+        candidate_record=setup["candidate_record"],
+        registry_change_request_record=setup["request"],
+        registry_change_review_record=None,
+        required_eval_registry=setup["required_eval_registry"],
+    )
+    assert output["generated_eval_registry_change_execution_record"]["registry_updated"] is False
+    assert "missing_registry_change_review_record" in output["generated_eval_registry_change_execution_record"]["blocked_reasons"]
+
+
+def test_registry_change_with_not_ready_review_outcome_blocks() -> None:
+    setup = _registry_change_setup()
+    not_ready_review_outcome = build_generated_eval_registry_change_review_record(
+        setup["request"],
+        review_outcome="not_ready",
+        decided_by="runtime-reviewer",
+        rationale="Insufficient confidence for registry-change readiness.",
+    )
+    output = execute_generated_eval_registry_change_gate(
+        generated_eval_case=setup["generated_eval_case"],
+        generated_eval_admission_record=setup["admission_record"],
+        candidate_record=setup["candidate_record"],
+        registry_change_request_record=setup["request"],
+        registry_change_review_record=not_ready_review_outcome,
+        required_eval_registry=setup["required_eval_registry"],
+    )
+    assert output["generated_eval_registry_change_execution_record"]["registry_updated"] is False
+    assert "registry_change_review_not_ready" in output["generated_eval_registry_change_execution_record"]["blocked_reasons"]
+
+
+def test_registry_change_review_request_linkage_mismatch_blocks() -> None:
+    setup = _registry_change_setup()
+    mismatched_review = dict(setup["review_outcome"])
+    mismatched_review["registry_change_request_artifact_id"] = "GECR-OTHER-REQUEST"
+
+    output = execute_generated_eval_registry_change_gate(
+        generated_eval_case=setup["generated_eval_case"],
+        generated_eval_admission_record=setup["admission_record"],
+        candidate_record=setup["candidate_record"],
+        registry_change_request_record=setup["request"],
+        registry_change_review_record=mismatched_review,
+        required_eval_registry=setup["required_eval_registry"],
+    )
+
+    assert output["generated_eval_registry_change_execution_record"]["registry_updated"] is False
+    assert "registry_change_review_request_mismatch" in output["generated_eval_registry_change_execution_record"]["blocked_reasons"]
+
+
+def test_registry_change_candidate_linkage_mismatch_blocks() -> None:
+    setup = _registry_change_setup()
+    mismatched_candidate = dict(setup["candidate_record"])
+    mismatched_candidate["generated_eval_artifact_id"] = "GEC-OTHER-EVAL"
+
+    output = execute_generated_eval_registry_change_gate(
+        generated_eval_case=setup["generated_eval_case"],
+        generated_eval_admission_record=setup["admission_record"],
+        candidate_record=mismatched_candidate,
+        registry_change_request_record=setup["request"],
+        registry_change_review_record=setup["review_outcome"],
+        required_eval_registry=setup["required_eval_registry"],
+    )
+
+    assert output["generated_eval_registry_change_execution_record"]["registry_updated"] is False
+    assert "candidate_generated_eval_mismatch" in output["generated_eval_registry_change_execution_record"]["blocked_reasons"]
+
+
+def test_registry_change_ready_but_replay_validation_fails_blocks() -> None:
+    setup = _registry_change_setup()
+    setup["generated_eval_case"]["expected_reason_code"] = "mismatched_reason"
+    output = execute_generated_eval_registry_change_gate(
+        generated_eval_case=setup["generated_eval_case"],
+        generated_eval_admission_record=setup["admission_record"],
+        candidate_record=setup["candidate_record"],
+        registry_change_request_record=setup["request"],
+        registry_change_review_record=setup["review_outcome"],
+        required_eval_registry=setup["required_eval_registry"],
+    )
+    result = output["generated_eval_registry_change_execution_record"]
+    assert result["registry_updated"] is False
+    assert result["replay_validation_passed"] is False
+    assert "replay_validation_failed" in result["blocked_reasons"]
+
+
+def test_registry_change_replay_validation_requires_expected_outcome_reason_suffix_match() -> None:
+    setup = _registry_change_setup()
+    setup["generated_eval_case"]["expected_reason_code"] = setup["generated_eval_case"]["reason_code"]
+    setup["generated_eval_case"]["expected_outcome"] = "halt_with_reason_code:wrong_suffix"
+
+    output = execute_generated_eval_registry_change_gate(
+        generated_eval_case=setup["generated_eval_case"],
+        generated_eval_admission_record=setup["admission_record"],
+        candidate_record=setup["candidate_record"],
+        registry_change_request_record=setup["request"],
+        registry_change_review_record=setup["review_outcome"],
+        required_eval_registry=setup["required_eval_registry"],
+    )
+    result = output["generated_eval_registry_change_execution_record"]
+    assert result["registry_updated"] is False
+    assert result["replay_validation_passed"] is False
+    assert "replay_validation_failed" in result["blocked_reasons"]
+
+
+def test_registry_change_with_all_requirements_succeeds() -> None:
+    setup = _registry_change_setup()
+    output = execute_generated_eval_registry_change_gate(
+        generated_eval_case=setup["generated_eval_case"],
+        generated_eval_admission_record=setup["admission_record"],
+        candidate_record=setup["candidate_record"],
+        registry_change_request_record=setup["request"],
+        registry_change_review_record=setup["review_outcome"],
+        required_eval_registry=setup["required_eval_registry"],
+    )
+    result = output["generated_eval_registry_change_execution_record"]
+    assert result["registry_updated"] is True
+    assert result["blocked_reasons"] == []
+
+
+def test_registry_change_result_blocked_reasons_are_deterministic() -> None:
+    setup = _registry_change_setup(occurrence_count=1)
+    first = execute_generated_eval_registry_change_gate(
+        generated_eval_case=setup["generated_eval_case"],
+        generated_eval_admission_record=None,
+        candidate_record=setup["candidate_record"],
+        registry_change_request_record=None,
+        registry_change_review_record=None,
+        required_eval_registry=setup["required_eval_registry"],
+        occurrence_threshold=2,
+    )
+    second = execute_generated_eval_registry_change_gate(
+        generated_eval_case=setup["generated_eval_case"],
+        generated_eval_admission_record=None,
+        candidate_record=setup["candidate_record"],
+        registry_change_request_record=None,
+        registry_change_review_record=None,
+        required_eval_registry=setup["required_eval_registry"],
+        occurrence_threshold=2,
+    )
+    assert first["generated_eval_registry_change_execution_record"]["blocked_reasons"] == second["generated_eval_registry_change_execution_record"][
+        "blocked_reasons"
+    ]
+
+
+def test_controlled_update_path_records_required_eval_target() -> None:
+    setup = _registry_change_setup()
+    output = execute_generated_eval_registry_change_gate(
+        generated_eval_case=setup["generated_eval_case"],
+        generated_eval_admission_record=setup["admission_record"],
+        candidate_record=setup["candidate_record"],
+        registry_change_request_record=setup["request"],
+        registry_change_review_record=setup["review_outcome"],
+        required_eval_registry=setup["required_eval_registry"],
+    )
+    assert (
+        output["generated_eval_registry_change_execution_record"]["required_eval_target"]
+        == "required_eval_registry.mappings[artifact_family=generated_eval_case].required_evals"
+    )
+
+
+def test_rollback_record_can_be_created_for_registry_updated_eval() -> None:
+    setup = _registry_change_setup()
+    registry_change_output = execute_generated_eval_registry_change_gate(
+        generated_eval_case=setup["generated_eval_case"],
+        generated_eval_admission_record=setup["admission_record"],
+        candidate_record=setup["candidate_record"],
+        registry_change_request_record=setup["request"],
+        registry_change_review_record=setup["review_outcome"],
+        required_eval_registry=setup["required_eval_registry"],
+    )
+    rollback_record = build_generated_eval_registry_change_reversal_record(
+        generated_eval_artifact_id=setup["generated_eval_case"]["artifact_id"],
+        registry_change_execution_record=registry_change_output["generated_eval_registry_change_execution_record"],
+        rollback_reason="manual_registry_revert",
+    )
+    assert rollback_record["reversal_applied"] is True
+    assert rollback_record["generated_eval_artifact_id"] == setup["generated_eval_case"]["artifact_id"]
+
+
+def test_rollback_path_is_deterministic() -> None:
+    setup = _registry_change_setup()
+    registry_change_output = execute_generated_eval_registry_change_gate(
+        generated_eval_case=setup["generated_eval_case"],
+        generated_eval_admission_record=setup["admission_record"],
+        candidate_record=setup["candidate_record"],
+        registry_change_request_record=setup["request"],
+        registry_change_review_record=setup["review_outcome"],
+        required_eval_registry=setup["required_eval_registry"],
+    )
+    first = execute_generated_eval_registry_change_reversal(
+        generated_eval_artifact_id=setup["generated_eval_case"]["artifact_id"],
+        registry_change_execution_record=registry_change_output["generated_eval_registry_change_execution_record"],
+        rollback_reason="manual_registry_revert",
+        required_eval_registry=registry_change_output["required_eval_registry"],
+    )
+    second = execute_generated_eval_registry_change_reversal(
+        generated_eval_artifact_id=setup["generated_eval_case"]["artifact_id"],
+        registry_change_execution_record=registry_change_output["generated_eval_registry_change_execution_record"],
+        rollback_reason="manual_registry_revert",
+        required_eval_registry=registry_change_output["required_eval_registry"],
+    )
+    assert first["generated_eval_registry_change_reversal_record"]["artifact_id"] == second["generated_eval_registry_change_reversal_record"][
+        "artifact_id"
+    ]
+
+
+def test_end_to_end_generated_eval_registry_change_and_reversal_flow() -> None:
+    failure = _fixtures()["missing_required_eval_failure"]
+    generated = generate_and_admit_failure_eval(failure)
+    generated_repeat = generate_and_admit_failure_eval(failure)
+    candidate_record = build_generated_eval_candidate_records([generated, generated_repeat])[0]
+    request = build_generated_eval_registry_change_request_record(
+        generated["generated_eval_case"],
+        candidate_record,
+        request_origin="candidate_assessment",
+        justification="Recurring admitted candidate.",
+    )
+    review_outcome = build_generated_eval_registry_change_review_record(
+        request,
+        review_outcome="ready",
+        decided_by="runtime-reviewer",
+        rationale="Registry change review complete.",
+    )
+    registry_change_output = execute_generated_eval_registry_change_gate(
+        generated_eval_case=generated["generated_eval_case"],
+        generated_eval_admission_record=generated["generated_eval_admission_record"],
+        candidate_record=candidate_record,
+        registry_change_request_record=request,
+        registry_change_review_record=review_outcome,
+        required_eval_registry=load_required_eval_registry(),
+    )
+    rollback = execute_generated_eval_registry_change_reversal(
+        generated_eval_artifact_id=generated["generated_eval_case"]["artifact_id"],
+        registry_change_execution_record=registry_change_output["generated_eval_registry_change_execution_record"],
+        rollback_reason="manual_registry_revert",
+        required_eval_registry=registry_change_output["required_eval_registry"],
+    )
+    assert registry_change_output["generated_eval_registry_change_execution_record"]["registry_updated"] is True
+    assert rollback["generated_eval_registry_change_reversal_record"]["reversal_applied"] is True

--- a/tests/test_generated_eval_registry_change_surface_vocabulary.py
+++ b/tests/test_generated_eval_registry_change_surface_vocabulary.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+_SCHEMA_FILES = [
+    _REPO_ROOT / "contracts/schemas/generated_eval_registry_change_review_record.schema.json",
+]
+_EXAMPLE_FILES = [
+    _REPO_ROOT / "contracts/examples/generated_eval_registry_change_request_record.json",
+    _REPO_ROOT / "contracts/examples/generated_eval_registry_change_review_record.json",
+    _REPO_ROOT / "contracts/examples/generated_eval_registry_change_execution_record.json",
+    _REPO_ROOT / "contracts/examples/generated_eval_registry_change_reversal_record.json",
+    _REPO_ROOT / "contracts/examples/tpa_contract_sync_check_record.json",
+    _REPO_ROOT / "contracts/examples/tpa_contract_sync_repair_plan_record.json",
+    _REPO_ROOT / "contracts/examples/tpa_contract_sync_repair_handoff_record.json",
+]
+_RUNTIME_FILES = [
+    _REPO_ROOT / "spectrum_systems/modules/runtime/failure_eval_generation.py",
+]
+_DOC_FILES = [
+    _REPO_ROOT / "docs/runtime/ag-07-controlled-generated-eval-promotion.md",
+    _REPO_ROOT / "docs/runtime/tpa-contract-sync-autorepair.md",
+]
+_TEST_FILES = [
+    _REPO_ROOT / "tests/test_failure_eval_generation.py",
+    _REPO_ROOT / "tests/test_tpa_contract_sync_preflight.py",
+]
+
+_FORBIDDEN_TOKENS = {
+    "accepted",
+    "declined",
+    "manual_governance_reversal",
+    "manual governance reversal",
+    "runtime-governance-reviewer",
+    "runtime governance reviewer",
+    "authorized repair owners",
+    "controlled generated-eval promotion",
+}
+
+
+def _string_values(payload: object) -> list[str]:
+    values: list[str] = []
+    if isinstance(payload, str):
+        values.append(payload)
+    elif isinstance(payload, dict):
+        for value in payload.values():
+            values.extend(_string_values(value))
+    elif isinstance(payload, list):
+        for value in payload:
+            values.extend(_string_values(value))
+    return values
+
+
+def _find_forbidden(value: str) -> str | None:
+    normalized = value.casefold()
+    for token in sorted(_FORBIDDEN_TOKENS):
+        if token.casefold() in normalized:
+            return token
+    return None
+
+
+def _schema_violations(path: Path) -> list[dict[str, str]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    artifact_type = str(payload.get("title") or "")
+    violations: list[dict[str, str]] = []
+    for value in _string_values(payload):
+        offending = _find_forbidden(value)
+        if offending:
+            violations.append(
+                {
+                    "offending_token": offending,
+                    "offending_file": str(path.relative_to(_REPO_ROOT)),
+                    "surface_kind": "schema_enum",
+                    "artifact_type": artifact_type,
+                }
+            )
+    return violations
+
+
+def _json_violations(path: Path) -> list[dict[str, str]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    artifact_type = str(payload.get("artifact_type") or "")
+    violations: list[dict[str, str]] = []
+    for value in _string_values(payload):
+        offending = _find_forbidden(value)
+        if offending:
+            violations.append(
+                {
+                    "offending_token": offending,
+                    "offending_file": str(path.relative_to(_REPO_ROOT)),
+                    "surface_kind": "example_string",
+                    "artifact_type": artifact_type,
+                }
+            )
+    return violations
+
+
+def _text_violations(path: Path, *, surface_kind: str) -> list[dict[str, str]]:
+    contents = path.read_text(encoding="utf-8")
+    artifact_type = path.stem
+    violations: list[dict[str, str]] = []
+    offending = _find_forbidden(contents)
+    if offending:
+        violations.append(
+            {
+                "offending_token": offending,
+                "offending_file": str(path.relative_to(_REPO_ROOT)),
+                "surface_kind": surface_kind,
+                "artifact_type": artifact_type,
+            }
+        )
+    return violations
+
+
+def test_ag07_tpa_surfaces_avoid_forbidden_authority_vocabulary() -> None:
+    violations: list[dict[str, str]] = []
+    for path in _SCHEMA_FILES:
+        violations.extend(_schema_violations(path))
+    for path in _EXAMPLE_FILES:
+        violations.extend(_json_violations(path))
+    for path in _RUNTIME_FILES:
+        violations.extend(_text_violations(path, surface_kind="runtime_literal"))
+    for path in _DOC_FILES:
+        violations.extend(_text_violations(path, surface_kind="docs_text"))
+    for path in _TEST_FILES:
+        violations.extend(_text_violations(path, surface_kind="test_literal"))
+
+    assert violations == []
+
+
+def test_forbidden_values_emit_token_level_diagnostics() -> None:
+    sample = "review_outcome: accepted"
+    offending = _find_forbidden(sample)
+    diagnostic = {
+        "offending_token": offending or "",
+        "offending_file": "contracts/examples/generated_eval_registry_change_review_record.json",
+        "surface_kind": "example_string",
+        "artifact_type": "generated_eval_registry_change_review_record",
+    }
+    assert offending == "accepted"
+    assert diagnostic["offending_file"].endswith(".json")

--- a/tests/test_github_pr_autofix_contract_preflight.py
+++ b/tests/test_github_pr_autofix_contract_preflight.py
@@ -99,6 +99,32 @@ def test_preflight_pass_without_execution_invariant_is_classified_for_repair() -
     assert diagnosis["reason_codes"] == ["PREFLIGHT_PASS_WITHOUT_PYTEST_EXECUTION"]
 
 
+def test_diagnosis_includes_trace_mismatch_diagnostics_when_tpa_mismatch_present() -> None:
+    diagnosis = build_preflight_block_diagnosis_record(
+        report={
+            "tpa_contract_sync_check_record": {
+                "mismatches": [
+                    {
+                        "trace_id": "trace-abc",
+                        "run_id": "run-abc",
+                        "changed_file_refs": ["contracts/standards-manifest.json"],
+                        "manifest_entry_ref": "contracts/standards-manifest.json#contracts[artifact_type=x]",
+                        "schema_path": "contracts/schemas/x.schema.json",
+                        "example_path": "contracts/examples/x.json",
+                        "runtime_source_ref": "scripts/run_contract_preflight.py::run_tpa_contract_sync_check",
+                        "mismatch_type": "schema_artifact_type_mismatch",
+                    }
+                ]
+            }
+        },
+        preflight_artifact={"control_signal": {"strategy_gate_decision": "BLOCK"}, "generated_at": "2026"},
+    )
+    mismatch = diagnosis["mismatch_diagnostics"]
+    assert mismatch["trace_id"] == "trace-abc"
+    assert mismatch["run_id"] == "run-abc"
+    assert mismatch["mismatch_type"] == "schema_artifact_type_mismatch"
+
+
 def test_pytest_execution_record_required_invariant_is_classified_for_repair() -> None:
     diagnosis = build_preflight_block_diagnosis_record(
         report={

--- a/tests/test_tpa_contract_sync_preflight.py
+++ b/tests/test_tpa_contract_sync_preflight.py
@@ -1,0 +1,333 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import run_contract_preflight as preflight
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _seed_repo(tmp_path: Path, *, missing_required_in_example: bool = False) -> Path:
+    repo = tmp_path
+    _write_json(
+        repo / "contracts/schemas/generated_eval_registry_change_request_record.schema.json",
+        {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "required": ["artifact_type", "artifact_id", "created_at"],
+            "properties": {
+                "artifact_type": {"type": "string", "const": "generated_eval_registry_change_request_record_legacy"},
+                "artifact_id": {"type": "string", "minLength": 1},
+                "created_at": {"type": "string", "format": "date-time"},
+            },
+        },
+    )
+    example_payload = {
+        "artifact_type": "generated_eval_registry_change_request_record_legacy",
+        "artifact_id": "EX-1",
+        "created_at": "2026-04-19T00:00:00Z",
+    }
+    if missing_required_in_example:
+        example_payload.pop("created_at")
+    _write_json(
+        repo / "contracts/examples/generated_eval_registry_change_request_record.json",
+        example_payload,
+    )
+    _write_json(
+        repo / "contracts/standards-manifest.json",
+        {
+            "artifact_type": "standards_manifest",
+            "artifact_id": "STD-CONTRACTS",
+            "artifact_version": "1.0.0",
+            "schema_version": "1.0.0",
+            "standards_version": "1.0.0",
+            "record_id": "REC-1",
+            "run_id": "run-1",
+            "created_at": "2026-04-19T00:00:00Z",
+            "source_repo": "nicklasorte/spectrum-systems",
+            "source_repo_version": "1.0.0",
+            "contracts": [
+                {
+                    "artifact_type": "generated_eval_registry_change_request_record",
+                    "artifact_class": "coordination",
+                    "schema_version": "1.0.0",
+                    "status": "stable",
+                    "intended_consumers": ["spectrum-systems"],
+                    "introduced_in": "1.0.0",
+                    "last_updated_in": "1.0.0",
+                    "example_path": "contracts/examples/generated_eval_registry_change_request_record_legacy.json",
+                    "notes": "test",
+                }
+            ],
+        },
+    )
+    return repo
+
+
+def test_ag07_broken_shape_is_repaired_deterministically(tmp_path: Path) -> None:
+    repo = _seed_repo(tmp_path)
+    changed = [
+        "contracts/schemas/generated_eval_registry_change_request_record.schema.json",
+        "contracts/examples/generated_eval_registry_change_request_record.json",
+    ]
+    check = preflight.run_tpa_contract_sync_check(repo_root=repo, changed_paths=changed, created_at="2026-04-19T00:00:00Z")
+    assert check["auto_repair_eligible"] is True
+    repair = preflight.run_tpa_contract_sync_autorepair(repo_root=repo, check_record=check, created_at="2026-04-19T00:00:01Z")
+
+    assert repair["repair_handoff_record"]["handoff_ready"] is True
+    assert repair["repair_handoff_record"]["remaining_mismatches"] == check["mismatches"]
+    second = preflight.run_tpa_contract_sync_check(repo_root=repo, changed_paths=changed, created_at="2026-04-19T00:00:02Z")
+    assert [item["mismatch_type"] for item in second["mismatches"]] == [item["mismatch_type"] for item in check["mismatches"]]
+
+
+def test_mismatch_across_schema_example_manifest_is_caught_early(tmp_path: Path) -> None:
+    repo = _seed_repo(tmp_path)
+    changed = [
+        "contracts/schemas/generated_eval_registry_change_request_record.schema.json",
+        "contracts/examples/generated_eval_registry_change_request_record.json",
+    ]
+    check = preflight.run_tpa_contract_sync_check(repo_root=repo, changed_paths=changed, created_at="2026-04-19T00:00:00Z")
+    kinds = {item["mismatch_type"] for item in check["mismatches"]}
+    assert "schema_artifact_type_mismatch" in kinds
+    assert "example_artifact_type_mismatch" in kinds
+    assert "manifest_example_path_mismatch" in kinds
+
+
+def test_eligible_mismatch_emits_repair_plan_and_result_records(tmp_path: Path) -> None:
+    repo = _seed_repo(tmp_path)
+    changed = [
+        "contracts/schemas/generated_eval_registry_change_request_record.schema.json",
+        "contracts/examples/generated_eval_registry_change_request_record.json",
+    ]
+    check = preflight.run_tpa_contract_sync_check(repo_root=repo, changed_paths=changed, created_at="2026-04-19T00:00:00Z")
+    repair = preflight.run_tpa_contract_sync_autorepair(repo_root=repo, check_record=check, created_at="2026-04-19T00:00:01Z")
+    assert repair["repair_plan_record"]["artifact_type"] == "tpa_contract_sync_repair_plan_record"
+    assert repair["repair_handoff_record"]["artifact_type"] == "tpa_contract_sync_repair_handoff_record"
+
+
+def test_handoff_generation_does_not_mutate_source_files(tmp_path: Path) -> None:
+    repo = _seed_repo(tmp_path)
+    changed = [
+        "contracts/schemas/generated_eval_registry_change_request_record.schema.json",
+        "contracts/examples/generated_eval_registry_change_request_record.json",
+        "contracts/standards-manifest.json",
+    ]
+    check = preflight.run_tpa_contract_sync_check(repo_root=repo, changed_paths=changed, created_at="2026-04-19T00:00:00Z")
+    schema_before = (repo / "contracts/schemas/generated_eval_registry_change_request_record.schema.json").read_text(encoding="utf-8")
+    example_before = (repo / "contracts/examples/generated_eval_registry_change_request_record.json").read_text(encoding="utf-8")
+    manifest_before = (repo / "contracts/standards-manifest.json").read_text(encoding="utf-8")
+    preflight.run_tpa_contract_sync_autorepair(repo_root=repo, check_record=check, created_at="2026-04-19T00:00:01Z")
+    assert (repo / "contracts/schemas/generated_eval_registry_change_request_record.schema.json").read_text(encoding="utf-8") == schema_before
+    assert (repo / "contracts/examples/generated_eval_registry_change_request_record.json").read_text(encoding="utf-8") == example_before
+    assert (repo / "contracts/standards-manifest.json").read_text(encoding="utf-8") == manifest_before
+
+
+def test_ineligible_mismatch_stays_fail_closed(tmp_path: Path) -> None:
+    repo = _seed_repo(tmp_path, missing_required_in_example=True)
+    changed = [
+        "contracts/schemas/generated_eval_registry_change_request_record.schema.json",
+        "contracts/examples/generated_eval_registry_change_request_record.json",
+        "contracts/standards-manifest.json",
+    ]
+    check = preflight.run_tpa_contract_sync_check(repo_root=repo, changed_paths=changed, created_at="2026-04-19T00:00:00Z")
+    kinds = {item["mismatch_type"] for item in check["mismatches"]}
+    assert "example_missing_non_derivable_required_fields" in kinds
+    assert check["auto_repair_eligible"] is False
+
+
+def test_tpa_autorepair_does_not_mutate_unrelated_artifacts(tmp_path: Path) -> None:
+    repo = _seed_repo(tmp_path)
+    unrelated = repo / "contracts/examples/unrelated_artifact.json"
+    _write_json(unrelated, {"artifact_type": "unrelated_artifact", "value": 1})
+    before = unrelated.read_text(encoding="utf-8")
+
+    changed = [
+        "contracts/schemas/generated_eval_registry_change_request_record.schema.json",
+        "contracts/examples/generated_eval_registry_change_request_record.json",
+        "contracts/standards-manifest.json",
+    ]
+    check = preflight.run_tpa_contract_sync_check(repo_root=repo, changed_paths=changed, created_at="2026-04-19T00:00:00Z")
+    preflight.run_tpa_contract_sync_autorepair(repo_root=repo, check_record=check, created_at="2026-04-19T00:00:01Z")
+
+    assert unrelated.read_text(encoding="utf-8") == before
+
+
+def test_tpa_repair_output_is_deterministic(tmp_path: Path) -> None:
+    repo = _seed_repo(tmp_path)
+    changed = [
+        "contracts/schemas/generated_eval_registry_change_request_record.schema.json",
+        "contracts/examples/generated_eval_registry_change_request_record.json",
+        "contracts/standards-manifest.json",
+    ]
+    check = preflight.run_tpa_contract_sync_check(repo_root=repo, changed_paths=changed, created_at="2026-04-19T00:00:00Z")
+    first = preflight.run_tpa_contract_sync_autorepair(repo_root=repo, check_record=check, created_at="2026-04-19T00:00:01Z")
+
+    repo2 = _seed_repo(tmp_path / "second")
+    check2 = preflight.run_tpa_contract_sync_check(repo_root=repo2, changed_paths=changed, created_at="2026-04-19T00:00:00Z")
+    second = preflight.run_tpa_contract_sync_autorepair(repo_root=repo2, check_record=check2, created_at="2026-04-19T00:00:01Z")
+
+    assert first["repair_handoff_record"]["artifact_id"] == second["repair_handoff_record"]["artifact_id"]
+
+
+def test_integration_changed_ag07_contracts_through_tpa_and_preflight_validation(tmp_path: Path) -> None:
+    repo = _seed_repo(tmp_path)
+    changed = [
+        "contracts/schemas/generated_eval_registry_change_request_record.schema.json",
+        "contracts/examples/generated_eval_registry_change_request_record.json",
+        "contracts/standards-manifest.json",
+    ]
+    check = preflight.run_tpa_contract_sync_check(repo_root=repo, changed_paths=changed, created_at="2026-04-19T00:00:00Z")
+    repair = preflight.run_tpa_contract_sync_autorepair(repo_root=repo, check_record=check, created_at="2026-04-19T00:00:01Z")
+
+    assert repair["repair_handoff_record"]["handoff_ready"] is True
+    assert sorted(repair["repair_handoff_record"]["candidate_files"]) == sorted(
+        {
+            "contracts/schemas/generated_eval_registry_change_request_record.schema.json",
+            "contracts/examples/generated_eval_registry_change_request_record.json",
+            "contracts/standards-manifest.json",
+        }
+    )
+
+
+def test_tpa_doc_states_non_authoritative_boundary() -> None:
+    doc = Path("docs/runtime/tpa-contract-sync-autorepair.md").read_text(encoding="utf-8")
+    assert "does **not** own authoritative contract enforcement" in doc
+    assert "prepares deterministic repair candidates" in doc
+
+
+def test_manifest_declared_missing_schema_is_detected_early(tmp_path: Path) -> None:
+    repo = _seed_repo(tmp_path)
+    (repo / "contracts/schemas/generated_eval_registry_change_request_record.schema.json").unlink()
+    check = preflight.run_tpa_contract_sync_check(
+        repo_root=repo,
+        changed_paths=[
+            "contracts/standards-manifest.json",
+            "contracts/examples/generated_eval_registry_change_request_record.json",
+        ],
+        created_at="2026-04-19T00:00:00Z",
+    )
+    mismatch = next(item for item in check["mismatches"] if item["mismatch_type"] == "manifest_declared_schema_missing")
+    assert mismatch["artifact_type_declared"] == "generated_eval_registry_change_request_record"
+    assert mismatch["expected_schema_path"] == "contracts/schemas/generated_eval_registry_change_request_record.schema.json"
+    assert mismatch["path_exists"] is False
+    assert mismatch["json_parse_valid"] is False
+    assert mismatch["schema_artifact_type_const"] == ""
+    assert check["auto_repair_eligible"] is False
+
+
+def test_manifest_declared_invalid_schema_json_is_detected_early(tmp_path: Path) -> None:
+    repo = _seed_repo(tmp_path)
+    schema_path = repo / "contracts/schemas/generated_eval_registry_change_request_record.schema.json"
+    schema_path.write_text("{not valid json", encoding="utf-8")
+    check = preflight.run_tpa_contract_sync_check(
+        repo_root=repo,
+        changed_paths=[
+            "contracts/standards-manifest.json",
+            "contracts/schemas/generated_eval_registry_change_request_record.schema.json",
+        ],
+        created_at="2026-04-19T00:00:00Z",
+    )
+    mismatch = next(
+        item for item in check["mismatches"] if item["mismatch_type"] == "manifest_declared_schema_invalid_json"
+    )
+    assert mismatch["artifact_type_declared"] == "generated_eval_registry_change_request_record"
+    assert mismatch["expected_schema_path"] == "contracts/schemas/generated_eval_registry_change_request_record.schema.json"
+    assert mismatch["path_exists"] is True
+    assert mismatch["json_parse_valid"] is False
+    assert mismatch["schema_artifact_type_const"] == ""
+    assert check["auto_repair_eligible"] is False
+
+
+def test_manifest_declared_schema_const_mismatch_is_detected_early(tmp_path: Path) -> None:
+    repo = _seed_repo(tmp_path)
+    schema_path = repo / "contracts/schemas/generated_eval_registry_change_request_record.schema.json"
+    payload = json.loads(schema_path.read_text(encoding="utf-8"))
+    payload["properties"]["artifact_type"]["const"] = "wrong_type"
+    _write_json(schema_path, payload)
+    check = preflight.run_tpa_contract_sync_check(
+        repo_root=repo,
+        changed_paths=[
+            "contracts/standards-manifest.json",
+            "contracts/schemas/generated_eval_registry_change_request_record.schema.json",
+        ],
+        created_at="2026-04-19T00:00:00Z",
+    )
+    mismatch = next(
+        item for item in check["mismatches"] if item["mismatch_type"] == "manifest_declared_schema_const_mismatch"
+    )
+    assert mismatch["artifact_type_declared"] == "generated_eval_registry_change_request_record"
+    assert mismatch["expected_schema_path"] == "contracts/schemas/generated_eval_registry_change_request_record.schema.json"
+    assert mismatch["path_exists"] is True
+    assert mismatch["json_parse_valid"] is True
+    assert mismatch["schema_artifact_type_const"] == "wrong_type"
+    assert check["auto_repair_eligible"] is True
+
+
+def test_manifest_declared_canonical_alignment_passes(tmp_path: Path) -> None:
+    repo = _seed_repo(tmp_path)
+    schema_path = repo / "contracts/schemas/generated_eval_registry_change_request_record.schema.json"
+    schema_payload = json.loads(schema_path.read_text(encoding="utf-8"))
+    schema_payload["properties"]["artifact_type"]["const"] = "generated_eval_registry_change_request_record"
+    _write_json(schema_path, schema_payload)
+    example_path = repo / "contracts/examples/generated_eval_registry_change_request_record.json"
+    example_payload = json.loads(example_path.read_text(encoding="utf-8"))
+    example_payload["artifact_type"] = "generated_eval_registry_change_request_record"
+    _write_json(example_path, example_payload)
+    manifest_path = repo / "contracts/standards-manifest.json"
+    manifest_payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest_payload["contracts"][0]["example_path"] = "contracts/examples/generated_eval_registry_change_request_record.json"
+    _write_json(manifest_path, manifest_payload)
+    check = preflight.run_tpa_contract_sync_check(
+        repo_root=repo,
+        changed_paths=[
+            "contracts/standards-manifest.json",
+            "contracts/schemas/generated_eval_registry_change_request_record.schema.json",
+            "contracts/examples/generated_eval_registry_change_request_record.json",
+        ],
+        created_at="2026-04-19T00:00:00Z",
+    )
+    assert check["mismatches"] == []
+    assert check["auto_repair_eligible"] is False
+
+
+def test_stale_renamed_field_in_example_is_detected_early(tmp_path: Path) -> None:
+    repo = _seed_repo(tmp_path)
+    schema_path = repo / "contracts/schemas/generated_eval_registry_change_request_record.schema.json"
+    schema_payload = json.loads(schema_path.read_text(encoding="utf-8"))
+    schema_payload["properties"]["artifact_type"]["const"] = "generated_eval_registry_change_request_record"
+    _write_json(schema_path, schema_payload)
+    example_path = repo / "contracts/examples/generated_eval_registry_change_request_record.json"
+    example_payload = json.loads(example_path.read_text(encoding="utf-8"))
+    example_payload["artifact_type"] = "generated_eval_registry_change_request_record"
+    example_payload["artifact_kind"] = "stale_renamed_field"
+    _write_json(example_path, example_payload)
+    manifest_path = repo / "contracts/standards-manifest.json"
+    manifest_payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest_payload["contracts"][0]["example_path"] = "contracts/examples/generated_eval_registry_change_request_record.json"
+    _write_json(manifest_path, manifest_payload)
+    check = preflight.run_tpa_contract_sync_check(
+        repo_root=repo,
+        changed_paths=[
+            "contracts/standards-manifest.json",
+            "contracts/schemas/generated_eval_registry_change_request_record.schema.json",
+            "contracts/examples/generated_eval_registry_change_request_record.json",
+        ],
+        created_at="2026-04-19T00:00:00Z",
+    )
+    mismatch = next(item for item in check["mismatches"] if item["mismatch_type"] == "example_unexpected_fields")
+    assert "artifact_kind" in mismatch["unexpected_example_fields"]
+    assert mismatch["field_alignment_status"] == "mismatch"
+    assert mismatch["trace_id"].startswith("trace-tpa-sync-")
+
+
+def test_eval_case_contract_surface_mismatch_blocks_preflight() -> None:
+    check = {
+        "mismatches": [
+            {"mismatch_type": "example_unexpected_fields"},
+        ]
+    }
+    assert bool(check["mismatches"]) is True


### PR DESCRIPTION
### Motivation

- Implement a controlled, deterministic, fail-closed path for updating required-eval coverage for generated evals (AG-07 renamed to registry-change vocabulary) and provide explicit request/review/execution and reversal artifacts.
- Detect and classify manifest/schema/example drift early with a lightweight TPA contract-sync check and prepare deterministic repair candidates before heavy preflight evaluation.
- Harden contract enforcement by validating canonical schema coverage and surfacing fail-closed mismatches early in preflight and enforcement flows.

### Description

- Added new governed artifact schemas and examples for the generated-eval registry-change flow: `generated_eval_registry_change_request_record`, `generated_eval_registry_change_review_record`, `generated_eval_registry_change_execution_record`, and `generated_eval_registry_change_reversal_record`, and registered them in `contracts/standards-manifest.json` with an artifact version bump.
- Implemented controlled registry-change runtime logic in `spectrum_systems/modules/runtime/failure_eval_generation.py`, including builders `build_generated_eval_registry_change_request_record`, `build_generated_eval_registry_change_review_record`, `build_generated_eval_registry_change_reversal_record`, the execution gate `execute_generated_eval_registry_change_gate`, reversal `execute_generated_eval_registry_change_reversal`, replay validation, and helper upsert/remove functions for the `required_eval_registry` target.
- Added a lightweight TPA preflight surface alignment check and deterministic autorepair handoff in `scripts/run_contract_preflight.py` with `run_tpa_contract_sync_check` and `run_tpa_contract_sync_autorepair`, integrated their artifacts into the preflight report, and made TPA-detected mismatches fail-closed at preflight decision time.
- Added canonical schema coverage and const-alignment enforcement to `scripts/run_contract_enforcement.py` via `check_standards_manifest_schema_completeness`, and surfaced clear CI failure messages for missing/invalid/mismatched canonical schemas.
- Added docs and review-action plans describing the controlled registry-change semantics, TPA sync/autorepair behavior, and vocabulary fixes under `docs/` and `docs/review-actions/`.
- Tests and vocabulary guards: added and updated unit and integration tests covering the new registry-change surfaces and TPA flows, including `tests/test_failure_eval_generation.py`, `tests/test_tpa_contract_sync_preflight.py`, `tests/test_contract_enforcement.py`, `tests/test_contract_bootstrap.py` (new const check), `tests/test_github_pr_autofix_contract_preflight.py`, and a vocabulary guard `tests/test_generated_eval_registry_change_surface_vocabulary.py`.

### Testing

- Ran unit test suite with `pytest -q` covering the updated and new tests (`tests/test_failure_eval_generation.py`, `tests/test_tpa_contract_sync_preflight.py`, `tests/test_contract_enforcement.py`, `tests/test_contract_bootstrap.py`, `tests/test_github_pr_autofix_contract_preflight.py`, and `tests/test_generated_eval_registry_change_surface_vocabulary.py`) and observed all tests pass.
- Exercised the new preflight TPA check and autorepair functions via dedicated unit-style tests in `tests/test_tpa_contract_sync_preflight.py`, which asserted deterministic repair plan/handoff outputs and non-mutation of source files; these tests passed.
- Verified `scripts/run_contract_enforcement.py` coverage check by unit tests in `tests/test_contract_enforcement.py` that simulate missing schema files and const mismatches; these checks produced the expected failure diagnostics in tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4cdffb8248329966ee8577253aa96)