### PR TITLE
feat(rge): analysis engine emits autonomy gate + AST fragility signals (PR-A)

### DIFF
--- a/artifacts/authenticity_hardgate_24_01/checkpoint_summary.json
+++ b/artifacts/authenticity_hardgate_24_01/checkpoint_summary.json
@@ -1,7 +1,7 @@
 {
   "artifact_type": "checkpoint_summary",
   "batch_id": "AUTHENTICITY-HARDGATE-24-01",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "execution_mode": "SERIAL WITH HARD CHECKPOINTS",
   "umbrella_sequence": [
     "UMBRELLA-1",

--- a/artifacts/authenticity_hardgate_24_01/closeout_artifact.json
+++ b/artifacts/authenticity_hardgate_24_01/closeout_artifact.json
@@ -1,7 +1,7 @@
 {
   "artifact_type": "closeout_artifact",
   "batch_id": "AUTHENTICITY-HARDGATE-24-01",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "status": "pass",
   "required_reporting_artifacts_non_empty": true,
   "final_success_conditions": {

--- a/artifacts/authenticity_hardgate_24_01/registry_alignment_result.json
+++ b/artifacts/authenticity_hardgate_24_01/registry_alignment_result.json
@@ -1,7 +1,7 @@
 {
   "artifact_type": "registry_alignment_result",
   "batch_id": "AUTHENTICITY-HARDGATE-24-01",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "authorities": [
     "README.md",
     "docs/architecture/system_registry.md",

--- a/artifacts/authenticity_hardgate_24_01/umbrella-1_checkpoint.json
+++ b/artifacts/authenticity_hardgate_24_01/umbrella-1_checkpoint.json
@@ -1,7 +1,7 @@
 {
   "artifact_type": "authenticity_hardgate_umbrella_checkpoint",
   "batch_id": "AUTHENTICITY-HARDGATE-24-01",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "execution_mode": "SERIAL WITH HARD CHECKPOINTS",
   "umbrella_id": "UMBRELLA-1",
   "umbrella_name": "AUTHENTICITY_HARDENING",

--- a/artifacts/authenticity_hardgate_24_01/umbrella-2_checkpoint.json
+++ b/artifacts/authenticity_hardgate_24_01/umbrella-2_checkpoint.json
@@ -1,7 +1,7 @@
 {
   "artifact_type": "authenticity_hardgate_umbrella_checkpoint",
   "batch_id": "AUTHENTICITY-HARDGATE-24-01",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "execution_mode": "SERIAL WITH HARD CHECKPOINTS",
   "umbrella_id": "UMBRELLA-2",
   "umbrella_name": "REPO_WRITE_INGRESS_UNIFICATION",

--- a/artifacts/authenticity_hardgate_24_01/umbrella-3_checkpoint.json
+++ b/artifacts/authenticity_hardgate_24_01/umbrella-3_checkpoint.json
@@ -1,7 +1,7 @@
 {
   "artifact_type": "authenticity_hardgate_umbrella_checkpoint",
   "batch_id": "AUTHENTICITY-HARDGATE-24-01",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "execution_mode": "SERIAL WITH HARD CHECKPOINTS",
   "umbrella_id": "UMBRELLA-3",
   "umbrella_name": "REPLAY_PROTECTED_REENTRY_AND_REPAIR",

--- a/artifacts/authenticity_hardgate_24_01/umbrella-4_checkpoint.json
+++ b/artifacts/authenticity_hardgate_24_01/umbrella-4_checkpoint.json
@@ -1,7 +1,7 @@
 {
   "artifact_type": "authenticity_hardgate_umbrella_checkpoint",
   "batch_id": "AUTHENTICITY-HARDGATE-24-01",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "execution_mode": "SERIAL WITH HARD CHECKPOINTS",
   "umbrella_id": "UMBRELLA-4",
   "umbrella_name": "HARD_GATE_EVIDENCE_CLOSURE_AND_OPERATOR_PROOF",

--- a/artifacts/authenticity_hardgate_24_01/umbrella_1/admission_authenticity_envelope_spec.json
+++ b/artifacts/authenticity_hardgate_24_01/umbrella_1/admission_authenticity_envelope_spec.json
@@ -2,7 +2,7 @@
   "artifact_type": "admission_authenticity_envelope_spec",
   "slice_id": "AH-01",
   "owner": "AEX",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "required_fields": [
     "issuer",
     "key_id",

--- a/artifacts/authenticity_hardgate_24_01/umbrella_1/attested_build_admission_record.json
+++ b/artifacts/authenticity_hardgate_24_01/umbrella_1/attested_build_admission_record.json
@@ -2,7 +2,7 @@
   "artifact_type": "attested_build_admission_record",
   "slice_id": "AH-02",
   "owner": "AEX",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "attested": true,
   "issuer": "aex-control-plane",
   "payload_digest": "sha256:attested-build-admission"

--- a/artifacts/authenticity_hardgate_24_01/umbrella_1/attested_normalized_execution_request.json
+++ b/artifacts/authenticity_hardgate_24_01/umbrella_1/attested_normalized_execution_request.json
@@ -2,7 +2,7 @@
   "artifact_type": "attested_normalized_execution_request",
   "slice_id": "AH-02",
   "owner": "AEX",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "attested": true,
   "normalized": true,
   "payload_digest": "sha256:attested-normalized-execution-request"

--- a/artifacts/authenticity_hardgate_24_01/umbrella_1/attested_tlc_handoff_record.json
+++ b/artifacts/authenticity_hardgate_24_01/umbrella_1/attested_tlc_handoff_record.json
@@ -2,7 +2,7 @@
   "artifact_type": "attested_tlc_handoff_record",
   "slice_id": "AH-03",
   "owner": "TLC",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "attested": true,
   "orchestration_only": true,
   "lineage": [

--- a/artifacts/authenticity_hardgate_24_01/umbrella_1/authenticity_regression_review_result.json
+++ b/artifacts/authenticity_hardgate_24_01/umbrella_1/authenticity_regression_review_result.json
@@ -2,7 +2,7 @@
   "artifact_type": "authenticity_regression_review_result",
   "slice_id": "AH-06",
   "owner": "RQX",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "review_loop_verification_only": true,
   "coverage_status": "all_known_repo_write_paths_reviewed"
 }

--- a/artifacts/authenticity_hardgate_24_01/umbrella_1/canonical_delivery_report_artifact.json
+++ b/artifacts/authenticity_hardgate_24_01/umbrella_1/canonical_delivery_report_artifact.json
@@ -1,7 +1,7 @@
 {
   "artifact_type": "canonical_delivery_report_artifact",
   "batch_id": "AUTHENTICITY-HARDGATE-24-01",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "non_empty": true,
   "summary": "Admission authenticity envelope and execution-edge forged-lineage fail gate established."
 }

--- a/artifacts/authenticity_hardgate_24_01/umbrella_1/canonical_review_report_artifact.json
+++ b/artifacts/authenticity_hardgate_24_01/umbrella_1/canonical_review_report_artifact.json
@@ -1,7 +1,7 @@
 {
   "artifact_type": "canonical_review_report_artifact",
   "batch_id": "AUTHENTICITY-HARDGATE-24-01",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "review_status": "pass",
   "ownership_boundaries_validated": true
 }

--- a/artifacts/authenticity_hardgate_24_01/umbrella_1/forged_lineage_enforcement_result.json
+++ b/artifacts/authenticity_hardgate_24_01/umbrella_1/forged_lineage_enforcement_result.json
@@ -2,7 +2,7 @@
   "artifact_type": "forged_lineage_enforcement_result",
   "slice_id": "AH-05",
   "owner": "SEL",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "fail_closed": true,
   "syntactically_valid_non_authentic_lineage": "blocked"
 }

--- a/artifacts/authenticity_hardgate_24_01/umbrella_1/repo_write_authenticity_validation_result.json
+++ b/artifacts/authenticity_hardgate_24_01/umbrella_1/repo_write_authenticity_validation_result.json
@@ -2,7 +2,7 @@
   "artifact_type": "repo_write_authenticity_validation_result",
   "slice_id": "AH-04",
   "owner": "PQX",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "execution_edge": "repo_write",
   "issuer_bound_authenticity": "pass",
   "payload_digest_continuity": "pass",

--- a/artifacts/authenticity_hardgate_24_01/umbrella_2/direct_caller_bypass_enforcement_result.json
+++ b/artifacts/authenticity_hardgate_24_01/umbrella_2/direct_caller_bypass_enforcement_result.json
@@ -2,7 +2,7 @@
   "artifact_type": "direct_caller_bypass_enforcement_result",
   "slice_id": "AH-09",
   "owner": "SEL",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "fail_closed": true,
   "legacy_direct_caller_repo_write": "blocked"
 }

--- a/artifacts/authenticity_hardgate_24_01/umbrella_2/mandatory_ingress_handoff_record.json
+++ b/artifacts/authenticity_hardgate_24_01/umbrella_2/mandatory_ingress_handoff_record.json
@@ -2,7 +2,7 @@
   "artifact_type": "mandatory_ingress_handoff_record",
   "slice_id": "AH-08",
   "owner": "TLC",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "orchestration_only": true,
   "routed_via_mandatory_ingress": true
 }

--- a/artifacts/authenticity_hardgate_24_01/umbrella_2/repo_write_capability_classification_record.json
+++ b/artifacts/authenticity_hardgate_24_01/umbrella_2/repo_write_capability_classification_record.json
@@ -2,7 +2,7 @@
   "artifact_type": "repo_write_capability_classification_record",
   "slice_id": "AH-10",
   "owner": "PQX",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "classification_mode": "capability_first",
   "default_classification": "repo_write_class",
   "isolation_proof_required_for_downgrade": true

--- a/artifacts/authenticity_hardgate_24_01/umbrella_2/repo_write_capability_scope_policy.json
+++ b/artifacts/authenticity_hardgate_24_01/umbrella_2/repo_write_capability_scope_policy.json
@@ -2,7 +2,7 @@
   "artifact_type": "repo_write_capability_scope_policy",
   "slice_id": "AH-11",
   "owner": "TPA",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "policy_scope_only": true,
   "gating_applies_to": "capability_classified_repo_write_execution"
 }

--- a/artifacts/authenticity_hardgate_24_01/umbrella_2/repo_write_ingress_allowlist_record.json
+++ b/artifacts/authenticity_hardgate_24_01/umbrella_2/repo_write_ingress_allowlist_record.json
@@ -2,7 +2,7 @@
   "artifact_type": "repo_write_ingress_allowlist_record",
   "slice_id": "AH-12",
   "owner": "AEX",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "allowlist_mode": "contracted",
   "alternate_callers_require_mandatory_ingress": true
 }

--- a/artifacts/authenticity_hardgate_24_01/umbrella_2/repo_write_ingress_manifest.json
+++ b/artifacts/authenticity_hardgate_24_01/umbrella_2/repo_write_ingress_manifest.json
@@ -2,7 +2,7 @@
   "artifact_type": "repo_write_ingress_manifest",
   "slice_id": "AH-07",
   "owner": "AEX",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "approved_ingress_seams": [
     "aex_repo_write_ingress_wrapper"
   ],

--- a/artifacts/authenticity_hardgate_24_01/umbrella_3/fix_reentry_lineage_forwarding_record.json
+++ b/artifacts/authenticity_hardgate_24_01/umbrella_3/fix_reentry_lineage_forwarding_record.json
@@ -2,7 +2,7 @@
   "artifact_type": "fix_reentry_lineage_forwarding_record",
   "slice_id": "AH-13",
   "owner": "TLC",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "orchestration_only": true,
   "lineage_forwarded": [
     "AEX",

--- a/artifacts/authenticity_hardgate_24_01/umbrella_3/reentry_continuation_decision.json
+++ b/artifacts/authenticity_hardgate_24_01/umbrella_3/reentry_continuation_decision.json
@@ -2,7 +2,7 @@
   "artifact_type": "reentry_continuation_decision",
   "slice_id": "AH-18",
   "owner": "CDE",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "authority": "continuation_decision_authoritative",
   "decision": "continue_only_when_authenticity_and_replay_constraints_hold"
 }

--- a/artifacts/authenticity_hardgate_24_01/umbrella_3/reentry_review_tightening_record.json
+++ b/artifacts/authenticity_hardgate_24_01/umbrella_3/reentry_review_tightening_record.json
@@ -2,7 +2,7 @@
   "artifact_type": "reentry_review_tightening_record",
   "slice_id": "AH-17",
   "owner": "RQX",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "review_loop_verification_only": true,
   "tightened_when_authenticity_or_replay_evidence_weak": true
 }

--- a/artifacts/authenticity_hardgate_24_01/umbrella_3/replay_safe_repair_candidate_bundle.json
+++ b/artifacts/authenticity_hardgate_24_01/umbrella_3/replay_safe_repair_candidate_bundle.json
@@ -2,7 +2,7 @@
   "artifact_type": "replay_safe_repair_candidate_bundle",
   "slice_id": "AH-16",
   "owner": "FRE",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "repair_planning_only": true,
   "lineage_and_replay_constraints_preserved": true
 }

--- a/artifacts/authenticity_hardgate_24_01/umbrella_3/replayed_lineage_enforcement_result.json
+++ b/artifacts/authenticity_hardgate_24_01/umbrella_3/replayed_lineage_enforcement_result.json
@@ -2,7 +2,7 @@
   "artifact_type": "replayed_lineage_enforcement_result",
   "slice_id": "AH-15",
   "owner": "SEL",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "fail_closed": true,
   "replayed_lineage": "blocked"
 }

--- a/artifacts/authenticity_hardgate_24_01/umbrella_3/repo_write_replay_protection_result.json
+++ b/artifacts/authenticity_hardgate_24_01/umbrella_3/repo_write_replay_protection_result.json
@@ -2,7 +2,7 @@
   "artifact_type": "repo_write_replay_protection_result",
   "slice_id": "AH-14",
   "owner": "PQX",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "execution_edge": "repo_write",
   "replay_protection": "enforced",
   "nonce_reuse": "blocked"

--- a/artifacts/authenticity_hardgate_24_01/umbrella_4/boundary_hardening_program_closeout.json
+++ b/artifacts/authenticity_hardgate_24_01/umbrella_4/boundary_hardening_program_closeout.json
@@ -2,7 +2,7 @@
   "artifact_type": "boundary_hardening_program_closeout",
   "slice_id": "AH-24",
   "owner": "PRG",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "authoritative": false,
   "trust_gap_reduction_signal": "improving",
   "next_remaining_focus": "issuer-key-rotation-evidence and replay-window telemetry"

--- a/artifacts/authenticity_hardgate_24_01/umbrella_4/certification_readiness_decision.json
+++ b/artifacts/authenticity_hardgate_24_01/umbrella_4/certification_readiness_decision.json
@@ -2,7 +2,7 @@
   "artifact_type": "certification_readiness_decision",
   "slice_id": "AH-21",
   "owner": "CDE",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "authority": "certification_readiness_authoritative",
   "depends_on": [
     "evidence_completeness",

--- a/artifacts/authenticity_hardgate_24_01/umbrella_4/hard_gate_evidence_completeness_packet.json
+++ b/artifacts/authenticity_hardgate_24_01/umbrella_4/hard_gate_evidence_completeness_packet.json
@@ -2,7 +2,7 @@
   "artifact_type": "hard_gate_evidence_completeness_packet",
   "slice_id": "AH-19",
   "owner": "RIL",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "interpretation_only": true,
   "statuses": [
     "complete",

--- a/artifacts/authenticity_hardgate_24_01/umbrella_4/hard_gate_evidence_gap_scoreboard.json
+++ b/artifacts/authenticity_hardgate_24_01/umbrella_4/hard_gate_evidence_gap_scoreboard.json
@@ -2,7 +2,7 @@
   "artifact_type": "hard_gate_evidence_gap_scoreboard",
   "slice_id": "AH-20",
   "owner": "PRG",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "authoritative": false,
   "tracks_recurring_gap_classes": true
 }

--- a/artifacts/authenticity_hardgate_24_01/umbrella_4/hard_gate_proof_projection_bundle.json
+++ b/artifacts/authenticity_hardgate_24_01/umbrella_4/hard_gate_proof_projection_bundle.json
@@ -2,7 +2,7 @@
   "artifact_type": "hard_gate_proof_projection_bundle",
   "slice_id": "AH-22",
   "owner": "MAP",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "projection_only": true,
   "semantics_invented": false
 }

--- a/artifacts/authenticity_hardgate_24_01/umbrella_4/promotion_evidence_closure_guard_result.json
+++ b/artifacts/authenticity_hardgate_24_01/umbrella_4/promotion_evidence_closure_guard_result.json
@@ -2,7 +2,7 @@
   "artifact_type": "promotion_evidence_closure_guard_result",
   "slice_id": "AH-23",
   "owner": "SEL",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "enforcement_only": true,
   "block_promotion_when_closure_incomplete": true
 }

--- a/artifacts/certification_judgment_40_explicit/certification_evidence_enforcement_result.json
+++ b/artifacts/certification_judgment_40_explicit/certification_evidence_enforcement_result.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 6,
   "owner": "SEL",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": true,

--- a/artifacts/certification_judgment_40_explicit/certification_judgment_program_closeout.json
+++ b/artifacts/certification_judgment_40_explicit/certification_judgment_program_closeout.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 40,
   "owner": "PRG",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": false,

--- a/artifacts/certification_judgment_40_explicit/certification_operator_proof_bundle.json
+++ b/artifacts/certification_judgment_40_explicit/certification_operator_proof_bundle.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 8,
   "owner": "MAP",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": false,

--- a/artifacts/certification_judgment_40_explicit/certification_probe_execution_bundle.json
+++ b/artifacts/certification_judgment_40_explicit/certification_probe_execution_bundle.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 4,
   "owner": "PQX",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": false,

--- a/artifacts/certification_judgment_40_explicit/certification_probe_review_verdict.json
+++ b/artifacts/certification_judgment_40_explicit/certification_probe_review_verdict.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 5,
   "owner": "RQX",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": false,

--- a/artifacts/certification_judgment_40_explicit/certification_readiness_decision.json
+++ b/artifacts/certification_judgment_40_explicit/certification_readiness_decision.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 7,
   "owner": "CDE",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": false,

--- a/artifacts/certification_judgment_40_explicit/certification_regression_enforcement_result.json
+++ b/artifacts/certification_judgment_40_explicit/certification_regression_enforcement_result.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 31,
   "owner": "SEL",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": true,

--- a/artifacts/certification_judgment_40_explicit/certification_regression_replay_bundle.json
+++ b/artifacts/certification_judgment_40_explicit/certification_regression_replay_bundle.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 29,
   "owner": "PQX",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": false,

--- a/artifacts/certification_judgment_40_explicit/certification_regression_review_tightening_record.json
+++ b/artifacts/certification_judgment_40_explicit/certification_regression_review_tightening_record.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 30,
   "owner": "RQX",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": false,

--- a/artifacts/certification_judgment_40_explicit/certification_requirement_scope_policy.json
+++ b/artifacts/certification_judgment_40_explicit/certification_requirement_scope_policy.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 3,
   "owner": "TPA",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": false,

--- a/artifacts/certification_judgment_40_explicit/certification_risk_admission_record.json
+++ b/artifacts/certification_judgment_40_explicit/certification_risk_admission_record.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 2,
   "owner": "AEX",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": false,

--- a/artifacts/certification_judgment_40_explicit/checkpoint-1.json
+++ b/artifacts/certification_judgment_40_explicit/checkpoint-1.json
@@ -2,7 +2,7 @@
   "artifact_type": "certification_judgment_checkpoint",
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "checkpoint": 1,
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "steps": [
     "STEP 01",

--- a/artifacts/certification_judgment_40_explicit/checkpoint-10.json
+++ b/artifacts/certification_judgment_40_explicit/checkpoint-10.json
@@ -2,7 +2,7 @@
   "artifact_type": "certification_judgment_checkpoint",
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "checkpoint": 10,
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "steps": [
     "STEP 37",

--- a/artifacts/certification_judgment_40_explicit/checkpoint-2.json
+++ b/artifacts/certification_judgment_40_explicit/checkpoint-2.json
@@ -2,7 +2,7 @@
   "artifact_type": "certification_judgment_checkpoint",
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "checkpoint": 2,
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "steps": [
     "STEP 05",

--- a/artifacts/certification_judgment_40_explicit/checkpoint-3.json
+++ b/artifacts/certification_judgment_40_explicit/checkpoint-3.json
@@ -2,7 +2,7 @@
   "artifact_type": "certification_judgment_checkpoint",
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "checkpoint": 3,
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "steps": [
     "STEP 09",

--- a/artifacts/certification_judgment_40_explicit/checkpoint-4.json
+++ b/artifacts/certification_judgment_40_explicit/checkpoint-4.json
@@ -2,7 +2,7 @@
   "artifact_type": "certification_judgment_checkpoint",
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "checkpoint": 4,
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "steps": [
     "STEP 13",

--- a/artifacts/certification_judgment_40_explicit/checkpoint-5.json
+++ b/artifacts/certification_judgment_40_explicit/checkpoint-5.json
@@ -2,7 +2,7 @@
   "artifact_type": "certification_judgment_checkpoint",
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "checkpoint": 5,
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "steps": [
     "STEP 17",

--- a/artifacts/certification_judgment_40_explicit/checkpoint-6.json
+++ b/artifacts/certification_judgment_40_explicit/checkpoint-6.json
@@ -2,7 +2,7 @@
   "artifact_type": "certification_judgment_checkpoint",
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "checkpoint": 6,
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "steps": [
     "STEP 21",

--- a/artifacts/certification_judgment_40_explicit/checkpoint-7.json
+++ b/artifacts/certification_judgment_40_explicit/checkpoint-7.json
@@ -2,7 +2,7 @@
   "artifact_type": "certification_judgment_checkpoint",
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "checkpoint": 7,
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "steps": [
     "STEP 25",

--- a/artifacts/certification_judgment_40_explicit/checkpoint-8.json
+++ b/artifacts/certification_judgment_40_explicit/checkpoint-8.json
@@ -2,7 +2,7 @@
   "artifact_type": "certification_judgment_checkpoint",
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "checkpoint": 8,
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "steps": [
     "STEP 29",

--- a/artifacts/certification_judgment_40_explicit/checkpoint-9.json
+++ b/artifacts/certification_judgment_40_explicit/checkpoint-9.json
@@ -2,7 +2,7 @@
   "artifact_type": "certification_judgment_checkpoint",
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "checkpoint": 9,
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "steps": [
     "STEP 33",

--- a/artifacts/certification_judgment_40_explicit/checkpoint_summary.json
+++ b/artifacts/certification_judgment_40_explicit/checkpoint_summary.json
@@ -1,7 +1,7 @@
 {
   "artifact_type": "checkpoint_summary",
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "checkpoints": [
     "checkpoint-1",
     "checkpoint-2",

--- a/artifacts/certification_judgment_40_explicit/delivery_report.json
+++ b/artifacts/certification_judgment_40_explicit/delivery_report.json
@@ -1,7 +1,7 @@
 {
   "artifact_type": "delivery_report",
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "required_outputs_delivered": true,
   "step_count": 40,
   "checkpoint_count": 10

--- a/artifacts/certification_judgment_40_explicit/drift_freeze_candidate_guard_result.json
+++ b/artifacts/certification_judgment_40_explicit/drift_freeze_candidate_guard_result.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 27,
   "owner": "SEL",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": true,

--- a/artifacts/certification_judgment_40_explicit/drift_hold_decision.json
+++ b/artifacts/certification_judgment_40_explicit/drift_hold_decision.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 28,
   "owner": "CDE",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": false,

--- a/artifacts/certification_judgment_40_explicit/drift_pressure_interpretation_packet.json
+++ b/artifacts/certification_judgment_40_explicit/drift_pressure_interpretation_packet.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 25,
   "owner": "RIL",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": false,

--- a/artifacts/certification_judgment_40_explicit/drift_pressure_scoreboard.json
+++ b/artifacts/certification_judgment_40_explicit/drift_pressure_scoreboard.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 26,
   "owner": "PRG",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": false,

--- a/artifacts/certification_judgment_40_explicit/evidence_debt_escalation_result.json
+++ b/artifacts/certification_judgment_40_explicit/evidence_debt_escalation_result.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 20,
   "owner": "SEL",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": true,

--- a/artifacts/certification_judgment_40_explicit/evidence_debt_interpretation_packet.json
+++ b/artifacts/certification_judgment_40_explicit/evidence_debt_interpretation_packet.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 17,
   "owner": "RIL",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": false,

--- a/artifacts/certification_judgment_40_explicit/evidence_debt_priority_stack.json
+++ b/artifacts/certification_judgment_40_explicit/evidence_debt_priority_stack.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 19,
   "owner": "PRG",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": false,

--- a/artifacts/certification_judgment_40_explicit/evidence_debt_register.json
+++ b/artifacts/certification_judgment_40_explicit/evidence_debt_register.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 18,
   "owner": "PRG",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": false,

--- a/artifacts/certification_judgment_40_explicit/hard_gate_evidence_inventory_packet.json
+++ b/artifacts/certification_judgment_40_explicit/hard_gate_evidence_inventory_packet.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 1,
   "owner": "RIL",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": false,

--- a/artifacts/certification_judgment_40_explicit/judgment_candidate_register.json
+++ b/artifacts/certification_judgment_40_explicit/judgment_candidate_register.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 10,
   "owner": "PRG",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": false,

--- a/artifacts/certification_judgment_40_explicit/judgment_extraction_interpretation_packet.json
+++ b/artifacts/certification_judgment_40_explicit/judgment_extraction_interpretation_packet.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 9,
   "owner": "RIL",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": false,

--- a/artifacts/certification_judgment_40_explicit/judgment_policy_candidate_set.json
+++ b/artifacts/certification_judgment_40_explicit/judgment_policy_candidate_set.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 11,
   "owner": "PRG",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": false,

--- a/artifacts/certification_judgment_40_explicit/judgment_priority_batch_artifact.json
+++ b/artifacts/certification_judgment_40_explicit/judgment_priority_batch_artifact.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 14,
   "owner": "RDX",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": false,

--- a/artifacts/certification_judgment_40_explicit/judgment_rationale_projection_bundle.json
+++ b/artifacts/certification_judgment_40_explicit/judgment_rationale_projection_bundle.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 12,
   "owner": "MAP",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": false,

--- a/artifacts/certification_judgment_40_explicit/judgment_reuse_scorecard.json
+++ b/artifacts/certification_judgment_40_explicit/judgment_reuse_scorecard.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 13,
   "owner": "PRG",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": false,

--- a/artifacts/certification_judgment_40_explicit/judgment_sensitive_readiness_decision.json
+++ b/artifacts/certification_judgment_40_explicit/judgment_sensitive_readiness_decision.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 16,
   "owner": "CDE",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": false,

--- a/artifacts/certification_judgment_40_explicit/judgment_umbrella_sequencing_plan.json
+++ b/artifacts/certification_judgment_40_explicit/judgment_umbrella_sequencing_plan.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 15,
   "owner": "RDX",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": false,

--- a/artifacts/certification_judgment_40_explicit/observability_completeness_guard_result.json
+++ b/artifacts/certification_judgment_40_explicit/observability_completeness_guard_result.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 24,
   "owner": "SEL",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": true,

--- a/artifacts/certification_judgment_40_explicit/observability_completeness_packet.json
+++ b/artifacts/certification_judgment_40_explicit/observability_completeness_packet.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 21,
   "owner": "RIL",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": false,

--- a/artifacts/certification_judgment_40_explicit/observability_debt_register.json
+++ b/artifacts/certification_judgment_40_explicit/observability_debt_register.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 22,
   "owner": "PRG",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": false,

--- a/artifacts/certification_judgment_40_explicit/observability_probe_execution_bundle.json
+++ b/artifacts/certification_judgment_40_explicit/observability_probe_execution_bundle.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 23,
   "owner": "PQX",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": false,

--- a/artifacts/certification_judgment_40_explicit/operator_ambiguity_tracker.json
+++ b/artifacts/certification_judgment_40_explicit/operator_ambiguity_tracker.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 36,
   "owner": "PRG",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": false,

--- a/artifacts/certification_judgment_40_explicit/operator_closure_topology_bundle.json
+++ b/artifacts/certification_judgment_40_explicit/operator_closure_topology_bundle.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 33,
   "owner": "MAP",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": false,

--- a/artifacts/certification_judgment_40_explicit/promotion_closure_decision.json
+++ b/artifacts/certification_judgment_40_explicit/promotion_closure_decision.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 38,
   "owner": "CDE",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": false,

--- a/artifacts/certification_judgment_40_explicit/promotion_proof_guard_result.json
+++ b/artifacts/certification_judgment_40_explicit/promotion_proof_guard_result.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 39,
   "owner": "SEL",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": true,

--- a/artifacts/certification_judgment_40_explicit/promotion_restraint_recommendation.json
+++ b/artifacts/certification_judgment_40_explicit/promotion_restraint_recommendation.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 37,
   "owner": "PRG",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": false,

--- a/artifacts/certification_judgment_40_explicit/registry_alignment_result.json
+++ b/artifacts/certification_judgment_40_explicit/registry_alignment_result.json
@@ -1,7 +1,7 @@
 {
   "artifact_type": "registry_alignment_result",
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "cross_checks": {
     "each_step_single_canonical_owner": "pass",
     "no_preparatory_artifact_as_authority": "pass",

--- a/artifacts/certification_judgment_40_explicit/regression_remediation_priority_recommendation.json
+++ b/artifacts/certification_judgment_40_explicit/regression_remediation_priority_recommendation.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 32,
   "owner": "PRG",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": false,

--- a/artifacts/certification_judgment_40_explicit/review_report.json
+++ b/artifacts/certification_judgment_40_explicit/review_report.json
@@ -1,7 +1,7 @@
 {
   "artifact_type": "review_report",
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "review_status": "pass",
   "fail_closed_integrity": "pass"
 }

--- a/artifacts/certification_judgment_40_explicit/stale_proof_interpretation_packet.json
+++ b/artifacts/certification_judgment_40_explicit/stale_proof_interpretation_packet.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 34,
   "owner": "RIL",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": false,

--- a/artifacts/certification_judgment_40_explicit/stale_proof_operator_guard_result.json
+++ b/artifacts/certification_judgment_40_explicit/stale_proof_operator_guard_result.json
@@ -3,7 +3,7 @@
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
   "step": 35,
   "owner": "SEL",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "status": "pass",
   "fail_closed": true,

--- a/artifacts/rdx_runs/AUTHENTICITY-HARDGATE-24-01-artifact-trace.json
+++ b/artifacts/rdx_runs/AUTHENTICITY-HARDGATE-24-01-artifact-trace.json
@@ -1,7 +1,7 @@
 {
   "artifact_type": "authenticity_hardgate_artifact_trace",
   "batch_id": "AUTHENTICITY-HARDGATE-24-01",
-  "generated_at": "2026-04-24T16:28:35Z",
+  "generated_at": "2026-04-24T21:03:50Z",
   "execution_mode": "SERIAL WITH HARD CHECKPOINTS",
   "checkpoint_progression": "stopped_on_first_failure_else_continue",
   "umbrella_sequence": [

--- a/artifacts/rdx_runs/CERTIFICATION-JUDGMENT-40-EXPLICIT-artifact-trace.json
+++ b/artifacts/rdx_runs/CERTIFICATION-JUDGMENT-40-EXPLICIT-artifact-trace.json
@@ -1,7 +1,7 @@
 {
   "artifact_type": "rdx_execution_trace",
   "batch_id": "CERTIFICATION-JUDGMENT-40-EXPLICIT",
-  "generated_at": "2026-04-24T16:28:40Z",
+  "generated_at": "2026-04-24T21:03:55Z",
   "execution_mode": "STRICT SERIAL WITH HARD CHECKPOINTS",
   "step_sequence": [
     "hard_gate_evidence_inventory_packet",

--- a/contracts/schemas/rge_analysis_record.schema.json
+++ b/contracts/schemas/rge_analysis_record.schema.json
@@ -16,16 +16,21 @@
     "context_maturity_level",
     "context_maturity_max",
     "modules_present",
+    "wave_status",
     "active_drift_legs",
     "complexity_budget_by_module",
     "mg_slice_health",
     "fragile_points",
+    "fragile_point_signals",
     "bottlenecks",
-    "leg_saturation"
+    "leg_saturation",
+    "entropy_vectors",
+    "rge_can_operate",
+    "rge_max_autonomy"
   ],
   "properties": {
     "artifact_type": { "type": "string", "const": "rge_analysis_record" },
-    "schema_version": { "type": "string", "const": "1.0.0" },
+    "schema_version": { "type": "string", "const": "1.1.0" },
     "record_id": { "type": "string", "minLength": 1 },
     "run_id": { "type": "string", "minLength": 1 },
     "trace_id": { "type": "string", "minLength": 1 },
@@ -34,6 +39,7 @@
     "context_maturity_level": { "type": "integer", "minimum": 0 },
     "context_maturity_max": { "type": "integer", "minimum": 1 },
     "modules_present": { "type": "array", "items": { "type": "string" } },
+    "wave_status": { "type": "integer", "minimum": 0, "maximum": 4 },
     "active_drift_legs": { "type": "array", "items": { "type": "string" } },
     "complexity_budget_by_module": { "type": "object" },
     "mg_slice_health": {
@@ -46,7 +52,47 @@
       }
     },
     "fragile_points": { "type": "array", "items": { "type": "string" } },
+    "fragile_point_signals": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type", "file", "count"],
+        "properties": {
+          "type": { "type": "string", "enum": ["stub_heavy", "silent_excepts"] },
+          "file": { "type": "string", "minLength": 1 },
+          "count": { "type": "integer", "minimum": 0 }
+        }
+      }
+    },
     "bottlenecks": { "type": "array", "items": { "type": "string" } },
-    "leg_saturation": { "type": "object" }
+    "leg_saturation": { "type": "object" },
+    "entropy_vectors": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "decision_entropy",
+        "silent_drift",
+        "exception_accumulation",
+        "hidden_logic_creep",
+        "evaluation_blind_spots",
+        "overconfidence_risk",
+        "loss_of_causality"
+      ],
+      "properties": {
+        "decision_entropy":       { "type": "string", "enum": ["clean", "warn", "critical"] },
+        "silent_drift":           { "type": "string", "enum": ["clean", "warn", "critical"] },
+        "exception_accumulation": { "type": "string", "enum": ["clean", "warn", "critical"] },
+        "hidden_logic_creep":     { "type": "string", "enum": ["clean", "warn", "critical"] },
+        "evaluation_blind_spots": { "type": "string", "enum": ["clean", "warn", "critical"] },
+        "overconfidence_risk":    { "type": "string", "enum": ["clean", "warn", "critical"] },
+        "loss_of_causality":      { "type": "string", "enum": ["clean", "warn", "critical"] }
+      }
+    },
+    "rge_can_operate": { "type": "boolean" },
+    "rge_max_autonomy": {
+      "type": "string",
+      "enum": ["shadow", "warn_gated", "autonomous"]
+    }
   }
 }

--- a/contracts/standards-manifest.json
+++ b/contracts/standards-manifest.json
@@ -16799,13 +16799,13 @@
     {
       "artifact_type": "rge_analysis_record",
       "artifact_class": "coordination",
-      "schema_version": "1.0.0",
+      "schema_version": "1.1.0",
       "status": "proposed",
       "intended_consumers": ["spectrum-systems"],
       "introduced_in": "RGE-E",
       "last_updated_in": "RGE-E",
       "example_path": "contracts/examples/rge_analysis_record.json",
-      "notes": "RGE Wave-0 repo audit snapshot."
+      "notes": "RGE Wave-0 repo audit snapshot. 1.1.0 adds wave_status, entropy_vectors, rge_can_operate, rge_max_autonomy, fragile_point_signals (AST-derived)."
     },
     {
       "artifact_type": "rge_roadmap_record",

--- a/docs/governance-reports/contract-enforcement-report.md
+++ b/docs/governance-reports/contract-enforcement-report.md
@@ -1,6 +1,6 @@
 # Cross-Repo Contract Enforcement Report
 
-Generated: 2026-04-24T16:37:08Z
+Generated: 2026-04-24T21:07:16Z
 Source: `contracts/standards-manifest.json`
 
 ## Summary

--- a/governance/reports/contract-dependency-graph.json
+++ b/governance/reports/contract-dependency-graph.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0.0",
-  "generated_at": "2026-04-24T16:37:08Z",
+  "generated_at": "2026-04-24T21:07:16Z",
   "source_manifest": "contracts/standards-manifest.json",
   "repos": [
     {

--- a/spectrum_systems/rge/analysis_engine.py
+++ b/spectrum_systems/rge/analysis_engine.py
@@ -4,18 +4,23 @@ Scans the repository to build a snapshot of its current state. The snapshot
 drives Principle 1 (where is complexity?) and Principle 2 (where is drift?)
 decisions downstream in the roadmap generator.
 
-Emits: rge_analysis_record
+Emits: rge_analysis_record (schema_version 1.1.0)
 
 Measured signals:
   - context_maturity_level: 0-10 based on presence of key runtime modules
+  - wave_status: 0-4 SBGE wave, derived from indicator-file presence
   - active_drift_legs: from loop_contribution_checker.get_active_drift_legs
   - complexity_budget_by_module: per-module burn rate
   - mg_slice_health: which meta-governance slices are present
-  - fragile_points: modules currently flagged as fragile
+  - fragile_points: caller-supplied module paths flagged as fragile
+  - fragile_point_signals: AST-derived stub/silent-except findings
+  - entropy_vectors: 7-vector assessment (clean | warn | critical)
+  - rge_can_operate / rge_max_autonomy: autonomy gate derived from maturity
   - bottlenecks: loop legs with saturation >= 6 contributors
 """
 from __future__ import annotations
 
+import ast
 import hashlib
 import json
 from datetime import datetime, timezone
@@ -45,6 +50,23 @@ _KEY_MODULES = (
     ("slo", "spectrum_systems/modules/runtime/autonomy_guardrails.py"),
 )
 
+# SBGE wave indicators: wave N is active iff the indicator path exists.
+# Waves are cumulative; the reported wave is the highest present.
+_WAVE_INDICATORS: tuple[tuple[int, str], ...] = (
+    (0, "spectrum_systems/__init__.py"),
+    (1, "contracts/schemas"),
+    (2, "spectrum_systems/modules/runtime/continuous_governance.py"),
+    (3, "spectrum_systems/modules/runtime/full_autonomy_execution.py"),
+    (4, "spectrum_systems/rge/orchestrator.py"),
+)
+
+_RGE_OPERATE_MIN_MATURITY = 7
+_AUTONOMY_WARN_GATED_MIN_MATURITY = 9
+_AUTONOMY_AUTONOMOUS_MIN_MATURITY = 10
+_AST_SCAN_FILE_CAP = 40
+_STUB_HEAVY_THRESHOLD = 3
+_SILENT_EXCEPT_THRESHOLD = 2
+
 
 def _utc_now() -> str:
     return (
@@ -66,6 +88,121 @@ def _measure_context_maturity(repo_root: Path) -> tuple[int, list[str]]:
         if (repo_root / rel_path).exists():
             present.append(label)
     return len(present), present
+
+
+def _measure_wave(repo_root: Path) -> int:
+    """Return the highest SBGE wave whose indicator exists."""
+    wave = 0
+    for w, indicator in _WAVE_INDICATORS:
+        if (repo_root / indicator).exists():
+            wave = w
+    return wave
+
+
+def _count_stubs(source: str) -> int:
+    """Count functions whose entire body is a single `pass`."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return 0
+    count = 0
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            body = node.body
+            if len(body) == 1 and isinstance(body[0], ast.Pass):
+                count += 1
+    return count
+
+
+def _count_silent_excepts(source: str) -> int:
+    """Count except handlers whose body is only pass or a bare ellipsis."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return 0
+    count = 0
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ExceptHandler):
+            continue
+        body = node.body
+        if not body:
+            continue
+        if all(_is_silent_statement(stmt) for stmt in body):
+            count += 1
+    return count
+
+
+def _is_silent_statement(stmt: ast.stmt) -> bool:
+    if isinstance(stmt, ast.Pass):
+        return True
+    if isinstance(stmt, ast.Expr):
+        value = stmt.value
+        if isinstance(value, ast.Constant) and value.value is Ellipsis:
+            return True
+    return False
+
+
+def _audit_fragile_point_signals(runtime_dir: Path) -> list[dict[str, Any]]:
+    """Scan `runtime_dir` for stub-heavy and silent-except modules.
+
+    Returns a list of {type, file, count} dicts. Only Python files are
+    examined. Caps scan at `_AST_SCAN_FILE_CAP` to keep the audit bounded.
+    """
+    signals: list[dict[str, Any]] = []
+    if not runtime_dir.exists() or not runtime_dir.is_dir():
+        return signals
+    files = sorted(runtime_dir.glob("*.py"))[:_AST_SCAN_FILE_CAP]
+    for py_file in files:
+        try:
+            source = py_file.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        stubs = _count_stubs(source)
+        silent = _count_silent_excepts(source)
+        if stubs > _STUB_HEAVY_THRESHOLD:
+            signals.append({
+                "type": "stub_heavy",
+                "file": py_file.name,
+                "count": stubs,
+            })
+        if silent > _SILENT_EXCEPT_THRESHOLD:
+            signals.append({
+                "type": "silent_excepts",
+                "file": py_file.name,
+                "count": silent,
+            })
+    return signals
+
+
+def _assess_entropy_vectors(
+    *,
+    maturity_level: int,
+    active_drift_legs: list[str],
+    fragile_point_signals: list[dict[str, Any]],
+) -> dict[str, str]:
+    stub_heavy = sum(1 for s in fragile_point_signals if s.get("type") == "stub_heavy")
+    silent = sum(1 for s in fragile_point_signals if s.get("type") == "silent_excepts")
+    return {
+        "decision_entropy":       "warn" if maturity_level < 7 else "clean",
+        "silent_drift":           "warn" if active_drift_legs else "clean",
+        "exception_accumulation": "warn" if silent > 5 else "clean",
+        "hidden_logic_creep":     "warn" if stub_heavy > 3 else "clean",
+        "evaluation_blind_spots": "warn" if maturity_level < 5 else "clean",
+        "overconfidence_risk":    "warn" if maturity_level < 9 else "clean",
+        "loss_of_causality":      "warn" if maturity_level < 6 else "clean",
+    }
+
+
+def _derive_autonomy(maturity_level: int) -> tuple[bool, str]:
+    """Derive (rge_can_operate, rge_max_autonomy) from maturity."""
+    can_operate = maturity_level >= _RGE_OPERATE_MIN_MATURITY
+    if maturity_level < _AUTONOMY_WARN_GATED_MIN_MATURITY:
+        mode = "shadow"
+    elif maturity_level < _AUTONOMY_AUTONOMOUS_MIN_MATURITY:
+        mode = "warn_gated"
+    else:
+        mode = "autonomous"
+    return can_operate, mode
 
 
 def _default_leg_counts(repo_root: Path) -> dict[str, int]:
@@ -125,6 +262,7 @@ def analyze_repository(
     root = Path(repo_root).resolve()
 
     maturity, present = _measure_context_maturity(root)
+    wave_status = _measure_wave(root)
     drift_legs = get_active_drift_legs(roadmap_signal_bundle) if roadmap_signal_bundle else []
     leg_counts = _default_leg_counts(root)
 
@@ -142,9 +280,21 @@ def analyze_repository(
         leg for leg, count in leg_counts.items() if count >= 6
     )
 
+    fragile_point_signals = _audit_fragile_point_signals(
+        root / "spectrum_systems" / "modules" / "runtime"
+    )
+
+    drift_legs_sorted = sorted(drift_legs)
+    entropy_vectors = _assess_entropy_vectors(
+        maturity_level=maturity,
+        active_drift_legs=drift_legs_sorted,
+        fragile_point_signals=fragile_point_signals,
+    )
+    can_operate, max_autonomy = _derive_autonomy(maturity)
+
     record = {
         "artifact_type": "rge_analysis_record",
-        "schema_version": "1.0.0",
+        "schema_version": "1.1.0",
         "record_id": _stable_id({"run_id": run_id, "trace_id": trace_id}),
         "run_id": run_id,
         "trace_id": trace_id,
@@ -153,15 +303,20 @@ def analyze_repository(
         "context_maturity_level": maturity,
         "context_maturity_max": len(_KEY_MODULES),
         "modules_present": sorted(present),
-        "active_drift_legs": sorted(drift_legs),
+        "wave_status": wave_status,
+        "active_drift_legs": drift_legs_sorted,
         "complexity_budget_by_module": budgets_by_module,
         "mg_slice_health": {
             "present": sorted(set(mg_slices_present or [])),
             "missing": [],
         },
         "fragile_points": sorted(set(fragile_points or [])),
+        "fragile_point_signals": fragile_point_signals,
         "bottlenecks": bottlenecks,
         "leg_saturation": leg_counts,
+        "entropy_vectors": entropy_vectors,
+        "rge_can_operate": can_operate,
+        "rge_max_autonomy": max_autonomy,
     }
 
     validate_artifact(record, "rge_analysis_record")

--- a/tests/test_rge_analysis_engine.py
+++ b/tests/test_rge_analysis_engine.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 from pathlib import Path
 
 from spectrum_systems.contracts import validate_artifact
-from spectrum_systems.rge.analysis_engine import analyze_repository
+from spectrum_systems.rge.analysis_engine import (
+    _audit_fragile_point_signals,
+    _count_silent_excepts,
+    _count_stubs,
+    analyze_repository,
+)
 
 _RUN = "run-ae-001"
 _TRACE = "trace-ae-001"
@@ -114,3 +119,70 @@ def test_stable_record_id_for_same_inputs():
     r1 = analyze_repository(repo_root=_REPO_ROOT, run_id=_RUN, trace_id=_TRACE)
     r2 = analyze_repository(repo_root=_REPO_ROOT, run_id=_RUN, trace_id=_TRACE)
     assert r1["record_id"] == r2["record_id"]
+
+
+def test_schema_version_is_1_1_0():
+    r = analyze_repository(repo_root=_REPO_ROOT, run_id=_RUN, trace_id=_TRACE)
+    assert r["schema_version"] == "1.1.0"
+
+
+def test_wave_status_in_range_and_reflects_indicators():
+    r = analyze_repository(repo_root=_REPO_ROOT, run_id=_RUN, trace_id=_TRACE)
+    assert 0 <= r["wave_status"] <= 4
+    # This repo has the RGE orchestrator indicator, so wave should be 4.
+    assert r["wave_status"] == 4
+
+
+def test_entropy_vectors_have_all_seven_keys_and_valid_values(tmp_path):
+    r = analyze_repository(repo_root=_REPO_ROOT, run_id=_RUN, trace_id=_TRACE)
+    expected = {
+        "decision_entropy",
+        "silent_drift",
+        "exception_accumulation",
+        "hidden_logic_creep",
+        "evaluation_blind_spots",
+        "overconfidence_risk",
+        "loss_of_causality",
+    }
+    assert set(r["entropy_vectors"].keys()) == expected
+    for v in r["entropy_vectors"].values():
+        assert v in {"clean", "warn", "critical"}
+
+
+def test_autonomy_gate_derived_from_maturity(tmp_path):
+    # Empty tmp dir => maturity 0 => cannot operate, shadow mode
+    r = analyze_repository(repo_root=tmp_path, run_id=_RUN, trace_id=_TRACE)
+    assert r["rge_can_operate"] is False
+    assert r["rge_max_autonomy"] == "shadow"
+    assert r["entropy_vectors"]["overconfidence_risk"] == "warn"
+
+
+def test_ast_detectors_find_stubs_and_silent_excepts(tmp_path):
+    stub_file = tmp_path / "mod_stubby.py"
+    stub_file.write_text(
+        "def a(): pass\n"
+        "def b(): pass\n"
+        "def c(): pass\n"
+        "def d(): pass\n"
+        "def e(): pass\n"
+    )
+    silent_file = tmp_path / "mod_silent.py"
+    silent_file.write_text(
+        "def x():\n"
+        "    try:\n        a = 1\n    except Exception:\n        pass\n"
+        "def y():\n"
+        "    try:\n        b = 2\n    except Exception:\n        ...\n"
+        "def z():\n"
+        "    try:\n        c = 3\n    except Exception:\n        pass\n"
+    )
+
+    assert _count_stubs(stub_file.read_text()) == 5
+    assert _count_silent_excepts(silent_file.read_text()) == 3
+
+    signals = _audit_fragile_point_signals(tmp_path)
+    types = {(s["type"], s["file"]) for s in signals}
+    assert ("stub_heavy", "mod_stubby.py") in types
+    assert ("silent_excepts", "mod_silent.py") in types
+    for s in signals:
+        assert isinstance(s["count"], int)
+        assert s["count"] >= 0


### PR DESCRIPTION
Extends rge_analysis_record to 1.1.0 with additive fields (no caller breaks):

  - wave_status (0-4): highest SBGE wave whose indicator file exists.
  - entropy_vectors: 7-key object (decision_entropy, silent_drift,
    exception_accumulation, hidden_logic_creep, evaluation_blind_spots,
    overconfidence_risk, loss_of_causality), each clean|warn|critical.
  - rge_can_operate (bool) and rge_max_autonomy
    (shadow|warn_gated|autonomous): autonomy gate derived from maturity.
  - fragile_point_signals: AST-derived list of {type, file, count} findings
    from scanning spectrum_systems/modules/runtime for stub-only functions
    and silent except handlers. Existing caller-supplied fragile_points
    remains a separate field.

Schema, record emission, and manifest all bumped 1.0.0 -> 1.1.0.
5 new tests cover schema version, wave_status, entropy vectors, autonomy
gate derivation, and AST detector. Existing 10 tests still green.

Closes the "analysis-engine autonomy signals" gap from the PR 1177-1181
diff-audit while preserving the existing analyze_repository API and
schema keys that the orchestrator depends on.

https://claude.ai/code/session_01N69bHtQjLcnZq5qup87utx