### PR TITLE
AG-07-CLEAN: add governed generated-eval registry-change artifacts and fail-closed runtime path

### DIFF
--- a/contracts/examples/generated_eval_registry_change_execution_record.json
+++ b/contracts/examples/generated_eval_registry_change_execution_record.json
@@ -1,0 +1,12 @@
+{
+  "artifact_type": "generated_eval_registry_change_execution_record",
+  "artifact_id": "GEREX-95E4EFC3316643B3",
+  "registry_change_request_artifact_id": "GERCR-40B710AFAEAE269F",
+  "registry_change_review_artifact_id": "GERVW-FE5BEF17CF897D74",
+  "generated_eval_artifact_id": "GEC-4B9A9F9E26A54D4C",
+  "registry_updated": true,
+  "blocked_reasons": [],
+  "replay_validation_passed": true,
+  "required_eval_target": "required_eval_registry",
+  "created_at": "2026-04-23T00:15:00Z"
+}

--- a/contracts/examples/generated_eval_registry_change_request_record.json
+++ b/contracts/examples/generated_eval_registry_change_request_record.json
@@ -1,0 +1,14 @@
+{
+  "artifact_type": "generated_eval_registry_change_request_record",
+  "artifact_id": "GERCR-40B710AFAEAE269F",
+  "generated_eval_artifact_id": "GEC-4B9A9F9E26A54D4C",
+  "source_failure_artifact_ids": [
+    "FAIL-MISSING-EVAL-001",
+    "FAIL-MISSING-EVAL-002"
+  ],
+  "reason_code": "missing_required_eval_result",
+  "occurrence_count": 2,
+  "request_origin": "candidate_assessment",
+  "justification": "Recurring failure pattern requires required_eval_registry update request.",
+  "created_at": "2026-04-23T00:00:00Z"
+}

--- a/contracts/examples/generated_eval_registry_change_reversal_record.json
+++ b/contracts/examples/generated_eval_registry_change_reversal_record.json
@@ -1,0 +1,9 @@
+{
+  "artifact_type": "generated_eval_registry_change_reversal_record",
+  "artifact_id": "GERREV-6A0A096C14C84A8A",
+  "generated_eval_artifact_id": "GEC-4B9A9F9E26A54D4C",
+  "registry_change_execution_artifact_id": "GEREX-95E4EFC3316643B3",
+  "reversal_reason": "manual_registry_revert",
+  "reversal_applied": true,
+  "created_at": "2026-04-23T00:20:00Z"
+}

--- a/contracts/examples/generated_eval_registry_change_review_record.json
+++ b/contracts/examples/generated_eval_registry_change_review_record.json
@@ -1,0 +1,10 @@
+{
+  "artifact_type": "generated_eval_registry_change_review_record",
+  "artifact_id": "GERVW-FE5BEF17CF897D74",
+  "registry_change_request_artifact_id": "GERCR-40B710AFAEAE269F",
+  "generated_eval_artifact_id": "GEC-4B9A9F9E26A54D4C",
+  "review_outcome": "ready",
+  "reviewed_by": "runtime-reviewer",
+  "rationale": "Replay consistency checks and recurrence threshold are satisfied.",
+  "created_at": "2026-04-23T00:10:00Z"
+}

--- a/contracts/schemas/generated_eval_registry_change_execution_record.schema.json
+++ b/contracts/schemas/generated_eval_registry_change_execution_record.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/generated_eval_registry_change_execution_record.schema.json",
+  "title": "generated_eval_registry_change_execution_record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "registry_change_request_artifact_id",
+    "registry_change_review_artifact_id",
+    "generated_eval_artifact_id",
+    "registry_updated",
+    "blocked_reasons",
+    "replay_validation_passed",
+    "required_eval_target",
+    "created_at"
+  ],
+  "properties": {
+    "artifact_type": { "type": "string", "const": "generated_eval_registry_change_execution_record" },
+    "artifact_id": { "type": "string", "minLength": 1 },
+    "registry_change_request_artifact_id": { "type": "string", "minLength": 1 },
+    "registry_change_review_artifact_id": { "type": "string", "minLength": 1 },
+    "generated_eval_artifact_id": { "type": "string", "minLength": 1 },
+    "registry_updated": { "type": "boolean" },
+    "blocked_reasons": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "replay_validation_passed": { "type": "boolean" },
+    "required_eval_target": { "type": "string", "minLength": 1 },
+    "created_at": { "type": "string", "format": "date-time" }
+  }
+}

--- a/contracts/schemas/generated_eval_registry_change_request_record.schema.json
+++ b/contracts/schemas/generated_eval_registry_change_request_record.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/generated_eval_registry_change_request_record.schema.json",
+  "title": "generated_eval_registry_change_request_record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "generated_eval_artifact_id",
+    "source_failure_artifact_ids",
+    "reason_code",
+    "occurrence_count",
+    "request_origin",
+    "justification",
+    "created_at"
+  ],
+  "properties": {
+    "artifact_type": { "type": "string", "const": "generated_eval_registry_change_request_record" },
+    "artifact_id": { "type": "string", "minLength": 1 },
+    "generated_eval_artifact_id": { "type": "string", "minLength": 1 },
+    "source_failure_artifact_ids": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "reason_code": { "type": "string", "minLength": 1 },
+    "occurrence_count": { "type": "integer", "minimum": 1 },
+    "request_origin": { "type": "string", "enum": ["manual", "candidate_assessment"] },
+    "justification": { "type": "string", "minLength": 1 },
+    "created_at": { "type": "string", "format": "date-time" }
+  }
+}

--- a/contracts/schemas/generated_eval_registry_change_reversal_record.schema.json
+++ b/contracts/schemas/generated_eval_registry_change_reversal_record.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/generated_eval_registry_change_reversal_record.schema.json",
+  "title": "generated_eval_registry_change_reversal_record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "generated_eval_artifact_id",
+    "registry_change_execution_artifact_id",
+    "reversal_reason",
+    "reversal_applied",
+    "created_at"
+  ],
+  "properties": {
+    "artifact_type": { "type": "string", "const": "generated_eval_registry_change_reversal_record" },
+    "artifact_id": { "type": "string", "minLength": 1 },
+    "generated_eval_artifact_id": { "type": "string", "minLength": 1 },
+    "registry_change_execution_artifact_id": { "type": "string", "minLength": 1 },
+    "reversal_reason": { "type": "string", "enum": ["manual_registry_revert"] },
+    "reversal_applied": { "type": "boolean" },
+    "created_at": { "type": "string", "format": "date-time" }
+  }
+}

--- a/contracts/schemas/generated_eval_registry_change_review_record.schema.json
+++ b/contracts/schemas/generated_eval_registry_change_review_record.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spectrum-systems.org/contracts/generated_eval_registry_change_review_record.schema.json",
+  "title": "generated_eval_registry_change_review_record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "artifact_id",
+    "registry_change_request_artifact_id",
+    "generated_eval_artifact_id",
+    "review_outcome",
+    "reviewed_by",
+    "rationale",
+    "created_at"
+  ],
+  "properties": {
+    "artifact_type": { "type": "string", "const": "generated_eval_registry_change_review_record" },
+    "artifact_id": { "type": "string", "minLength": 1 },
+    "registry_change_request_artifact_id": { "type": "string", "minLength": 1 },
+    "generated_eval_artifact_id": { "type": "string", "minLength": 1 },
+    "review_outcome": { "type": "string", "enum": ["ready", "not_ready"] },
+    "reviewed_by": { "type": "string", "minLength": 1 },
+    "rationale": { "type": "string", "minLength": 1 },
+    "created_at": { "type": "string", "format": "date-time" }
+  }
+}

--- a/contracts/standards-manifest.json
+++ b/contracts/standards-manifest.json
@@ -1,9 +1,9 @@
 {
   "artifact_type": "standards_manifest",
   "artifact_id": "STD-CONTRACTS",
-  "artifact_version": "1.3.150",
+  "artifact_version": "1.3.151",
   "schema_version": "1.3.99",
-  "standards_version": "1.9.9",
+  "standards_version": "1.9.10",
   "record_id": "REC-STD-2026-04-18-ENF-01",
   "run_id": "run-20260418T000000Z-enf-01",
   "created_at": "2026-04-18T00:00:00Z",
@@ -15,7 +15,7 @@
     "contact": "architecture@spectrum-systems.test"
   },
   "source_repo": "nicklasorte/spectrum-systems",
-  "source_repo_version": "1.3.150",
+  "source_repo_version": "1.3.151",
   "input_artifacts": [
     {
       "artifact_id": "STD-CONTRACTS",
@@ -6338,6 +6338,58 @@
       "last_updated_in": "1.9.9",
       "example_path": "contracts/examples/generated_eval_case.json",
       "notes": "EVAL-AUTO-01 deterministic failure_record-to-eval artifact for replayable prevention candidate generation."
+    },
+    {
+      "artifact_type": "generated_eval_registry_change_execution_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.151",
+      "last_updated_in": "1.3.151",
+      "example_path": "contracts/examples/generated_eval_registry_change_execution_record.json",
+      "notes": "AG-07 deterministic execution output for generated eval registry-change path with explicit replay validation status."
+    },
+    {
+      "artifact_type": "generated_eval_registry_change_request_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.151",
+      "last_updated_in": "1.3.151",
+      "example_path": "contracts/examples/generated_eval_registry_change_request_record.json",
+      "notes": "AG-07 deterministic request artifact for generated eval registry-change path with source failure linkage and recurrence count."
+    },
+    {
+      "artifact_type": "generated_eval_registry_change_reversal_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.151",
+      "last_updated_in": "1.3.151",
+      "example_path": "contracts/examples/generated_eval_registry_change_reversal_record.json",
+      "notes": "AG-07 deterministic reversal output for manual registry revert after generated eval registry-change execution."
+    },
+    {
+      "artifact_type": "generated_eval_registry_change_review_record",
+      "artifact_class": "coordination",
+      "schema_version": "1.0.0",
+      "status": "proposed",
+      "intended_consumers": [
+        "spectrum-systems"
+      ],
+      "introduced_in": "1.3.151",
+      "last_updated_in": "1.3.151",
+      "example_path": "contracts/examples/generated_eval_registry_change_review_record.json",
+      "notes": "AG-07 deterministic review artifact for generated eval registry-change path using ready or not_ready outcomes."
     },
     {
       "artifact_type": "github_review_handoff_artifact",

--- a/docs/review-actions/PLAN-AG-07-CLEAN-2026-04-23.md
+++ b/docs/review-actions/PLAN-AG-07-CLEAN-2026-04-23.md
@@ -1,0 +1,32 @@
+# PLAN
+
+## Prompt Type
+BUILD
+
+## Work Item
+AG-07-CLEAN
+
+## Scope
+Implement a narrow generated eval registry-change path limited to request, review, execution, and reversal artifacts plus minimal runtime and test coverage.
+
+## Files
+- contracts/examples/generated_eval_registry_change_request_record.json
+- contracts/examples/generated_eval_registry_change_review_record.json
+- contracts/examples/generated_eval_registry_change_execution_record.json
+- contracts/examples/generated_eval_registry_change_reversal_record.json
+- contracts/schemas/generated_eval_registry_change_request_record.schema.json
+- contracts/schemas/generated_eval_registry_change_review_record.schema.json
+- contracts/schemas/generated_eval_registry_change_execution_record.schema.json
+- contracts/schemas/generated_eval_registry_change_reversal_record.schema.json
+- contracts/standards-manifest.json
+- spectrum_systems/modules/runtime/failure_eval_generation.py
+- tests/test_failure_eval_generation.py
+- tests/test_generated_eval_registry_change_surface_vocabulary.py
+- docs/runtime/ag-07-generated-eval-registry-change.md
+
+## Steps
+1. Add four contract schemas and examples with fail-closed constraints and deterministic artifact identifiers.
+2. Register all four artifacts in the standards manifest with a single version increment.
+3. Add one runtime execution path and one reversal path that always emit records and block on missing conditions.
+4. Add narrow tests for contract validation, block conditions, success path, deterministic reversal, and vocabulary guard.
+5. Run targeted tests and required contract checks.

--- a/docs/runtime/ag-07-generated-eval-registry-change.md
+++ b/docs/runtime/ag-07-generated-eval-registry-change.md
@@ -1,0 +1,26 @@
+# AG-07 generated eval registry-change path
+
+## Purpose
+
+This path gives an admitted generated eval candidate one narrow way to request a required eval registry change, receive review, produce an execution result, and support reversal.
+
+## Sequence
+
+1. Emit `generated_eval_registry_change_request_record`.
+2. Emit `generated_eval_registry_change_review_record` with `review_outcome` set to `ready` or `not_ready`.
+3. Run one execution function that emits `generated_eval_registry_change_execution_record` in all outcomes.
+4. If needed, emit `generated_eval_registry_change_reversal_record` with `reversal_reason=manual_registry_revert`.
+
+## One-path rule
+
+Only one execution function performs registry-change evaluation. The function is deterministic and keeps lineage across failure, generated eval case, request, review, and execution records.
+
+## Replay validation requirement
+
+Replay validation is explicit. Replay mismatch blocks registry update and records `replay_validation_passed=false` with a blocking reason.
+
+## Fail-closed behavior
+
+The execution record blocks updates when any required input is missing, admission did not succeed, linkage is mismatched, threshold is not met, review is not `ready`, or replay validation fails.
+
+No silent registry update is allowed.

--- a/spectrum_systems/modules/runtime/failure_eval_generation.py
+++ b/spectrum_systems/modules/runtime/failure_eval_generation.py
@@ -490,6 +490,164 @@ def generate_eval_candidate_review_bundle(
     }
 
 
+def _replay_validation_block_reasons(
+    generated_eval_case: Dict[str, Any],
+    candidate_record: Dict[str, Any],
+    request_record: Dict[str, Any],
+) -> list[str]:
+    blocked_reasons: list[str] = []
+    generated_eval_artifact_id = _as_nonempty_string(generated_eval_case.get("artifact_id"))
+    candidate_generated_eval_artifact_id = _as_nonempty_string(candidate_record.get("generated_eval_artifact_id"))
+    if generated_eval_artifact_id != candidate_generated_eval_artifact_id:
+        blocked_reasons.append("replay_validation_generated_eval_mismatch")
+
+    case_reason_code = _as_nonempty_string(generated_eval_case.get("reason_code"))
+    request_reason_code = _as_nonempty_string(request_record.get("reason_code"))
+    if case_reason_code != request_reason_code:
+        blocked_reasons.append("replay_validation_reason_code_mismatch")
+
+    source_failure_artifact_id = _as_nonempty_string(generated_eval_case.get("source_failure_artifact_id"))
+    source_failure_artifact_ids = request_record.get("source_failure_artifact_ids")
+    if not isinstance(source_failure_artifact_ids, list) or source_failure_artifact_id not in source_failure_artifact_ids:
+        blocked_reasons.append("replay_validation_source_failure_link_missing")
+
+    return sorted(set(blocked_reasons))
+
+
+def execute_generated_eval_registry_change(
+    generated_eval_case: Dict[str, Any] | None,
+    generated_eval_admission_record: Dict[str, Any] | None,
+    candidate_record: Dict[str, Any] | None,
+    request_record: Dict[str, Any] | None,
+    review_record: Dict[str, Any] | None,
+    *,
+    occurrence_threshold: int = 2,
+    required_eval_target: str = "required_eval_registry",
+) -> Dict[str, Any]:
+    """Execute the single controlled generated eval registry-change path."""
+
+    blocked_reasons: list[str] = []
+    generated_eval_case = generated_eval_case if isinstance(generated_eval_case, dict) else {}
+    generated_eval_admission_record = (
+        generated_eval_admission_record if isinstance(generated_eval_admission_record, dict) else {}
+    )
+    candidate_record = candidate_record if isinstance(candidate_record, dict) else {}
+    request_record = request_record if isinstance(request_record, dict) else {}
+    review_record = review_record if isinstance(review_record, dict) else {}
+
+    generated_eval_artifact_id = _as_nonempty_string(generated_eval_case.get("artifact_id"), "missing:generated_eval_artifact_id")
+    request_generated_eval_artifact_id = _as_nonempty_string(request_record.get("generated_eval_artifact_id"))
+    candidate_generated_eval_artifact_id = _as_nonempty_string(candidate_record.get("generated_eval_artifact_id"))
+    review_generated_eval_artifact_id = _as_nonempty_string(review_record.get("generated_eval_artifact_id"))
+
+    if not generated_eval_case:
+        blocked_reasons.append("missing_generated_eval_case")
+    if not generated_eval_admission_record:
+        blocked_reasons.append("missing_generated_eval_admission_record")
+    if not candidate_record:
+        blocked_reasons.append("missing_candidate_record")
+    if not request_record:
+        blocked_reasons.append("missing_registry_change_request_record")
+    if not review_record:
+        blocked_reasons.append("missing_registry_change_review_record")
+
+    admission_generated_eval_artifact_id = _as_nonempty_string(generated_eval_admission_record.get("generated_eval_artifact_id"))
+    if not generated_eval_admission_record.get("admitted"):
+        blocked_reasons.append("generated_eval_not_admitted")
+    if admission_generated_eval_artifact_id != generated_eval_artifact_id:
+        blocked_reasons.append("admission_generated_eval_mismatch")
+
+    if candidate_generated_eval_artifact_id != generated_eval_artifact_id:
+        blocked_reasons.append("candidate_generated_eval_mismatch")
+    if request_generated_eval_artifact_id != generated_eval_artifact_id:
+        blocked_reasons.append("request_generated_eval_mismatch")
+    if review_generated_eval_artifact_id != generated_eval_artifact_id:
+        blocked_reasons.append("review_generated_eval_mismatch")
+
+    threshold = occurrence_threshold if occurrence_threshold >= 1 else 1
+    if _as_nonnegative_int(request_record.get("occurrence_count")) < threshold:
+        blocked_reasons.append("occurrence_count_below_threshold")
+
+    if _as_nonempty_string(review_record.get("review_outcome")) != "ready":
+        blocked_reasons.append("review_not_ready")
+
+    request_artifact_id = _as_nonempty_string(request_record.get("artifact_id"), "missing:registry_change_request_artifact_id")
+    if _as_nonempty_string(review_record.get("registry_change_request_artifact_id")) != request_artifact_id:
+        blocked_reasons.append("review_request_link_mismatch")
+
+    replay_validation_blocked_reasons = (
+        _replay_validation_block_reasons(generated_eval_case, candidate_record, request_record)
+        if generated_eval_case and candidate_record and request_record
+        else ["replay_validation_inputs_missing"]
+    )
+    replay_validation_passed = len(replay_validation_blocked_reasons) == 0
+    blocked_reasons.extend(replay_validation_blocked_reasons)
+
+    deduped_blocked_reasons = sorted(set(blocked_reasons))
+    registry_updated = len(deduped_blocked_reasons) == 0
+
+    execution_record = {
+        "artifact_type": "generated_eval_registry_change_execution_record",
+        "artifact_id": _hash_id(
+            "GEREX",
+            {
+                "generated_eval_artifact_id": generated_eval_artifact_id,
+                "registry_change_request_artifact_id": request_artifact_id,
+                "registry_change_review_artifact_id": _as_nonempty_string(
+                    review_record.get("artifact_id"),
+                    "missing:registry_change_review_artifact_id",
+                ),
+                "blocked_reasons": deduped_blocked_reasons,
+            },
+        ),
+        "registry_change_request_artifact_id": request_artifact_id,
+        "registry_change_review_artifact_id": _as_nonempty_string(
+            review_record.get("artifact_id"),
+            "missing:registry_change_review_artifact_id",
+        ),
+        "generated_eval_artifact_id": generated_eval_artifact_id,
+        "registry_updated": registry_updated,
+        "blocked_reasons": deduped_blocked_reasons,
+        "replay_validation_passed": replay_validation_passed,
+        "required_eval_target": _as_nonempty_string(required_eval_target, "required_eval_registry"),
+        "created_at": _normalized_timestamp(request_record.get("created_at")),
+    }
+    Draft202012Validator(load_schema("generated_eval_registry_change_execution_record")).validate(execution_record)
+    return execution_record
+
+
+def emit_generated_eval_registry_change_reversal_record(
+    execution_record: Dict[str, Any],
+    *,
+    reversal_reason: str = "manual_registry_revert",
+) -> Dict[str, Any]:
+    """Emit deterministic reversal output for a generated eval registry-change execution record."""
+
+    generated_eval_artifact_id = _as_nonempty_string(execution_record.get("generated_eval_artifact_id"), "missing:generated_eval_artifact_id")
+    execution_artifact_id = _as_nonempty_string(
+        execution_record.get("artifact_id"),
+        "missing:registry_change_execution_artifact_id",
+    )
+    reversal_record = {
+        "artifact_type": "generated_eval_registry_change_reversal_record",
+        "artifact_id": _hash_id(
+            "GERREV",
+            {
+                "generated_eval_artifact_id": generated_eval_artifact_id,
+                "registry_change_execution_artifact_id": execution_artifact_id,
+                "reversal_reason": reversal_reason,
+            },
+        ),
+        "generated_eval_artifact_id": generated_eval_artifact_id,
+        "registry_change_execution_artifact_id": execution_artifact_id,
+        "reversal_reason": reversal_reason,
+        "reversal_applied": True,
+        "created_at": _normalized_timestamp(execution_record.get("created_at")),
+    }
+    Draft202012Validator(load_schema("generated_eval_registry_change_reversal_record")).validate(reversal_record)
+    return reversal_record
+
+
 def generate_eval_staging_and_review_bundle(
     generated_eval_cases_with_admission: Sequence[Dict[str, Any]],
     *,

--- a/tests/test_failure_eval_generation.py
+++ b/tests/test_failure_eval_generation.py
@@ -3,11 +3,16 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from jsonschema import Draft202012Validator
+
+from spectrum_systems.contracts import load_schema
 from spectrum_systems.modules.runtime.failure_eval_generation import (
     admit_generated_eval_case,
     build_generated_eval_candidate_queue,
     build_generated_eval_candidate_records,
     build_generated_eval_candidate_assessment_records,
+    emit_generated_eval_registry_change_reversal_record,
+    execute_generated_eval_registry_change,
     generate_eval_candidate_review_bundle,
     generate_and_admit_failure_eval,
     generate_eval_case_from_failure_record,
@@ -316,3 +321,157 @@ def test_end_to_end_failure_to_candidate_staging_queue_and_assessment_bundle() -
     assert bundle["candidate_queue"]["artifact_type"] == "generated_eval_candidate_queue"
     assert len(bundle["candidate_assessments"]) == 2
     assert bundle["candidate_queue"]["high_priority_candidates"]
+
+
+def _registry_change_inputs(
+    *,
+    admitted: bool = True,
+    review_outcome: str = "ready",
+    request_occurrence_count: int = 2,
+    candidate_eval_id_matches: bool = True,
+    request_eval_id_matches: bool = True,
+    review_eval_id_matches: bool = True,
+    source_link_present: bool = True,
+    reason_code_matches: bool = True,
+) -> tuple[dict, dict, dict, dict, dict]:
+    pair = _admitted_pair("missing_required_eval_failure")
+    generated_eval_case = pair["generated_eval_case"]
+    admission = pair["generated_eval_admission_record"]
+    if not admitted:
+        admission["admitted"] = False
+
+    generated_eval_artifact_id = generated_eval_case["artifact_id"]
+    candidate_eval_id = generated_eval_artifact_id if candidate_eval_id_matches else "GEC-MISMATCH"
+    request_eval_id = generated_eval_artifact_id if request_eval_id_matches else "GEC-MISMATCH"
+    review_eval_id = generated_eval_artifact_id if review_eval_id_matches else "GEC-MISMATCH"
+    request_reason_code = generated_eval_case["reason_code"] if reason_code_matches else "other_reason_code"
+
+    candidate_record = {
+        "artifact_type": "generated_eval_candidate_record",
+        "artifact_id": "GES-E2F404E36AAE91FA",
+        "generated_eval_artifact_id": candidate_eval_id,
+        "source_failure_artifact_id": generated_eval_case["source_failure_artifact_id"],
+        "reason_code": generated_eval_case["reason_code"],
+        "staging_status": "pending_review",
+        "occurrence_count": request_occurrence_count,
+        "first_seen_at": "2026-04-19T00:02:00Z",
+        "last_seen_at": "2026-04-19T00:05:00Z",
+        "created_at": "2026-04-19T00:02:00Z",
+    }
+
+    source_failure_ids = (
+        [generated_eval_case["source_failure_artifact_id"], "FAIL-MISSING-EVAL-002"] if source_link_present else ["FAIL-OTHER-001"]
+    )
+    request_record = {
+        "artifact_type": "generated_eval_registry_change_request_record",
+        "artifact_id": "GERCR-40B710AFAEAE269F",
+        "generated_eval_artifact_id": request_eval_id,
+        "source_failure_artifact_ids": source_failure_ids,
+        "reason_code": request_reason_code,
+        "occurrence_count": request_occurrence_count,
+        "request_origin": "candidate_assessment",
+        "justification": "Recurring failure pattern requires required_eval_registry update request.",
+        "created_at": "2026-04-23T00:00:00Z",
+    }
+
+    review_record = {
+        "artifact_type": "generated_eval_registry_change_review_record",
+        "artifact_id": "GERVW-FE5BEF17CF897D74",
+        "registry_change_request_artifact_id": request_record["artifact_id"],
+        "generated_eval_artifact_id": review_eval_id,
+        "review_outcome": review_outcome,
+        "reviewed_by": "runtime-reviewer",
+        "rationale": "Replay consistency checks and recurrence threshold are satisfied.",
+        "created_at": "2026-04-23T00:10:00Z",
+    }
+    return generated_eval_case, admission, candidate_record, request_record, review_record
+
+
+def test_generated_eval_registry_change_request_record_validates() -> None:
+    Draft202012Validator(load_schema("generated_eval_registry_change_request_record")).validate(
+        json.loads((Path(__file__).resolve().parents[1] / "contracts" / "examples" / "generated_eval_registry_change_request_record.json").read_text(encoding="utf-8"))
+    )
+
+
+def test_generated_eval_registry_change_review_record_validates() -> None:
+    Draft202012Validator(load_schema("generated_eval_registry_change_review_record")).validate(
+        json.loads((Path(__file__).resolve().parents[1] / "contracts" / "examples" / "generated_eval_registry_change_review_record.json").read_text(encoding="utf-8"))
+    )
+
+
+def test_generated_eval_registry_change_execution_record_validates() -> None:
+    Draft202012Validator(load_schema("generated_eval_registry_change_execution_record")).validate(
+        json.loads((Path(__file__).resolve().parents[1] / "contracts" / "examples" / "generated_eval_registry_change_execution_record.json").read_text(encoding="utf-8"))
+    )
+
+
+def test_generated_eval_registry_change_reversal_record_validates() -> None:
+    Draft202012Validator(load_schema("generated_eval_registry_change_reversal_record")).validate(
+        json.loads((Path(__file__).resolve().parents[1] / "contracts" / "examples" / "generated_eval_registry_change_reversal_record.json").read_text(encoding="utf-8"))
+    )
+
+
+def test_registry_update_blocks_without_admission() -> None:
+    inputs = _registry_change_inputs(admitted=False)
+    execution = execute_generated_eval_registry_change(*inputs)
+    assert execution["registry_updated"] is False
+    assert "generated_eval_not_admitted" in execution["blocked_reasons"]
+
+
+def test_registry_update_blocks_without_candidate_staging_linkage() -> None:
+    inputs = _registry_change_inputs(candidate_eval_id_matches=False)
+    execution = execute_generated_eval_registry_change(*inputs)
+    assert execution["registry_updated"] is False
+    assert "candidate_generated_eval_mismatch" in execution["blocked_reasons"]
+
+
+def test_registry_update_blocks_below_threshold() -> None:
+    inputs = _registry_change_inputs(request_occurrence_count=1)
+    execution = execute_generated_eval_registry_change(*inputs, occurrence_threshold=2)
+    assert execution["registry_updated"] is False
+    assert "occurrence_count_below_threshold" in execution["blocked_reasons"]
+
+
+def test_registry_update_blocks_without_review_record() -> None:
+    generated_eval_case, admission, candidate_record, request_record, _review_record = _registry_change_inputs()
+    execution = execute_generated_eval_registry_change(
+        generated_eval_case,
+        admission,
+        candidate_record,
+        request_record,
+        None,
+    )
+    assert execution["registry_updated"] is False
+    assert "missing_registry_change_review_record" in execution["blocked_reasons"]
+
+
+def test_registry_update_blocks_when_review_not_ready() -> None:
+    inputs = _registry_change_inputs(review_outcome="not_ready")
+    execution = execute_generated_eval_registry_change(*inputs)
+    assert execution["registry_updated"] is False
+    assert "review_not_ready" in execution["blocked_reasons"]
+
+
+def test_registry_update_blocks_when_replay_validation_fails() -> None:
+    inputs = _registry_change_inputs(source_link_present=False)
+    execution = execute_generated_eval_registry_change(*inputs)
+    assert execution["registry_updated"] is False
+    assert execution["replay_validation_passed"] is False
+    assert "replay_validation_source_failure_link_missing" in execution["blocked_reasons"]
+
+
+def test_registry_update_succeeds_only_when_all_requirements_are_satisfied() -> None:
+    execution = execute_generated_eval_registry_change(*_registry_change_inputs())
+    assert execution["registry_updated"] is True
+    assert execution["blocked_reasons"] == []
+    assert execution["replay_validation_passed"] is True
+
+
+def test_reversal_record_emits_deterministically() -> None:
+    execution = execute_generated_eval_registry_change(*_registry_change_inputs())
+    first = emit_generated_eval_registry_change_reversal_record(execution)
+    second = emit_generated_eval_registry_change_reversal_record(execution)
+
+    assert first["artifact_id"] == second["artifact_id"]
+    assert first["reversal_reason"] == "manual_registry_revert"
+    assert first["reversal_applied"] is True

--- a/tests/test_generated_eval_registry_change_surface_vocabulary.py
+++ b/tests/test_generated_eval_registry_change_surface_vocabulary.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_AG07_FILES = (
+    _REPO_ROOT / "contracts" / "schemas" / "generated_eval_registry_change_request_record.schema.json",
+    _REPO_ROOT / "contracts" / "schemas" / "generated_eval_registry_change_review_record.schema.json",
+    _REPO_ROOT / "contracts" / "schemas" / "generated_eval_registry_change_execution_record.schema.json",
+    _REPO_ROOT / "contracts" / "schemas" / "generated_eval_registry_change_reversal_record.schema.json",
+    _REPO_ROOT / "contracts" / "examples" / "generated_eval_registry_change_request_record.json",
+    _REPO_ROOT / "contracts" / "examples" / "generated_eval_registry_change_review_record.json",
+    _REPO_ROOT / "contracts" / "examples" / "generated_eval_registry_change_execution_record.json",
+    _REPO_ROOT / "contracts" / "examples" / "generated_eval_registry_change_reversal_record.json",
+    _REPO_ROOT / "docs" / "runtime" / "ag-07-generated-eval-registry-change.md",
+)
+
+_FORBIDDEN_TOKENS = (
+    "approved",
+    "rejected",
+    "promote",
+    "promoted",
+    "accepted",
+    "declined",
+    "governance",
+    "authority",
+    "authorized",
+    "rollback",
+)
+
+
+def test_ag07_surface_rejects_forbidden_vocabulary_tokens() -> None:
+    for path in _AG07_FILES:
+        payload = path.read_text(encoding="utf-8").lower()
+        for forbidden in _FORBIDDEN_TOKENS:
+            assert forbidden not in payload, f"forbidden AG-07 vocabulary '{forbidden}' found in {path}"
+
+
+def test_ag07_runtime_literals_reject_forbidden_vocabulary_tokens() -> None:
+    runtime_path = _REPO_ROOT / "spectrum_systems" / "modules" / "runtime" / "failure_eval_generation.py"
+    lines = runtime_path.read_text(encoding="utf-8").splitlines()
+    ag07_lines = [
+        line.lower()
+        for line in lines
+        if "generated_eval_registry_change" in line
+        or "replay_validation_" in line
+        or "manual_registry_revert" in line
+        or "registry_change_" in line
+    ]
+    payload = "\n".join(ag07_lines)
+    for forbidden in _FORBIDDEN_TOKENS:
+        assert forbidden not in payload, f"forbidden AG-07 vocabulary '{forbidden}' found in AG-07 runtime literals"


### PR DESCRIPTION
### Motivation

- Provide a single, narrow, auditable path by which an admitted generated eval candidate can request a required-eval registry change, undergo review, produce an execution result, and support deterministic reversal. 
- Keep the slice minimal and fail-closed, confined to the governed Python/artifact surface without widening ownership or adding unrelated surfaces.

### Description

- Add four new contract schemas and examples for `generated_eval_registry_change_request_record`, `generated_eval_registry_change_review_record`, `generated_eval_registry_change_execution_record`, and `generated_eval_registry_change_reversal_record` under `contracts/schemas` and `contracts/examples`. 
- Register the four artifacts in `contracts/standards-manifest.json` with a manifest version bump and safe example paths. 
- Implement one deterministic execution path and a reversal emitter in `spectrum_systems/modules/runtime/failure_eval_generation.py` via `_replay_validation_block_reasons`, `execute_generated_eval_registry_change`, and `emit_generated_eval_registry_change_reversal_record` that always emits an execution record, performs explicit replay validation, and blocks on missing or mismatched inputs. 
- Add a concise runtime doc `docs/runtime/ag-07-generated-eval-registry-change.md`, a plan `docs/review-actions/PLAN-AG-07-CLEAN-2026-04-23.md`, extend `tests/test_failure_eval_generation.py` with focused execution/reversal tests, and add `tests/test_generated_eval_registry_change_surface_vocabulary.py` to enforce forbidden vocabulary tokens for this slice.

### Testing

- Ran `pytest tests/test_failure_eval_generation.py tests/test_generated_eval_registry_change_surface_vocabulary.py` and all tests passed. 
- Ran `pytest tests/test_contracts.py tests/test_contract_enforcement.py` and both suites passed. 
- Ran `python scripts/run_contract_enforcement.py` which completed with no failures, and ran `.codex/skills/contract-boundary-audit/run.sh` which completed `PASS-WARN` with no blocking violations. 
- All added contract examples validate against their schemas using `Draft202012Validator(load_schema(...))` in the test suite and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9f6b170208329bc5c39ffc87b5350)