### PR TITLE
feat(rge): wire red-teamer through RQX + add must_fix/warn split (PR-B)

### DIFF
--- a/contracts/schemas/rge_redteam_record.schema.json
+++ b/contracts/schemas/rge_redteam_record.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://spectrum-systems.org/contracts/rge_redteam_record.schema.json",
   "title": "rge_redteam_record",
-  "description": "Emitted by the RGE Red-Teamer. Summary of six-check red-team pass.",
+  "description": "Emitted by the RGE Red-Teamer. Summary of six-check red-team pass with RQX-routed findings and must_fix/warn split.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -15,12 +15,15 @@
     "roadmap_record_id",
     "decision",
     "finding_count",
+    "must_fix_count",
+    "warn_count",
+    "roadmap_approved",
     "findings",
     "checks_run"
   ],
   "properties": {
     "artifact_type": { "type": "string", "const": "rge_redteam_record" },
-    "schema_version": { "type": "string", "const": "1.0.0" },
+    "schema_version": { "type": "string", "const": "1.1.0" },
     "record_id": { "type": "string", "minLength": 1 },
     "run_id": { "type": "string", "minLength": 1 },
     "trace_id": { "type": "string", "minLength": 1 },
@@ -28,18 +31,41 @@
     "roadmap_record_id": { "type": "string" },
     "decision": { "type": "string", "enum": ["pass", "block"] },
     "finding_count": { "type": "integer", "minimum": 0 },
+    "must_fix_count": { "type": "integer", "minimum": 0 },
+    "warn_count": { "type": "integer", "minimum": 0 },
+    "roadmap_approved": { "type": "boolean" },
     "findings": {
       "type": "array",
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["finding_class", "statement", "affected_phases", "owner", "routing_reason"],
+        "required": [
+          "finding_class",
+          "statement",
+          "affected_phases",
+          "owner",
+          "routing_reason",
+          "rqx_routing",
+          "must_fix"
+        ],
         "properties": {
           "finding_class": { "type": "string" },
           "statement": { "type": "string" },
           "affected_phases": { "type": "array", "items": { "type": ["string", "null"] } },
           "owner": { "type": "string" },
-          "routing_reason": { "type": "string" }
+          "routing_reason": { "type": "string" },
+          "rqx_routing": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["rqx_class", "routing_ref", "finding_id", "rqx_routed"],
+            "properties": {
+              "rqx_class": { "type": "string" },
+              "routing_ref": { "type": "string" },
+              "finding_id": { "type": "string" },
+              "rqx_routed": { "type": "boolean" }
+            }
+          },
+          "must_fix": { "type": "boolean" }
         }
       }
     },

--- a/contracts/standards-manifest.json
+++ b/contracts/standards-manifest.json
@@ -16821,13 +16821,13 @@
     {
       "artifact_type": "rge_redteam_record",
       "artifact_class": "coordination",
-      "schema_version": "1.0.0",
+      "schema_version": "1.1.0",
       "status": "proposed",
       "intended_consumers": ["spectrum-systems"],
       "introduced_in": "RGE-G",
       "last_updated_in": "RGE-G",
       "example_path": "contracts/examples/rge_redteam_record.json",
-      "notes": "RGE red-team six-check output."
+      "notes": "RGE red-team six-check output. 1.1.0 routes findings via rqx_redteam_orchestrator (rqx_routing per finding) and adds must_fix/warn split (must_fix_count, warn_count, roadmap_approved)."
     },
     {
       "artifact_type": "rge_amendment_record",

--- a/spectrum_systems/rge/rge_red_teamer.py
+++ b/spectrum_systems/rge/rge_red_teamer.py
@@ -12,8 +12,16 @@ The six checks:
   5. DELETION-GUARD        - deletion phases must cite the module they delete
   6. MG-21-SESSION-REALISM - orchestrator session budget sanity check
 
-Finding routing uses the canonical RQX class-to-owner mapping. Unrecognized
-classes fall back to a generic "RGE" owner to avoid silent drops.
+Each RGE finding class is mapped to a canonical RQX finding class, then routed
+through `rqx_redteam_orchestrator.route_finding_owner` to produce the
+governed routing record (owner + routing_ref). Findings whose class has no
+RQX mapping fall back to a generic "RGE" owner so nothing is silently dropped.
+
+Findings are bucketed `must_fix | warn`:
+  - must_fix: structural defects that block roadmap promotion
+  - warn:     advisory signals that do not block (saturation, realism)
+
+`decision` blocks iff at least one `must_fix` finding exists.
 """
 from __future__ import annotations
 
@@ -23,16 +31,45 @@ from datetime import datetime, timezone
 from typing import Any
 
 from spectrum_systems.contracts import validate_artifact
+from spectrum_systems.modules.runtime.rqx_redteam_orchestrator import (
+    RQXRedTeamError,
+    build_redteam_finding_record,
+    route_finding_owner as rqx_route_finding_owner,
+)
 
 
-_CLASS_TO_OWNER: dict[str, str] = {
-    "red_team_pairing_missing": "PQX",
-    "circular_failure_chain": "CDE",
-    "same_leg_same_batch": "TLC",
-    "complexity_on_freeze": "TPA",
-    "deletion_guard_violation": "GOV",
-    "mg_21_session_violation": "MG",
+# Map RGE finding classes -> canonical RQX finding classes.
+# RQX classes are: interpretation, repair_planning, decision_quality,
+# enforcement_mismatch, execution_trace, trust_policy.
+_RGE_TO_RQX_CLASS: dict[str, str] = {
+    "red_team_pairing_missing":  "execution_trace",
+    "circular_failure_chain":    "decision_quality",
+    "same_leg_same_batch":       "repair_planning",
+    "complexity_on_freeze":      "trust_policy",
+    "deletion_guard_violation":  "enforcement_mismatch",
+    "mg_21_session_violation":   "interpretation",
 }
+
+# Canonical RQX-class -> owner mapping (mirrors rqx_redteam_orchestrator._OWNER_BY_CLASS).
+_RQX_OWNER_BY_CLASS: dict[str, str] = {
+    "interpretation":       "RIL",
+    "repair_planning":      "FRE",
+    "decision_quality":     "CDE",
+    "enforcement_mismatch": "SEL",
+    "execution_trace":      "PQX",
+    "trust_policy":         "TPA",
+}
+
+# Findings that block roadmap promotion (must_fix).
+# Anything not listed here is advisory (warn).
+_MUST_FIX_CLASSES: frozenset[str] = frozenset({
+    "red_team_pairing_missing",
+    "circular_failure_chain",
+    "complexity_on_freeze",
+    "deletion_guard_violation",
+})
+
+_FALLBACK_OWNER = "RGE"
 
 
 def _utc_now() -> str:
@@ -50,12 +87,74 @@ def _stable_id(payload: dict[str, Any]) -> str:
 
 
 def route_finding_owner(finding_class: str) -> str:
-    """Return canonical 3LS owner for a finding class.
+    """Return canonical 3LS owner for an RGE finding class.
 
-    Falls back to 'RGE' for classes without a mapping, so no finding is silently
-    dropped.
+    Resolves the RGE class to its RQX canonical class, then to the canonical
+    3LS owner. Unmapped classes fall back to 'RGE' so nothing is silently
+    dropped. (See `_route_via_rqx` for the schema-validated routing record
+    used on each finding emitted by `red_team_roadmap`.)
     """
-    return _CLASS_TO_OWNER.get(finding_class, "RGE")
+    rqx_class = _RGE_TO_RQX_CLASS.get(finding_class)
+    if rqx_class is None:
+        return _FALLBACK_OWNER
+    return _RQX_OWNER_BY_CLASS.get(rqx_class, _FALLBACK_OWNER)
+
+
+def _route_via_rqx(
+    *,
+    rge_class: str,
+    statement: str,
+    affected_phases: list[Any],
+    trace_id: str,
+) -> dict[str, Any]:
+    """Build a redteam_finding_record and route it through RQX.
+
+    Returns a routing dict with `owner`, `routing_reason`, `routing_ref`,
+    `finding_id`, and `rqx_class`. Falls back to a local owner record when
+    the RGE class has no canonical RQX mapping or RQX rejects the input,
+    so no finding is silently dropped.
+    """
+    rqx_class = _RGE_TO_RQX_CLASS.get(rge_class)
+    if rqx_class is None:
+        return {
+            "owner": _FALLBACK_OWNER,
+            "routing_reason": f"class:{rge_class}",
+            "routing_ref": "redteam_finding_record:UNROUTED",
+            "finding_id": "",
+            "rqx_class": "",
+            "rqx_routed": False,
+        }
+
+    exploit_refs = [str(p) for p in affected_phases if p] or [f"rge_class:{rge_class}"]
+    bounded_scope = f"rge_red_teamer:{rge_class}"
+
+    try:
+        finding_record = build_redteam_finding_record(
+            trace_id=trace_id,
+            finding_class=rqx_class,
+            finding_statement=statement or f"RGE {rge_class}",
+            exploit_refs=exploit_refs,
+            bounded_scope=bounded_scope,
+        )
+        routing = rqx_route_finding_owner(finding_record=finding_record)
+    except RQXRedTeamError:
+        return {
+            "owner": _RQX_OWNER_BY_CLASS.get(rqx_class, _FALLBACK_OWNER),
+            "routing_reason": f"class:{rge_class}",
+            "routing_ref": "redteam_finding_record:RQX_REJECTED",
+            "finding_id": "",
+            "rqx_class": rqx_class,
+            "rqx_routed": False,
+        }
+
+    return {
+        "owner": routing["owner"],
+        "routing_reason": f"class:{rge_class}",
+        "routing_ref": routing["routing_ref"],
+        "finding_id": finding_record["finding_id"],
+        "rqx_class": rqx_class,
+        "rqx_routed": True,
+    }
 
 
 def _check_red_team_pairing(phases: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -209,21 +308,41 @@ def red_team_roadmap(
     raw_findings.extend(_check_mg_21_session_realism(phases, session_budget_hours))
 
     routed: list[dict[str, Any]] = []
+    must_fix_count = 0
+    warn_count = 0
     for f in raw_findings:
-        owner = route_finding_owner(f["finding_class"])
+        rge_class = f["finding_class"]
+        routing = _route_via_rqx(
+            rge_class=rge_class,
+            statement=f["statement"],
+            affected_phases=f["affected_phases"],
+            trace_id=trace_id,
+        )
+        is_must_fix = rge_class in _MUST_FIX_CLASSES
+        if is_must_fix:
+            must_fix_count += 1
+        else:
+            warn_count += 1
         routed.append({
-            "finding_class": f["finding_class"],
+            "finding_class": rge_class,
             "statement": f["statement"],
             "affected_phases": f["affected_phases"],
-            "owner": owner,
-            "routing_reason": f"class:{f['finding_class']}",
+            "owner": routing["owner"],
+            "routing_reason": routing["routing_reason"],
+            "rqx_routing": {
+                "rqx_class": routing["rqx_class"],
+                "routing_ref": routing["routing_ref"],
+                "finding_id": routing["finding_id"],
+                "rqx_routed": routing["rqx_routed"],
+            },
+            "must_fix": is_must_fix,
         })
 
-    decision = "block" if routed else "pass"
+    decision = "block" if must_fix_count > 0 else "pass"
 
     record = {
         "artifact_type": "rge_redteam_record",
-        "schema_version": "1.0.0",
+        "schema_version": "1.1.0",
         "record_id": _stable_id({"run_id": run_id, "findings": len(routed)}),
         "run_id": run_id,
         "trace_id": trace_id,
@@ -231,6 +350,9 @@ def red_team_roadmap(
         "roadmap_record_id": str(roadmap.get("record_id", "")),
         "decision": decision,
         "finding_count": len(routed),
+        "must_fix_count": must_fix_count,
+        "warn_count": warn_count,
+        "roadmap_approved": must_fix_count == 0,
         "findings": routed,
         "checks_run": [
             "red_team_pairing",

--- a/tests/test_rge_red_teamer.py
+++ b/tests/test_rge_red_teamer.py
@@ -140,3 +140,101 @@ def test_decision_blocks_when_findings_present():
     )
     assert r["decision"] == "block"
     assert r["finding_count"] > 0
+
+
+def test_schema_version_is_1_1_0():
+    r = red_team_roadmap(
+        roadmap=_roadmap([_phase()]), run_id=_RUN, trace_id=_TRACE
+    )
+    assert r["schema_version"] == "1.1.0"
+
+
+def test_findings_routed_through_rqx():
+    """Each finding carries a schema-validated RQX routing record."""
+    r = red_team_roadmap(roadmap=_roadmap([_phase()]), run_id=_RUN, trace_id=_TRACE)
+    assert r["findings"]
+    for f in r["findings"]:
+        assert "rqx_routing" in f
+        rr = f["rqx_routing"]
+        assert rr["rqx_routed"] is True
+        assert rr["rqx_class"] in {
+            "interpretation", "repair_planning", "decision_quality",
+            "enforcement_mismatch", "execution_trace", "trust_policy",
+        }
+        assert rr["finding_id"].startswith("rqx-find-")
+        assert rr["routing_ref"].startswith("redteam_finding_record:")
+
+
+def test_canonical_3ls_owners_replace_local_labels():
+    """Owners come from RQX's _OWNER_BY_CLASS, not the old local map."""
+    # red_team_pairing_missing -> execution_trace -> PQX (unchanged)
+    # mg_21_session_violation  -> interpretation  -> RIL (was MG)
+    r = red_team_roadmap(
+        roadmap=_roadmap([_phase()]),
+        run_id=_RUN,
+        trace_id=_TRACE,
+        session_budget_hours=12.0,
+    )
+    by_class = {f["finding_class"]: f for f in r["findings"]}
+    assert by_class["red_team_pairing_missing"]["owner"] == "PQX"
+    assert by_class["mg_21_session_violation"]["owner"] == "RIL"
+
+
+def test_must_fix_warn_split():
+    """red_team_pairing is must_fix; mg_21_session is warn (advisory)."""
+    r = red_team_roadmap(
+        roadmap=_roadmap([_phase()]),
+        run_id=_RUN,
+        trace_id=_TRACE,
+        session_budget_hours=12.0,
+    )
+    by_class = {f["finding_class"]: f for f in r["findings"]}
+    assert by_class["red_team_pairing_missing"]["must_fix"] is True
+    assert by_class["mg_21_session_violation"]["must_fix"] is False
+    assert r["must_fix_count"] >= 1
+    assert r["warn_count"] >= 1
+    assert r["finding_count"] == r["must_fix_count"] + r["warn_count"]
+
+
+def test_warn_only_findings_do_not_block():
+    """A roadmap with only warn findings should pass; old behavior blocked."""
+    # Pair the EVL phase with a red-team phase (clears red_team_pairing must_fix).
+    # The redteam phase satisfies pairing but its loop_leg='EVL' would also
+    # collide with the ADD phase under same_leg_same_batch — so we put the
+    # redteam phase on a different leg. Remaining: mg_21_session_violation (warn).
+    phases = [
+        _phase(),
+        _phase(
+            phase_id="P2",
+            name="Red-team EVL telemetry",
+            phase_type="redteam",
+            loop_leg="OBS",
+        ),
+    ]
+    r = red_team_roadmap(
+        roadmap=_roadmap(phases),
+        run_id=_RUN,
+        trace_id=_TRACE,
+        session_budget_hours=12.0,
+    )
+    classes = {f["finding_class"] for f in r["findings"]}
+    # Only warn-class findings should be present
+    must_fix_classes = {
+        "red_team_pairing_missing",
+        "circular_failure_chain",
+        "complexity_on_freeze",
+        "deletion_guard_violation",
+    }
+    assert not (classes & must_fix_classes), f"unexpected must_fix in {classes}"
+    assert "mg_21_session_violation" in classes
+    assert r["must_fix_count"] == 0
+    assert r["warn_count"] >= 1
+    assert r["decision"] == "pass"
+    assert r["roadmap_approved"] is True
+
+
+def test_roadmap_approved_false_when_must_fix_present():
+    r = red_team_roadmap(roadmap=_roadmap([_phase()]), run_id=_RUN, trace_id=_TRACE)
+    assert r["must_fix_count"] >= 1
+    assert r["roadmap_approved"] is False
+    assert r["decision"] == "block"


### PR DESCRIPTION
## Summary

Closes the **"red-teamer: RQX routing + `must_fix`/`warn` split"** gap from the PR 1177–1181 diff-audit. Companion to merged PR-A (analysis-engine autonomy signals) and PR-C (#1181, amender → `roadmap_adjustment_engine` wiring).

### Routing now goes through RQX

Each RGE finding is mapped to its canonical RQX finding class and routed via `rqx_redteam_orchestrator.route_finding_owner`. A schema-validated `redteam_finding_record` is built per finding; the resulting routing record (owner + `routing_ref` + `finding_id`) lands on every emitted finding.

| RGE class | RQX class | Owner |
|---|---|---|
| `red_team_pairing_missing` | `execution_trace` | PQX |
| `circular_failure_chain` | `decision_quality` | CDE |
| `same_leg_same_batch` | `repair_planning` | FRE |
| `complexity_on_freeze` | `trust_policy` | TPA |
| `deletion_guard_violation` | `enforcement_mismatch` | SEL |
| `mg_21_session_violation` | `interpretation` | RIL |

Findings whose RGE class has no RQX mapping fall back to a generic `"RGE"` owner — nothing is silently dropped.

### `must_fix` / `warn` split

| Bucket | Classes |
|---|---|
| **must_fix** (block) | `red_team_pairing_missing`, `circular_failure_chain`, `complexity_on_freeze`, `deletion_guard_violation` |
| **warn** (advisory) | `same_leg_same_batch`, `mg_21_session_violation` |

**Behavior change:** `decision` now blocks iff `must_fix_count > 0`. Old behavior treated *any* finding as a block. The orchestrator does not read `redteam["decision"]`, so no caller breaks.

### Schema bump 1.0.0 → 1.1.0 (additive)

Per-finding new required fields:
- `must_fix` (bool)
- `rqx_routing`: `{ rqx_class, routing_ref, finding_id, rqx_routed }`

Top-level new required fields:
- `must_fix_count`, `warn_count` — integers
- `roadmap_approved` — bool (= `must_fix_count == 0`)

Public `route_finding_owner(finding_class: str) -> str` keeps its single-string API; internally it now delegates through the RGE→RQX class map and the canonical RQX `_OWNER_BY_CLASS`. Unmapped classes still return `"RGE"`.

### Tests

- 6 new: schema version, RQX routing record validity, canonical 3LS owner labels, `must_fix`/`warn` split, warn-only does not block, `must_fix` blocks.
- 12 existing unchanged.
- **253 passed** locally across RGE + ALG + contracts/manifest tests.

## Test plan

- [ ] CI: `pytest tests/test_rge_red_teamer.py` (18 tests) green
- [ ] CI: `pytest tests/test_rge_orchestrator.py` still green
- [ ] CI: `pytest tests/test_authority_leak_guard_local.py` ALG gate passes
- [ ] CI: `pytest tests/test_contracts.py` manifest/schema tests pass

https://claude.ai/code/session_01N69bHtQjLcnZq5qup87utx

---
_Generated by [Claude Code](https://claude.ai/code/session_01N69bHtQjLcnZq5qup87utx)_