### PR TITLE
docs(changelog): record 5 core loop fixes (strengthen-core-loops)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 ## Added
+- 2026-04-24 — Strengthen core loops: closed 5 disconnected feedback paths in the governed execution runtime (PR #1170).
+  - **FailureToEvalPipeline** (`modules/feedback/failure_to_eval_pipeline.py`): Routes classified errors into governed `eval_candidate` artifacts so each failure class improves future eval coverage. Closes `failure → classified → (dead end)`.
+  - **ReviewConvergenceController** (`modules/review_convergence_controller.py`): Wraps the review-fix cycle in a convergence loop that retries until output is clean or `max_iterations` is exceeded. Closes `review → fix → (assume clean)`.
+  - **Drift-Aware Admission** (`govern/govern.py`): `policy_check()` now accepts an optional `drift_state`; critical signals block admission to prevent amplification during recovery, warning signals log but allow. Closes `drift detected → (no throttle)`.
+  - **WPG Judgment Persistence** (`orchestration/wpg_pipeline.py`): Valid WPG judgments are persisted to `JudgmentCorpus` via `_persist_judgment_if_valid` for precedent reuse. Closes `WPG judgments → (discarded)`.
+  - **In-Memory Judgment Handoff** (`orchestration/cycle_runner.py`): Judgment artifacts are carried in `manifest["_judgment_inmem"]` and surfaced in the `run_cycle` return value, eliminating a redundant file re-read. Closes `judgment → file → re-read`.
+  - 15 new tests across 5 test files; 0 regressions on the existing suite.
 - 2026-03-14 — Added the meeting agenda contract (schema v1.0.0) with canonical inputs, outputs, agenda item/source reference schemas, JSON/Markdown/DOCX targets, and examples for agenda generation.
 - 2026-03-14 — Published the PDF-anchored DOCX comment injection contract as a czar-level artifact (schema v1.0.1) with fixed column order, status normalization, audit reporting, and duplicate guards.
 - 2026-03-13 — Added governance documents to guide system design (CONTRIBUTING.md, GLOSSARY.md, VALIDATION.md, DATA_SOURCES.md, REPO_MAP.md, SYSTEM_TEMPLATE.md, CHANGELOG.md, DECISIONS.md).


### PR DESCRIPTION
## Summary

- Adds a CHANGELOG.md entry documenting the 5 core feedback loop fixes that shipped in PR #1170.
- This completes the execution checklist item: *"Update CHANGELOG.md"* for each loop fix.

The 5 fixes recorded:

| Fix | Module | Loop closed |
|-----|--------|-------------|
| FailureToEvalPipeline | `modules/feedback/failure_to_eval_pipeline.py` | `failure → classified → (dead end)` |
| ReviewConvergenceController | `modules/review_convergence_controller.py` | `review → fix → (assume clean)` |
| Drift-Aware Admission | `govern/govern.py` | `drift detected → (no throttle)` |
| WPG Judgment Persistence | `orchestration/wpg_pipeline.py` | `WPG judgments → (discarded)` |
| In-Memory Judgment Handoff | `orchestration/cycle_runner.py` | `judgment → file → re-read` |

## Test plan

- [ ] No code changes — CHANGELOG update only.
- [ ] All 15 loop-fix tests still pass: `pytest tests/test_failure_to_eval_pipeline.py tests/test_review_convergence_controller.py tests/test_govern_drift_aware.py tests/test_wpg_judgment_persistence.py tests/test_cycle_runner_judgment_handoff.py -v`

https://claude.ai/code/session_01PsYsy3EPFWTmxQ3yp6DcU9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PsYsy3EPFWTmxQ3yp6DcU9)_