### PR TITLE
feat(loops): close 5 core feedback loops in spectrum-systems runtime

### DIFF
--- a/spectrum_systems/govern/govern.py
+++ b/spectrum_systems/govern/govern.py
@@ -30,11 +30,21 @@ class GOVERNSystem:
         self,
         artifact: Dict[str, Any],
         policy_ref: Optional[str] = None,
+        drift_state: Optional[Dict[str, Any]] = None,
     ) -> Tuple[bool, str]:
         """Check artifact against referenced policy result for governance evidence packaging.
 
-        Returns (passed, reason). Blocks on policy violation.
+        Returns (passed, reason). Blocks on policy violation OR critical drift.
+
+        If drift_state is provided and contains critical signals, admission is
+        paused to prevent amplification during recovery.
         """
+        # Drift check first — most constraining condition
+        if drift_state is not None:
+            drift_check = self._check_drift_state(drift_state)
+            if not drift_check[0]:
+                return drift_check
+
         artifact_type = artifact.get("artifact_type", "")
         if not artifact_type:
             return False, "policy_check BLOCK: artifact_type missing — cannot determine policy scope"
@@ -52,6 +62,32 @@ class GOVERNSystem:
 
         self._emit_event("lifecycle_transition", artifact, {"phase": "policy_check", "passed": True})
         return True, reason
+
+    def _check_drift_state(self, drift_state: Dict[str, Any]) -> Tuple[bool, str]:
+        """Return (allowed, reason) based on current drift signal severities.
+
+        Critical signals block admission entirely; warning signals allow but log.
+        """
+        signals = drift_state.get("signals", [])
+
+        critical_signals = [s for s in signals if s.get("severity") == "critical"]
+        if critical_signals:
+            signal_names = ", ".join(s.get("signal_type", "unknown") for s in critical_signals)
+            return False, (
+                f"policy_check BLOCK: drift critical ({signal_names}) — "
+                f"admission paused during recovery"
+            )
+
+        warning_signals = [s for s in signals if s.get("severity") == "warning"]
+        if warning_signals:
+            signal_names = ", ".join(s.get("signal_type", "unknown") for s in warning_signals)
+            self._emit_event(
+                "drift_warning_admission_allowed",
+                {"signals": signal_names},
+                {},
+            )
+
+        return True, "drift_state PASS: no critical signals"
 
     def detect_policy_drift(
         self,

--- a/spectrum_systems/modules/feedback/failure_to_eval_pipeline.py
+++ b/spectrum_systems/modules/feedback/failure_to_eval_pipeline.py
@@ -1,0 +1,129 @@
+"""FailureToEvalPipeline: Wire classified failures into the eval candidate lifecycle.
+
+Closes the learning loop:
+  failure → classified → eval_candidate → governance_decision → eval_suite
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+from spectrum_systems.modules.evaluation.error_taxonomy import ErrorType
+
+
+@dataclass
+class FailureToEvalPipeline:
+    """Route classified failures into eval candidate creation and governed adoption."""
+
+    artifact_store: Any
+    governance_system: Any
+    eval_registry: Any
+
+    def route_classified_error(
+        self,
+        classified_error_artifact: Dict[str, Any],
+        trace_id: str,
+    ) -> Dict[str, Any]:
+        """Take a classified error artifact and create an eval_candidate for it.
+
+        Returns eval_adoption_decision if governance approves, else the governance result.
+        Missing error_type emits a finding artifact instead of proceeding.
+        """
+        error_type = classified_error_artifact.get("error_type")
+        if not error_type:
+            return self._emit_finding("MISSING_ERROR_TYPE", trace_id)
+
+        eval_candidate = self._build_eval_candidate(
+            classified_error_artifact=classified_error_artifact,
+            trace_id=trace_id,
+        )
+
+        governance_result = self.governance_system.request_eval_adoption(
+            eval_candidate=eval_candidate,
+            trace_id=trace_id,
+        )
+
+        if governance_result.get("approved"):
+            self.eval_registry.add_candidate(eval_candidate)
+            return {
+                "artifact_type": "eval_adoption_decision",
+                "decision": "approved",
+                "eval_candidate_id": eval_candidate.get("eval_candidate_id"),
+                "trace_id": trace_id,
+            }
+
+        return governance_result
+
+    def _build_eval_candidate(
+        self,
+        classified_error_artifact: Dict[str, Any],
+        trace_id: str,
+    ) -> Dict[str, Any]:
+        """Build an eval_candidate from a classified error artifact."""
+        error_type = classified_error_artifact.get("error_type")
+        source_artifact = classified_error_artifact.get("source_artifact", {})
+
+        candidate = {
+            "artifact_type": "eval_candidate",
+            "eval_candidate_id": f"EVC-{uuid.uuid4().hex[:12].upper()}",
+            "source_error_type": error_type,
+            "source_artifact_type": source_artifact.get("artifact_type"),
+            "source_artifact_id": source_artifact.get("artifact_id"),
+            "reproduction_fixture": self._build_fixture(classified_error_artifact),
+            "expected_output": self._infer_expected_behavior(classified_error_artifact),
+            "acceptance_criteria": self._build_criteria(error_type),
+            "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "trace_id": trace_id,
+            "status": "candidate",
+        }
+
+        self.artifact_store.put(candidate, namespace="governance/eval_candidates")
+        return candidate
+
+    def _infer_expected_behavior(self, classified_error: Dict[str, Any]) -> Dict[str, Any]:
+        """Reverse-engineer what should have happened given the error type."""
+        error_type = classified_error.get("error_type")
+
+        inference_rules = {
+            ErrorType.extraction_error: "All required fields should be populated",
+            ErrorType.reasoning_error: "Decision should be logically sound and well-justified",
+            ErrorType.grounding_failure: "All claims should reference source material with citations",
+            ErrorType.hallucination: "No factual claims beyond documented evidence",
+            ErrorType.schema_violation: "Output should conform to declared schema",
+        }
+
+        return {
+            "description": inference_rules.get(error_type, "Correct output"),
+            "criteria": ["passes_schema", "passes_correctness_check"],
+        }
+
+    def _build_fixture(self, classified_error: Dict[str, Any]) -> Dict[str, Any]:
+        """Build a reusable reproduction fixture from the error."""
+        source = classified_error.get("source_artifact", {})
+        return {
+            "input": source,
+            "expected_pass": False,
+            "description": f"Reproduction case for {classified_error.get('error_type')}",
+        }
+
+    def _build_criteria(self, error_type: str) -> List[str]:
+        """Build acceptance criteria for this error type."""
+        return [
+            "fixture_reproduces_error",
+            "fix_passes_fixture",
+            "no_regressions_on_baseline",
+        ]
+
+    def _emit_finding(self, category: str, trace_id: str) -> Dict[str, Any]:
+        """Emit a finding artifact and halt instead of proceeding with missing data."""
+        finding = {
+            "artifact_type": "finding_artifact",
+            "category": category,
+            "trace_id": trace_id,
+            "message": f"Cannot route error to eval: {category}",
+        }
+        self.artifact_store.put(finding, namespace="governance/findings")
+        return finding

--- a/spectrum_systems/modules/feedback/failure_to_eval_pipeline.py
+++ b/spectrum_systems/modules/feedback/failure_to_eval_pipeline.py
@@ -49,8 +49,8 @@ class FailureToEvalPipeline:
         if governance_result.get("approved"):
             self.eval_registry.add_candidate(eval_candidate)
             return {
-                "artifact_type": "eval_adoption_decision",
-                "decision": "approved",
+                "artifact_type": "eval_adoption_record",
+                "adoption_status": "approved",
                 "eval_candidate_id": eval_candidate.get("eval_candidate_id"),
                 "trace_id": trace_id,
             }

--- a/spectrum_systems/modules/review_convergence_controller.py
+++ b/spectrum_systems/modules/review_convergence_controller.py
@@ -1,0 +1,122 @@
+"""ReviewConvergenceController: Run review-fix cycles until convergence or max iterations.
+
+Tightens the loop: execute → review → if not clean, fix → re-review → repeat.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+
+from spectrum_systems.modules.review_fix_execution_loop import run_review_fix_execution_cycle
+
+
+@dataclass
+class ReviewConvergenceController:
+    """Run review-fix cycles until output is clean or max_iterations is exceeded.
+
+    For production use, supply output_dir, repo_root, and review_docs_dir so they
+    are forwarded to run_review_fix_execution_cycle.  In tests those parameters are
+    not needed because the underlying function is mocked.
+    """
+
+    max_iterations: int = 3
+    artifact_store: Optional[Any] = None
+    output_dir: Optional[Path] = None
+    repo_root: Optional[Path] = None
+    review_docs_dir: Optional[Path] = None
+
+    def run_until_clean(
+        self,
+        request_artifact: Dict[str, Any],
+        trace_id: str,
+    ) -> Dict[str, Any]:
+        """Run review-fix cycles until clean output or max iterations reached.
+
+        Returns final_result_artifact with convergence_status CLEAN or
+        BLOCKED_MAX_ITERATIONS.
+        """
+        current_request = request_artifact
+
+        for iteration in range(1, self.max_iterations + 1):
+            result = self._execute_cycle(current_request)
+
+            if self._is_clean(result):
+                result["convergence_iterations"] = iteration
+                result["convergence_status"] = "CLEAN"
+                self._emit_event("convergence_reached", result, trace_id)
+                return result
+
+            if iteration < self.max_iterations:
+                current_request = self._advance_request(result)
+                self._emit_event("fix_incomplete_retrying", result, trace_id)
+            else:
+                result["convergence_iterations"] = iteration
+                result["convergence_status"] = "BLOCKED_MAX_ITERATIONS"
+                self._emit_finding("max_iterations_exceeded", result, trace_id)
+                return result
+
+        # Unreachable — loop always returns within the for body
+        return {"artifact_type": "error_artifact", "error": "unreachable"}
+
+    def _execute_cycle(self, request_artifact: Dict[str, Any]) -> Dict[str, Any]:
+        """Delegate one cycle to run_review_fix_execution_cycle."""
+        kwargs: Dict[str, Any] = {}
+        if self.output_dir is not None:
+            kwargs["output_dir"] = self.output_dir
+        if self.repo_root is not None:
+            kwargs["repo_root"] = self.repo_root
+        if self.review_docs_dir is not None:
+            kwargs["review_docs_dir"] = self.review_docs_dir
+        return run_review_fix_execution_cycle(request_artifact, **kwargs)
+
+    def _is_clean(self, result: Dict[str, Any]) -> bool:
+        """Return True if the result has no remaining issues."""
+        status = result.get("review_status")
+        issues = result.get("remaining_issues", [])
+        return (status == "pass") or (len(issues) == 0)
+
+    def _advance_request(self, result: Dict[str, Any]) -> Dict[str, Any]:
+        """Build the next iteration's request from the fixed artifact."""
+        return {
+            "artifact_type": "review_fix_execution_request_artifact",
+            "input_artifact": result.get("fixed_artifact"),
+            "trace_id": result.get("trace_id"),
+            "iteration": result.get("iteration", 0) + 1,
+        }
+
+    def _emit_event(
+        self,
+        event_type: str,
+        result: Dict[str, Any],
+        trace_id: str,
+    ) -> None:
+        if self.artifact_store:
+            self.artifact_store.put(
+                {
+                    "artifact_type": "convergence_event",
+                    "event_type": event_type,
+                    "trace_id": trace_id,
+                    "result_id": result.get("artifact_id"),
+                },
+                namespace="observability/convergence",
+            )
+
+    def _emit_finding(
+        self,
+        finding_type: str,
+        result: Dict[str, Any],
+        trace_id: str,
+    ) -> None:
+        if self.artifact_store:
+            self.artifact_store.put(
+                {
+                    "artifact_type": "finding_artifact",
+                    "finding_type": finding_type,
+                    "trace_id": trace_id,
+                    "affected_artifact_id": result.get("artifact_id"),
+                    "message": f"Review-fix convergence failed: {finding_type}",
+                },
+                namespace="governance/findings",
+            )

--- a/spectrum_systems/orchestration/cycle_runner.py
+++ b/spectrum_systems/orchestration/cycle_runner.py
@@ -368,7 +368,9 @@ def _certification_handoff(manifest: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _write_manifest(manifest_path: str | Path, manifest: Dict[str, Any]) -> None:
-    normalized = normalize_cycle_manifest(manifest)
+    # Strip runtime-only sidecar keys (prefixed with _) before schema validation.
+    clean = {k: v for k, v in manifest.items() if not k.startswith("_")}
+    normalized = normalize_cycle_manifest(clean)
     _validate_manifest(normalized)
     Path(manifest_path).write_text(json.dumps(normalized, indent=2) + "\n", encoding="utf-8")
 
@@ -477,6 +479,14 @@ def _run_required_judgment_if_needed(manifest: Dict[str, Any], manifest_path: st
     manifest["judgment_record_path"] = str(jr)
     manifest["judgment_application_record_path"] = str(ja)
     manifest["judgment_eval_result_path"] = str(je)
+    # Carry judgment data in-memory via a sidecar key so the schema-validated
+    # manifest dict stays clean.  Callers that need the data use
+    # manifest["_judgment_inmem"] rather than re-reading from disk.
+    manifest["_judgment_inmem"] = {
+        "judgment_record": outputs["judgment_record"],
+        "judgment_application_record": outputs["judgment_application_record"],
+        "judgment_eval_result": outputs["judgment_eval_result"],
+    }
     return manifest
 
 
@@ -776,14 +786,20 @@ def run_cycle(manifest_path: str | Path) -> Dict[str, Any]:
         hard_gates = manifest.get("hard_gates", {})
         if not all(bool(hard_gates.get(k)) for k in ("roadmap_approved", "execution_contracts_pinned", "review_templates_present")):
             return blocked("hard gates not satisfied for execution readiness")
-        return {
+        result: Dict[str, Any] = {
             "cycle_id": manifest["cycle_id"],
             "status": "ok",
             "current_state": state,
             "next_state": "execution_ready",
             "next_action": "prepare_execution_request",
             "blocking_issues": manifest.get("blocking_issues", []),
+            "judgment_record_path": manifest.get("judgment_record_path"),
+            "judgment_application_record_path": manifest.get("judgment_application_record_path"),
+            "judgment_eval_result_path": manifest.get("judgment_eval_result_path"),
         }
+        # Include in-memory judgment artifacts so callers avoid a redundant file re-read.
+        result.update(manifest.get("_judgment_inmem", {}))
+        return result
 
     if state == "execution_ready":
         request_path = manifest.get("pqx_execution_request_path")

--- a/spectrum_systems/orchestration/wpg_pipeline.py
+++ b/spectrum_systems/orchestration/wpg_pipeline.py
@@ -54,6 +54,7 @@ from spectrum_systems.modules.runtime.bottleneck_alerts import compute_bottlenec
 from spectrum_systems.modules.runtime.semantic_eval import evaluate_semantic_classes, summarize_semantic_evidence
 from spectrum_systems.modules.runtime.failure_to_eval import convert_failures_to_eval_cases
 from spectrum_systems.modules.runtime.evaluation_control import build_evaluation_control_decision
+from spectrum_systems.judgment.judgment_corpus import JudgmentCorpus
 
 
 REQUIRED_ENFORCEMENT = {"ALLOW": "proceed", "WARN": "annotate", "BLOCK": "trigger_repair", "FREEZE": "halt"}
@@ -534,6 +535,30 @@ def _build_comment_disposition_record(comment_resolution_matrix: Dict[str, Any],
     )
 
 
+def _persist_judgment_if_valid(
+    judgment_record: Dict[str, Any],
+    judgment_eval: Dict[str, Any],
+    artifact_store: Any,
+) -> None:
+    """Persist a valid WPG judgment to the JudgmentCorpus for precedent reuse."""
+    if artifact_store is None:
+        return
+    decision = (
+        judgment_eval
+        .get("evaluation_refs", {})
+        .get("control_decision", {})
+        .get("decision")
+    )
+    if decision == "ALLOW":
+        corpus = JudgmentCorpus(artifact_store)
+        corpus.record_judgment(
+            decision_context=judgment_record.get("cycle_id", ""),
+            decision=judgment_record.get("selected_outcome", ""),
+            rationale=judgment_record.get("rationale_summary", ""),
+            confidence=1.0,
+        )
+
+
 def run_wpg_pipeline(
     transcript_payload: Dict[str, Any],
     *,
@@ -546,6 +571,7 @@ def run_wpg_pipeline(
     comment_artifact: Dict[str, Any] | None = None,
     phase_checkpoint_record: Dict[str, Any] | None = None,
     phase_registry: Dict[str, Any] | None = None,
+    artifact_store: Any | None = None,
 ) -> Dict[str, Any]:
     ctx = StageContext(run_id=run_id, trace_id=trace_id)
     registry = ensure_contract(phase_registry, "phase_registry") if phase_registry else default_phase_registry(trace_id)
@@ -623,6 +649,7 @@ def run_wpg_pipeline(
     judgment_record = build_judgment_record(critique_artifact=stakeholder_critique_artifact, trace_id=trace_id)
     precedent_retrieval = retrieve_precedent(judgment_record=judgment_record, prior_records=[judgment_record], trace_id=trace_id)
     judgment_eval = evaluate_judgment(judgment_record=judgment_record, precedent_retrieval=precedent_retrieval, trace_id=trace_id)
+    _persist_judgment_if_valid(judgment_record, judgment_eval, artifact_store)
     wpg_cross_run_comparison_artifact = compare_cross_run(run_a={"replay": {"signature": stable_hash(question_set)}}, run_b={"replay": {"signature": stable_hash(sections)}}, trace_id=trace_id)
     wpg_study_policy_profile = build_study_policy_profile(study_id="wpg-default-study", required_rules=["require_eval_suite", "require_control_decision"], trace_id=trace_id)
     wpg_quality_slo = evaluate_quality_slo(quality_score=0.95, error_budget_remaining=0.2, trace_id=trace_id)

--- a/state/repo_write_lineage_consumed_tokens.json
+++ b/state/repo_write_lineage_consumed_tokens.json
@@ -1,6 +1,10 @@
 {
   "schema_version": "1.0",
   "consumed_token_keys": [
-    "lin-2b1ff11edb994eaeb0b86a30"
+    "lin-2b1ff11edb994eaeb0b86a30",
+    "lin-588d21eb54e44257b2bdc961",
+    "lin-9e767a35117b4721abc34a33",
+    "lin-eaf07e1bde3e4ba9b951c22e",
+    "lin-f9fe2c5eceac41acad324afb"
   ]
 }

--- a/tests/test_cycle_runner_judgment_handoff.py
+++ b/tests/test_cycle_runner_judgment_handoff.py
@@ -1,0 +1,264 @@
+"""Tests for in-memory judgment handoff in cycle_runner — RT-Loop-12."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from spectrum_systems.orchestration import cycle_runner
+from tests.helpers_repo_write_lineage import build_valid_repo_write_lineage
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_FIXTURES = _REPO_ROOT / "tests" / "fixtures" / "autonomous_cycle"
+
+
+def _write(path: Path, payload: dict) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return str(path)
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _fixture(name: str) -> dict:
+    return _load(_FIXTURES / name)
+
+
+def _manifest(tmp_path: Path) -> tuple[dict, Path]:
+    """Build a minimal valid cycle manifest for the roadmap_approved state."""
+    roadmap_path = _REPO_ROOT / "docs" / "roadmap" / "system_roadmap.md"
+
+    review_path = tmp_path / "roadmap_review.json"
+    review_payload = _fixture("roadmap_review_approved.json")
+    review_payload["schema_version"] = "1.1.0"
+    review_payload["governance_provenance"] = {
+        "strategy_authority": {
+            "path": "docs/architecture/system_strategy.md",
+            "version": "2026-03-30",
+        },
+        "source_authorities": [
+            {
+                "source_id": "SRE-MAPPING",
+                "path": "docs/source_structured/mapping_google_sre_reliability_principles_to_spectrum_systems.json",
+            }
+        ],
+        "invariant_checks": [
+            {"invariant_id": "strategy_alignment", "status": "pass", "detail": "aligned"},
+            {"invariant_id": "source_grounding", "status": "pass", "detail": "bounded refs"},
+        ],
+        "drift_findings": [],
+    }
+    _write(review_path, review_payload)
+
+    pqx_request_path = tmp_path / "pqx_request.json"
+    _write(pqx_request_path, {
+        "step_id": "AI-01",
+        "roadmap_path": str(roadmap_path),
+        "state_path": str(tmp_path / "pqx_state.json"),
+        "runs_root": str(tmp_path / "pqx_runs"),
+        "pqx_output_text": "deterministic pqx output",
+        "repo_mutation_requested": False,
+    })
+
+    eligibility_path = tmp_path / "roadmap_eligibility.json"
+    _write(eligibility_path, {
+        "artifact_type": "roadmap_eligibility_artifact",
+        "schema_version": "1.2.0",
+        "artifact_version": "1.2.0",
+        "roadmap_ref": "docs/roadmaps/system_roadmap.md",
+        "evaluated_at": "2026-03-30T00:00:00Z",
+        "identity_basis": {
+            "roadmap_artifact_id": "roadmap-cycle-test",
+            "roadmap_digest": "a542be4e4e3d2a77e6a508d46267f37754378291a075e59977fe80c0baab1128",
+        },
+        "program_alignment_status": "not_evaluated",
+        "program_violation": False,
+        "program_enforcement_action": "no_program_artifact",
+        "eligible_step_ids": ["AI-01"],
+        "recommended_next_step_ids": ["AI-01"],
+        "blocked_steps": [],
+        "strategy_status_artifacts": [
+            {
+                "artifact_type": "pqx_strategy_status_artifact",
+                "schema_version": "1.0.0",
+                "roadmap_row_id": "AI-01",
+                "strategy_gate_decision": "allow",
+                "violated_invariants": [],
+                "drift_signals": [],
+                "hardening_vs_expansion": "hardening",
+                "replay_trace_declared": True,
+                "eval_control_declared": False,
+                "rationale": "strategy gate allows execution",
+            }
+        ],
+        "summary": {
+            "total_steps": 1,
+            "completed_steps": 0,
+            "eligible_steps": 1,
+            "blocked_steps": 0,
+            "strategy_gate": {"allow": 1, "warn": 0, "freeze": 0, "block": 0},
+        },
+        "artifact_id": "c1bfd40c7ea68193b177e33a01da488ff42d8d59cd6ab745ee019ec83afe83a1",
+    })
+
+    allow_policy_path = tmp_path / "evaluation_control_decision_allow.json"
+    allow_policy = json.loads(
+        (_REPO_ROOT / "contracts" / "examples" / "evaluation_control_decision.json")
+        .read_text(encoding="utf-8")
+    )
+    allow_policy["decision"] = "allow"
+    allow_policy["system_response"] = "allow"
+    allow_policy["system_status"] = "healthy"
+    allow_policy["rationale_code"] = "allow_all_signals_healthy"
+    _write(allow_policy_path, allow_policy)
+
+    manifest = {
+        "cycle_id": "cycle-test-jdg-handoff",
+        "current_state": "roadmap_approved",
+        "sequence_mode": "legacy",
+        "roadmap_artifact_path": str(roadmap_path),
+        "strategy_authority": {
+            "path": "docs/architecture/system_strategy.md",
+            "version": "2026-03-30",
+        },
+        "source_authorities": [
+            {
+                "source_id": "SRE-MAPPING",
+                "path": "docs/source_structured/mapping_google_sre_reliability_principles_to_spectrum_systems.json",
+                "title": "Mapping Google SRE Reliability Principles to Spectrum Systems",
+            }
+        ],
+        "roadmap_review_artifact_paths": [str(review_path)],
+        "execution_report_paths": [],
+        "implementation_review_paths": [],
+        "fix_roadmap_path": None,
+        "fix_roadmap_markdown_path": None,
+        "fix_group_refs": [],
+        "fix_execution_report_paths": [],
+        "certification_record_path": None,
+        "blocking_issues": [],
+        "next_action": "await_roadmap_approval",
+        "roadmap_approval_state": "approved",
+        "hard_gates": {
+            "roadmap_approved": True,
+            "execution_contracts_pinned": True,
+            "review_templates_present": True,
+        },
+        "pqx_execution_request_path": str(pqx_request_path),
+        "pqx_request_ref": None,
+        "execution_started_at": None,
+        "execution_completed_at": None,
+        "certification_status": "pending",
+        "certification_summary": None,
+        "done_certification_input_refs": {
+            "replay_result_ref": "a",
+            "regression_result_ref": "b",
+            "certification_pack_ref": "c",
+            "error_budget_ref": "d",
+            "policy_ref": str(allow_policy_path),
+            "closure_decision_artifact_ref": str(
+                _REPO_ROOT / "contracts" / "examples" / "closure_decision_artifact.json"
+            ),
+            "review_control_signal_ref": str(
+                _REPO_ROOT / "contracts" / "examples" / "review_control_signal.json"
+            ),
+            "ril_output_artifact_ref": str(
+                _REPO_ROOT / "contracts" / "examples" / "review_integration_packet_artifact.json"
+            ),
+            "trust_spine_evidence_cohesion_result_ref": str(
+                _REPO_ROOT / "contracts" / "examples" / "trust_spine_evidence_cohesion_result.json"
+            ),
+        },
+        "required_judgments": ["artifact_release_readiness"],
+        "required_judgment_eval_types": ["evidence_coverage", "policy_alignment", "replay_consistency"],
+        "judgment_scope": "autonomous_cycle",
+        "judgment_environment": "prod",
+        "judgment_policy_paths": [
+            str(_REPO_ROOT / "contracts" / "examples" / "judgment_policy.json")
+        ],
+        "judgment_policy_lifecycle_paths": [
+            str(_REPO_ROOT / "contracts" / "examples" / "judgment_policy_lifecycle_record.json")
+        ],
+        "judgment_policy_rollout_paths": [
+            str(_REPO_ROOT / "contracts" / "examples" / "judgment_policy_rollout_record.json")
+        ],
+        "judgment_input_context": {
+            "quality_score": 0.95,
+            "evidence_complete": True,
+            "risk_level": "low",
+            "scope_tag": "autonomous_cycle",
+        },
+        "judgment_evidence_refs": [
+            str(_REPO_ROOT / "contracts" / "examples" / "execution_report_artifact.json")
+        ],
+        "judgment_precedent_record_paths": [
+            str(_REPO_ROOT / "contracts" / "examples" / "judgment_record.json")
+        ],
+        "judgment_replay_reference_path": None,
+        "judgment_record_path": None,
+        "judgment_application_record_path": None,
+        "judgment_eval_result_path": None,
+        "next_step_decision_artifact_path": None,
+        "roadmap_eligibility_artifact_path": str(eligibility_path),
+        "eligible_step_ids_snapshot": ["AI-01"],
+        "recommended_next_step_ids": ["AI-01"],
+        "selected_step_id": "AI-01",
+        "selected_step_status": "authorized",
+        "decision_summary": "Preseeded eligibility decision summary.",
+        "decision_blocked": False,
+        "decision_block_reason": None,
+        "eligibility_summary_snapshot": {
+            "total_steps": 1,
+            "completed_steps": 0,
+            "eligible_steps": 1,
+            "blocked_steps": 0,
+        },
+        "drift_remediation_artifact_path": None,
+        "fix_plan_artifact_path": None,
+        "sequence_trace_id": "trace-jdg-handoff-test",
+        "sequence_lineage": ["contracts/examples/roadmap_eligibility_artifact.json"],
+        "sequence_transition_history": [],
+        "control_allow_promotion": False,
+        "updated_at": "2026-03-30T00:00:00Z",
+    }
+    manifest_path = tmp_path / "cycle_manifest.json"
+    _write(manifest_path, manifest)
+    return manifest, manifest_path
+
+
+def test_judgment_passed_in_memory(tmp_path: Path) -> None:
+    """RT-Loop-12: Judgment is available in-memory in the manifest after run_cycle.
+
+    The disk file must also exist for provenance, and the in-memory copy must
+    be identical to the on-disk record — no second file read needed.
+    """
+    _, manifest_path = _manifest(tmp_path)
+
+    result = cycle_runner.run_cycle(manifest_path)
+
+    assert result["status"] == "ok"
+    # In-memory judgment_record must be present
+    assert "judgment_record" in result
+    assert result["judgment_record"]["artifact_type"] == "judgment_record"
+    # Disk path must also be set for provenance
+    assert result["judgment_record_path"] is not None
+    assert Path(result["judgment_record_path"]).is_file()
+    # In-memory and on-disk records must be identical
+    on_disk = json.loads(Path(result["judgment_record_path"]).read_text(encoding="utf-8"))
+    assert result["judgment_record"] == on_disk
+
+
+def test_judgment_application_and_eval_also_in_memory(tmp_path: Path) -> None:
+    """Judgment application record and eval result are also passed in-memory."""
+    _, manifest_path = _manifest(tmp_path)
+
+    result = cycle_runner.run_cycle(manifest_path)
+
+    assert result["status"] == "ok"
+    assert "judgment_application_record" in result
+    assert "judgment_eval_result" in result
+    assert result["judgment_application_record"]["artifact_type"] == "judgment_application_record"

--- a/tests/test_failure_to_eval_pipeline.py
+++ b/tests/test_failure_to_eval_pipeline.py
@@ -1,0 +1,74 @@
+"""Tests for FailureToEvalPipeline — RT-Loop-01 through RT-Loop-03."""
+
+import pytest
+from unittest.mock import Mock
+from spectrum_systems.modules.feedback.failure_to_eval_pipeline import FailureToEvalPipeline
+from spectrum_systems.modules.evaluation.error_taxonomy import ErrorType
+
+
+@pytest.fixture
+def pipeline():
+    return FailureToEvalPipeline(
+        artifact_store=Mock(),
+        governance_system=Mock(),
+        eval_registry=Mock(),
+    )
+
+
+def test_route_classified_error_creates_eval_candidate(pipeline):
+    """RT-Loop-01: Classified error creates eval_candidate and governance approves it."""
+    classified_error = {
+        "artifact_type": "classified_error_artifact",
+        "error_type": ErrorType.extraction_error,
+        "source_artifact": {
+            "artifact_type": "some_output",
+            "artifact_id": "out-123",
+        },
+    }
+
+    pipeline.governance_system.request_eval_adoption.return_value = {"approved": True}
+
+    result = pipeline.route_classified_error(classified_error, "trace-001")
+
+    assert result["artifact_type"] == "eval_adoption_decision"
+    assert result["decision"] == "approved"
+    assert result["trace_id"] == "trace-001"
+    pipeline.eval_registry.add_candidate.assert_called_once()
+
+
+def test_route_classified_error_requests_governance(pipeline):
+    """RT-Loop-02: Governance denial prevents eval candidate from being added to suite."""
+    classified_error = {
+        "artifact_type": "classified_error_artifact",
+        "error_type": ErrorType.reasoning_error,
+        "source_artifact": {"artifact_type": "judgment", "artifact_id": "jdg-456"},
+    }
+
+    pipeline.governance_system.request_eval_adoption.return_value = {
+        "approved": False,
+        "reason": "eval_capacity_exhausted",
+    }
+
+    result = pipeline.route_classified_error(classified_error, "trace-002")
+
+    assert result["approved"] is False
+    pipeline.eval_registry.add_candidate.assert_not_called()
+
+
+def test_eval_candidate_has_fixture_and_criteria(pipeline):
+    """RT-Loop-03: Eval candidate includes a reproducible fixture and acceptance criteria."""
+    classified_error = {
+        "artifact_type": "classified_error_artifact",
+        "error_type": ErrorType.schema_violation,
+        "source_artifact": {"artifact_type": "output", "artifact_id": "out-789"},
+    }
+
+    pipeline.governance_system.request_eval_adoption.return_value = {"approved": True}
+
+    pipeline.route_classified_error(classified_error, "trace-003")
+
+    added_candidate = pipeline.eval_registry.add_candidate.call_args[0][0]
+    assert "reproduction_fixture" in added_candidate
+    assert added_candidate["reproduction_fixture"] != {}
+    assert "acceptance_criteria" in added_candidate
+    assert len(added_candidate["acceptance_criteria"]) > 0

--- a/tests/test_failure_to_eval_pipeline.py
+++ b/tests/test_failure_to_eval_pipeline.py
@@ -30,8 +30,8 @@ def test_route_classified_error_creates_eval_candidate(pipeline):
 
     result = pipeline.route_classified_error(classified_error, "trace-001")
 
-    assert result["artifact_type"] == "eval_adoption_decision"
-    assert result["decision"] == "approved"
+    assert result["artifact_type"] == "eval_adoption_record"
+    assert result["adoption_status"] == "approved"
     assert result["trace_id"] == "trace-001"
     pipeline.eval_registry.add_candidate.assert_called_once()
 

--- a/tests/test_govern_drift_aware.py
+++ b/tests/test_govern_drift_aware.py
@@ -1,0 +1,62 @@
+"""Tests for drift-aware admission gating in GOVERNSystem — RT-Loop-07 through RT-Loop-09."""
+
+import pytest
+from spectrum_systems.govern.govern import GOVERNSystem
+
+
+@pytest.fixture
+def govern():
+    return GOVERNSystem()
+
+
+def test_policy_check_blocks_on_critical_drift(govern):
+    """RT-Loop-07: Critical drift signal blocks artifact admission."""
+    artifact = {"artifact_type": "execution_slice", "artifact_id": "slice-001"}
+
+    critical_drift_state = {
+        "signals": [
+            {"signal_type": "decision_divergence", "severity": "critical", "value": 0.25}
+        ]
+    }
+
+    passed, reason = govern.policy_check(artifact=artifact, drift_state=critical_drift_state)
+
+    assert not passed
+    assert "critical" in reason.lower()
+    assert "admission paused" in reason.lower()
+
+
+def test_policy_check_allows_on_no_drift(govern):
+    """RT-Loop-08: Empty drift signals allow normal admission."""
+    artifact = {"artifact_type": "execution_slice", "artifact_id": "slice-002"}
+
+    passed, reason = govern.policy_check(artifact=artifact, drift_state={"signals": []})
+
+    assert passed
+    assert "PASS" in reason
+
+
+def test_policy_check_warns_on_warning_drift(govern):
+    """RT-Loop-09: Warning-level drift logs but does not block admission."""
+    artifact = {"artifact_type": "execution_slice", "artifact_id": "slice-003"}
+
+    warning_drift_state = {
+        "signals": [
+            {"signal_type": "exception_rate", "severity": "warning", "value": 0.015}
+        ]
+    }
+
+    passed, reason = govern.policy_check(artifact=artifact, drift_state=warning_drift_state)
+
+    assert passed
+    assert "PASS" in reason
+
+
+def test_policy_check_no_drift_state_unchanged(govern):
+    """Existing callers omitting drift_state still get normal policy_check behaviour."""
+    artifact = {"artifact_type": "execution_slice", "artifact_id": "slice-004"}
+
+    passed, reason = govern.policy_check(artifact=artifact)
+
+    assert passed
+    assert "PASS" in reason

--- a/tests/test_review_convergence_controller.py
+++ b/tests/test_review_convergence_controller.py
@@ -1,0 +1,71 @@
+"""Tests for ReviewConvergenceController — RT-Loop-04 through RT-Loop-06."""
+
+import pytest
+from unittest.mock import patch
+from spectrum_systems.modules.review_convergence_controller import ReviewConvergenceController
+
+_MODULE = "spectrum_systems.modules.review_convergence_controller.run_review_fix_execution_cycle"
+
+
+@pytest.fixture
+def controller():
+    return ReviewConvergenceController(max_iterations=3)
+
+
+def test_converges_on_first_iteration(controller):
+    """RT-Loop-04: Already-clean result returns immediately without further iterations."""
+    with patch(_MODULE) as mock_run:
+        mock_run.return_value = {
+            "artifact_type": "review_fix_result",
+            "review_status": "pass",
+            "artifact_id": "res-1",
+        }
+
+        result = controller.run_until_clean({"artifact_type": "request"}, trace_id="trace-001")
+
+        assert result["convergence_status"] == "CLEAN"
+        assert result["convergence_iterations"] == 1
+        assert mock_run.call_count == 1
+
+
+def test_converges_after_fix(controller):
+    """RT-Loop-05: Runs a second iteration after an incomplete fix, then stops when clean."""
+    with patch(_MODULE) as mock_run:
+        mock_run.side_effect = [
+            {
+                "artifact_type": "review_fix_result",
+                "review_status": "fail",
+                "remaining_issues": ["issue_1"],
+                "fixed_artifact": {"data": "fixed"},
+                "artifact_id": "res-1",
+            },
+            {
+                "artifact_type": "review_fix_result",
+                "review_status": "pass",
+                "remaining_issues": [],
+                "artifact_id": "res-2",
+            },
+        ]
+
+        result = controller.run_until_clean({"artifact_type": "request"}, trace_id="trace-002")
+
+        assert result["convergence_status"] == "CLEAN"
+        assert result["convergence_iterations"] == 2
+        assert mock_run.call_count == 2
+
+
+def test_blocks_after_max_iterations(controller):
+    """RT-Loop-06: Returns BLOCKED_MAX_ITERATIONS when no iteration produces a clean result."""
+    with patch(_MODULE) as mock_run:
+        mock_run.return_value = {
+            "artifact_type": "review_fix_result",
+            "review_status": "fail",
+            "remaining_issues": ["persistent_issue"],
+            "artifact_id": "res-x",
+        }
+
+        result = controller.run_until_clean({"artifact_type": "request"}, trace_id="trace-003")
+
+        assert result["convergence_status"] == "BLOCKED_MAX_ITERATIONS"
+        assert result["convergence_iterations"] == 3
+        assert mock_run.call_count == 3

--- a/tests/test_wpg_judgment_persistence.py
+++ b/tests/test_wpg_judgment_persistence.py
@@ -1,0 +1,73 @@
+"""Tests for WPG judgment persistence — RT-Loop-10 and RT-Loop-11."""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from spectrum_systems.orchestration.wpg_pipeline import _persist_judgment_if_valid
+
+
+_ALLOW_JUDGMENT_EVAL = {
+    "artifact_type": "judgment_eval",
+    "evaluation_refs": {
+        "control_decision": {
+            "decision": "ALLOW",
+            "reasons": ["judgment_quality_ok"],
+            "enforcement": {"action": "proceed"},
+        }
+    },
+}
+
+_BLOCK_JUDGMENT_EVAL = {
+    "artifact_type": "judgment_eval",
+    "evaluation_refs": {
+        "control_decision": {
+            "decision": "BLOCK",
+            "reasons": ["rationale_non_empty"],
+            "enforcement": {"action": "trigger_repair"},
+        }
+    },
+}
+
+_JUDGMENT_RECORD = {
+    "artifact_type": "judgment_record",
+    "artifact_id": "jdg-abc123",
+    "cycle_id": "cycle-trace-001",
+    "selected_outcome": "approve",
+    "rationale_summary": "finding:none",
+}
+
+
+def test_wpg_persists_valid_judgment():
+    """RT-Loop-10: Valid (ALLOW) judgment is persisted to the JudgmentCorpus."""
+    artifact_store = Mock()
+
+    with patch("spectrum_systems.orchestration.wpg_pipeline.JudgmentCorpus") as mock_corpus_class:
+        mock_corpus = Mock()
+        mock_corpus_class.return_value = mock_corpus
+
+        _persist_judgment_if_valid(_JUDGMENT_RECORD, _ALLOW_JUDGMENT_EVAL, artifact_store)
+
+        mock_corpus_class.assert_called_once_with(artifact_store)
+        mock_corpus.record_judgment.assert_called_once()
+        call_kwargs = mock_corpus.record_judgment.call_args.kwargs
+        assert call_kwargs["decision"] == "approve"
+        assert call_kwargs["confidence"] >= 0.0
+
+
+def test_wpg_skips_persistence_on_blocked_judgment():
+    """RT-Loop-11: BLOCK judgment is not persisted to the JudgmentCorpus."""
+    artifact_store = Mock()
+
+    with patch("spectrum_systems.orchestration.wpg_pipeline.JudgmentCorpus") as mock_corpus_class:
+        mock_corpus = Mock()
+        mock_corpus_class.return_value = mock_corpus
+
+        _persist_judgment_if_valid(_JUDGMENT_RECORD, _BLOCK_JUDGMENT_EVAL, artifact_store)
+
+        mock_corpus.record_judgment.assert_not_called()
+
+
+def test_wpg_skips_persistence_without_artifact_store():
+    """No artifact_store means persistence is skipped entirely (backward compat)."""
+    with patch("spectrum_systems.orchestration.wpg_pipeline.JudgmentCorpus") as mock_corpus_class:
+        _persist_judgment_if_valid(_JUDGMENT_RECORD, _ALLOW_JUDGMENT_EVAL, None)
+        mock_corpus_class.assert_not_called()


### PR DESCRIPTION
Implements five independent loop fixes that tighten the execution →
eval → control → enforcement → feedback → execution cycle:

1. FailureToEvalPipeline (modules/feedback/failure_to_eval_pipeline.py)
   Routes classified errors into governed eval candidate creation so each
   failure class can improve future eval coverage (RT-Loop-01..03).

2. ReviewConvergenceController (modules/review_convergence_controller.py)
   Wraps run_review_fix_execution_cycle in a convergence loop that retries
   until output is clean or max_iterations is exceeded (RT-Loop-04..06).

3. Drift-Aware Admission (govern/govern.py)
   Extends policy_check() with an optional drift_state parameter; critical
   drift signals block admission to prevent amplification during recovery,
   while warning signals allow but log (RT-Loop-07..09).

4. WPG Judgment Persistence (orchestration/wpg_pipeline.py)
   Persists valid WPG judgments to JudgmentCorpus so precedents are
   available for future cycles (RT-Loop-10..11).

5. In-Memory Judgment Handoff (orchestration/cycle_runner.py)
   Carries judgment artifacts in the run_cycle return dict alongside
   their disk paths, eliminating a redundant file re-read for downstream
   callers (RT-Loop-12).

15 new tests, 0 regressions on existing suite.

https://claude.ai/code/session_01UUR3pa6iFJGmk7tJnbcDnV